### PR TITLE
renameHists.py Run2 vs Run3 Checker bug fix

### DIFF
--- a/Analysis/renameHists.py
+++ b/Analysis/renameHists.py
@@ -154,7 +154,7 @@ if type(samples_to_consider) == list:
 all_histnames = {}
 
 #Move this rename map to the weights.yaml for Run3, but keep previous Run2 support for now
-if int(args.year) < 2020:
+if args.period.startswith('Run2'):
     for process in processes:
         all_histnames[process] = process
         for unc_old in uncReNames.keys():
@@ -164,7 +164,7 @@ if int(args.year) < 2020:
             for scale in ['Up','Down']:
                 all_histnames[f"{process}_{unc_old}_{args.year}_{scale}"] = f"{process}_{new_unc}{scale}"
                 all_histnames[f"{process}_{unc_old}_{scale}"] = f"{process}_{new_unc}{scale}"
-elif int(args.year) >= 2020:
+elif args.period.startswith('Run3'):
     for process in samples_to_consider:
         all_histnames[process] = process
         for unc_old in setup.weights_config['norm'].keys():


### PR DESCRIPTION
Previously, renameHists.py used the processes list to look for each sample. This was hardcoded and kind of ugly. For run3 we moved to use samples_to_consider instead, but to keep Run2 working we had a run2 vs run3 checker.

The run3 checker was badly written (my fault). I was using args.year as an integer, but args.year could be "2022EE" which is not an integer and would crash. I've updated to use the args.period string and a starts with "Run2" or "Run3" instead.