### PR TITLE
added H(mumu) xs and adapted config entries with get

### DIFF
--- a/Analysis/HistMerger.py
+++ b/Analysis/HistMerger.py
@@ -174,17 +174,19 @@ if __name__ == "__main__":
         print("unknown unc source {args.uncSource}")
 
     categories = list(global_cfg_dict['categories'])
-    boosted_categories = list(global_cfg_dict['boosted_categories'])
-    QCDregions = list(global_cfg_dict['QCDRegions'])
+
+    boosted_categories = list(global_cfg_dict.get('apply_btag_shape_weights', [])) # list(global_cfg_dict['boosted_categories'])
+    QCDregions =  list(global_cfg_dict['SignRegions']) # list(global_cfg_dict['QCDRegions'])
+
     #Controlregions = list(global_cfg_dict['ControlRegions']) #Later maybe we want to separate Controls from QCDs
     global_cfg_dict['channelSelection']=args.channels.split(',')
 
     channels = global_cfg_dict['channelSelection']
     # print(channels)
 
-    signals = list(global_cfg_dict['signal_types'])
-    unc_to_not_consider_boosted = list(global_cfg_dict['unc_to_not_consider_boosted'])
-    boosted_variables = list(global_cfg_dict['var_only_boosted'])
+    signals = list(global_cfg_dict.get('signal_types', []))
+    unc_to_not_consider_boosted = list(global_cfg_dict.get('unc_to_not_consider_boosted', []))
+    boosted_variables = list(global_cfg_dict.get('var_only_boosted', []))
 
     all_categories = categories + boosted_categories
     if args.var in boosted_variables:
@@ -242,8 +244,9 @@ if __name__ == "__main__":
         all_histograms_1D=GetBTagWeightDict(args.var,all_histograms, categories, boosted_categories, boosted_variables)
     else:
         all_histograms_1D = all_histograms
-    fixNegativeContributions = False
-    error_on_qcdnorm,error_on_qcdnorm_varied = AddQCDInHistDict(args.var, all_histograms_1D, channels, all_categories, args.uncSource, all_samples_types.keys(), scales, wantNegativeContributions=False)
+    if not analysis_import == "Analysis.H_mumu":
+        fixNegativeContributions = False
+        error_on_qcdnorm,error_on_qcdnorm_varied = AddQCDInHistDict(args.var, all_histograms_1D, channels, all_categories, args.uncSource, all_samples_types.keys(), scales, wantNegativeContributions=False)
 
     outFile = ROOT.TFile(args.outFile, "RECREATE")
 

--- a/Analysis/HistProducerFile.py
+++ b/Analysis/HistProducerFile.py
@@ -264,7 +264,7 @@ if __name__ == "__main__":
             kwargset['region'] = args.region
             kwargset['isData'] = isData
             kwargset['isCentral'] = True
-            kwargset['whichType'] = datasetType
+
 
 
         all_dataframes = {}

--- a/Analysis/tasks.py
+++ b/Analysis/tasks.py
@@ -312,7 +312,7 @@ class MergeTask(Task, HTCondorWorkflow, law.LocalWorkflow):
         customisation_dict['apply_btag_shape_weights']=='True' if 'apply_btag_shape_weights' in customisation_dict.keys() else self.global_params.get('apply_btag_shape_weights', False)
         uncNames = ['Central']
         unc_cfg_dict = load_unc_config(unc_config)
-        uncs_to_exclude = self.global_params['uncs_to_exclude'][self.period]
+        uncs_to_exclude = self.global_params['uncs_to_exclude'][self.period] if "uncs_to_exclude" in self.global_params.keys() else []
 
         compute_unc_histograms = customisation_dict['compute_unc_histograms']=='True' if 'compute_unc_histograms' in customisation_dict.keys() else self.global_params.get('compute_unc_histograms', False)
         if compute_unc_histograms:

--- a/config/crossSections13p6TeV.yaml
+++ b/config/crossSections13p6TeV.yaml
@@ -551,7 +551,7 @@ WminusH_Hto2Mu_WtoAll:
   reference: https://indico.cern.ch/event/1119741/contributions/4715908/attachments/2383849/4073592/YR4_13p6_VH_update.pdf
   unc: +0.4% -0.7% (QCD scale) ±1.8% (PDF+alphas) ±1.6 (PDF) ±0.9 (alpha s) ; +1.23% -1.2% (theory) +0.97% -0.99% (mq) +0.59% -0.64% (alphas)
 
-WminusH_Hto2Mu_WtoAll:
+WplusH_Hto2Mu_WtoAll:
   crossSec: 0.8889 * (0.0002176) # 1.457 (total)
   reference: https://indico.cern.ch/event/1119741/contributions/4715908/attachments/2383849/4073592/YR4_13p6_VH_update.pdf
   unc: +0.4% -0.7% (QCD scale) ±1.8% (PDF+alphas) ±1.6 (PDF) ±0.9 (alpha s) ; +1.23% -1.2% (theory) +0.97% -0.99% (mq) +0.59% -0.64% (alphas)

--- a/config/crossSections13p6TeV.yaml
+++ b/config/crossSections13p6TeV.yaml
@@ -229,6 +229,13 @@ DYto2TautoMuTauh_M-50_madgraphMLM:
   reference: XSDB DYto2TautoMuTauh_M-50_TuneCP5_13p6TeV_madgraphMLM-pythia8 modifiedOn 2023-03-26 13:56:19
   unc: 0.5212
 
+
+GluGluHto2Mu:
+  crossSec: 52.23 * (0.0002176)
+  reference: https://twiki.cern.ch/twiki/bin/view/LHCPhysics/LHCHWG136TeVxsec_extrap and https://twiki.cern.ch/twiki/bin/view/LHCPhysics/CERNYellowReportPageBR for BR
+  unc: +4.6% -6.7% (theory) +-3.9 (TH Gaussian) +-3.2 (PDF+alpha s) +-1.9 (PDF) +-2.6 (alpha s) ; +1.23% -1.2% (theory) +0.97% -0.99% (mq) +0.59% -0.64% (alphas)
+
+
 GluGluHToTauTau_M125:
   crossSec: 52.23 * (0.06272)
   reference: https://twiki.cern.ch/twiki/bin/view/LHCPhysics/LHCHWG136TeVxsec_extrap
@@ -520,6 +527,16 @@ ttHToNonbb_M125:
   reference: https://twiki.cern.ch/twiki/bin/view/LHCPhysics/LHCHWG136TeVxsec_extrap
   unc: +6% -9.3% (QCD Scale) +-3.5% (PDF alpha s) +-3% (PDF) +-2 (alpha s)
 
+TTH_Hto2Mu:
+  crossSec: 0.57 * (0.0002176)
+  reference: https://twiki.cern.ch/twiki/bin/view/LHCPhysics/LHCHWG136TeVxsec_extrap
+  unc: +6% -9.3% (QCD Scale) +-3.5% (PDF alpha s) +-3% (PDF) +-2 (alpha s) ; +1.23% -1.2% (theory) +0.97% -0.99% (mq) +0.59% -0.64% (alphas)
+
+VBFHto2Mu:
+  crossSec: 4.078 * (0.0002176)
+  reference: https://twiki.cern.ch/twiki/bin/view/LHCPhysics/LHCHWG136TeVxsec_extrap and https://twiki.cern.ch/twiki/bin/view/LHCPhysics/CERNYellowReportPageBR for BR
+  unc: +0.5% -0.3% (QCD Scale) +-2.1% (PDF alpha s) +-2.1% (PDF) +-0.5 (alpha s) ; +1.23% -1.2% (theory) +0.97% -0.99% (mq) +0.59% -0.64% (alphas)
+
 VBFHToTauTau_M125:
   crossSec: 4.078 * (0.06272)
   reference: https://twiki.cern.ch/twiki/bin/view/LHCPhysics/LHCHWG136TeVxsec_extrap
@@ -528,6 +545,16 @@ VBFHToWWTo2L2Nu_M125:
   crossSec: 4.078 * (0.2137) * (3 * 0.1086)
   reference: https://twiki.cern.ch/twiki/bin/view/LHCPhysics/LHCHWG136TeVxsec_extrap
   unc: +0.5% -0.3% (QCD Scale) +-2.1% (PDF alpha s) +-2.1% (PDF) +-0.5 (alpha s)
+
+WminusH_Hto2Mu_WtoAll:
+  crossSec: 0.5677 * (0.0002176) # 1.457 (total)
+  reference: https://indico.cern.ch/event/1119741/contributions/4715908/attachments/2383849/4073592/YR4_13p6_VH_update.pdf
+  unc: +0.4% -0.7% (QCD scale) ±1.8% (PDF+alphas) ±1.6 (PDF) ±0.9 (alpha s) ; +1.23% -1.2% (theory) +0.97% -0.99% (mq) +0.59% -0.64% (alphas)
+
+WminusH_Hto2Mu_WtoAll:
+  crossSec: 0.8889 * (0.0002176) # 1.457 (total)
+  reference: https://indico.cern.ch/event/1119741/contributions/4715908/attachments/2383849/4073592/YR4_13p6_VH_update.pdf
+  unc: +0.4% -0.7% (QCD scale) ±1.8% (PDF+alphas) ±1.6 (PDF) ±0.9 (alpha s) ; +1.23% -1.2% (theory) +0.97% -0.99% (mq) +0.59% -0.64% (alphas)
 
 WtoLNu_0J_amcatnloFXFX:
   crossSec: 55760.0
@@ -656,6 +683,11 @@ ZH_Hbb_Zqq:
   crossSec: 9.439e-1 * 0.5824 * 0.69911
   reference: https://twiki.cern.ch/twiki/bin/view/LHCPhysics/LHCHWG136TeVxsec_extrap
   unc: +3.7 -3.2 (qcd scale) +-1.6 (pdf alpha) +-1.3 (pdf) +- 0.9 (alpha)
+
+ZH_Hto2Mu_ZtoAll:
+  crossSec: 0.9439 * (0.0002176)
+  reference: https://twiki.cern.ch/twiki/bin/view/LHCPhysics/LHCHWG136TeVxsec_extrap
+  unc: +3.7 -3.2 (qcd scale) +-1.6 (pdf alpha) +-1.3 (pdf) +- 0.9 (alpha) ; +1.23% -1.2% (theory) +0.97% -0.99% (mq) +0.59% -0.64% (alphas)
 
 Zto2Nu_HT-100To200:
   crossSec: 273.7

--- a/include/AnalysisTools.h
+++ b/include/AnalysisTools.h
@@ -66,8 +66,7 @@ enum class SampleType : int {
   ZJNuNu = 29,
   TTX = 30,
   ggH = 31,
-  ttH = 32,
-  VBFH = 33
+  VBFH = 32
 };
 
 enum class GenLeptonMatch : int {

--- a/include/AnalysisTools.h
+++ b/include/AnalysisTools.h
@@ -65,6 +65,9 @@ enum class SampleType : int {
   WG = 28,
   ZJNuNu = 29,
   TTX = 30,
+  ggH = 31,
+  ttH = 32,
+  VBFH = 33
 };
 
 enum class GenLeptonMatch : int {


### PR DESCRIPTION
This PR is intended for:
- Adding H(mumu) cross sections (in different prod modes) 
- Replacing the non-optional config dict args with get: 
```e.g. boosted_categories = global_cfg_dict['boosted_categories']``` becomes ```boosted_variables = global_cfg_dict.get('var_only_boosted', [])```