### PR TITLE
Full evt id def

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,6 @@
 __pycache__
 /output
 /soft
-/test
 /utilities
 /.vscode
 /site

--- a/AnaProd/SkimEvents.py
+++ b/AnaProd/SkimEvents.py
@@ -38,6 +38,8 @@ col_type_dict = {
   'ROOT::VecOps::RVec<float>':'ROOT::VecOps::RVec<float>',
   'ROOT::VecOps::RVec<int>':'ROOT::VecOps::RVec<int>',
   'ROOT::VecOps::RVec<unsigned char>':'ROOT::VecOps::RVec<unsigned char>',
+  'ROOT::VecOps::RVec<unsigned long long>':'ROOT::VecOps::RVec<unsigned long long>',
+  'ROOT::VecOps::RVec<unsigned long>':'ROOT::VecOps::RVec<unsigned long>',
   'ROOT::VecOps::RVec<short>':'ROOT::VecOps::RVec<short>',
   'ROOT::VecOps::RVec<double>':'ROOT::VecOps::RVec<double>',
   }
@@ -59,8 +61,8 @@ def make_df(inputFileCentral,inputFileShifted,outDir,treeName,treeName_in='Event
     createVoidTree(os.path.join(outDir, f"{treeName}_nonValid.root"), f"{treeName}_nonValid.root")
     createVoidTree(os.path.join(outDir, f"{treeName}_noDiff.root"), f"{treeName}_noDiff.root")
     return
-  entryIndexIdx = colNames.index("entryIndex")
-  colNames[entryIndexIdx], colNames[0] = colNames[0], colNames[entryIndexIdx]
+  FullEventIdIdx = colNames.index("FullEventId")
+  colNames[FullEventIdIdx], colNames[0] = colNames[0], colNames[FullEventIdIdx]
   col_types = [str(df_out.GetColumnType(c)) for c in colNames]
   tuple_maker = ROOT.analysis.TupleMaker(*col_types)(ROOT.RDataFrame(treeName_central,inputFileCentral), 4)
   print("tuplemaker created")
@@ -71,8 +73,12 @@ def make_df(inputFileCentral,inputFileShifted,outDir,treeName,treeName_in='Event
   df_out_valid = df_out.Filter('isValid')
 
   colToSave_diff= []
-  colToNotToMakeDiff = ["period","run", "sample_name", "sample_type", "entryIndex", "event", "isData", "luminosityBlock", "X_mass", "X_spin"]
+  colToNotToMakeDiff = ["period","run", "sample_type", "FullEventId", "event", "isData", "luminosityBlock","X_mass", "X_spin"]
 
+  # this will be needed as some observables that have to be copied - as X_mass/X_spin - are analysis specific
+  for col_name in optcolToNotToMakeDiff:
+    if col_name not in colNames:
+      colToNotToMakeDiff.remove(col_name)
 
   condition_noDiff_list = []
   condition_Valid_list = []

--- a/AnaProd/SkimEvents.py
+++ b/AnaProd/SkimEvents.py
@@ -74,7 +74,7 @@ def make_df(inputFileCentral,inputFileShifted,outDir,treeName,treeName_in='Event
 
   colToSave_diff= []
 
-  colToNotToMakeDiff = [ "FullEventId"]
+  colToNotToMakeDiff = ["FullEventId"]
 
 
   condition_noDiff_list = []

--- a/AnaProd/SkimEvents.py
+++ b/AnaProd/SkimEvents.py
@@ -73,12 +73,9 @@ def make_df(inputFileCentral,inputFileShifted,outDir,treeName,treeName_in='Event
   df_out_valid = df_out.Filter('isValid')
 
   colToSave_diff= []
-  colToNotToMakeDiff = ["period","run", "sample_type", "FullEventId", "event", "isData", "luminosityBlock","X_mass", "X_spin"]
 
-  # this will be needed as some observables that have to be copied - as X_mass/X_spin - are analysis specific
-  for col_name in optcolToNotToMakeDiff:
-    if col_name not in colNames:
-      colToNotToMakeDiff.remove(col_name)
+  colToNotToMakeDiff = [ "FullEventId"]
+
 
   condition_noDiff_list = []
   condition_Valid_list = []

--- a/AnaProd/anaCacheTupleProducer.py
+++ b/AnaProd/anaCacheTupleProducer.py
@@ -13,7 +13,7 @@ from FLAF.RunKit.run_tools import ps_call
 import FLAF.Common.LegacyVariables as LegacyVariables
 import FLAF.Common.Utilities as Utilities
 
-defaultColToSave = ["entryIndex","luminosityBlock", "run","event", "sample_type", "sample_name", "period", "X_mass", "X_spin", "isData"]
+defaultColToSave = ["FullEventId","luminosityBlock", "run","event", "sample_type", "sample_name", "period", "X_mass", "X_spin", "isData"]
 scales = ['Up','Down']
 
 def getKeyNames(root_file_name):

--- a/AnaProd/anaTupleProducer.py
+++ b/AnaProd/anaTupleProducer.py
@@ -30,6 +30,7 @@ def createAnatuple(inFile, treeName, outDir, setup, sample_name, anaCache, snaps
     compression_settings = snapshotOptions.fCompressionAlgorithm * 100 + snapshotOptions.fCompressionLevel
     period = setup.global_params["era"]
     sample_config = setup.samples[sample_name]
+    sample_type = sample_config["sampleType"]
     mass = -1 if 'mass' not in sample_config else sample_config['mass']
     spin = -100 if 'spin' not in sample_config else sample_config['spin']
     isHH = True if mass > 0 else False
@@ -38,7 +39,7 @@ def createAnatuple(inFile, treeName, outDir, setup, sample_name, anaCache, snaps
     loadHHBtag = anaTupleDef.loadHHBtag
     lepton_legs = anaTupleDef.lepton_legs
     Baseline.Initialize(loadTF, loadHHBtag)
-    Corrections.initializeGlobal(setup.global_params, sample_name, isData=isData, load_corr_lib=True)
+    Corrections.initializeGlobal(setup.global_params, sample_name, sample_type, isData=isData, load_corr_lib=True)
     corrections = Corrections.getGlobal()
     triggerFile = setup.global_params.get('triggerFile')
     if triggerFile is not None:

--- a/AnaProd/anaTupleProducer.py
+++ b/AnaProd/anaTupleProducer.py
@@ -25,7 +25,7 @@ def SelectBTagShapeSF(df,weight_name):
     df = df.Define("weight_bTagShapeSF", weight_name)
     return df
 
-def createAnatuple(inFile, treeName, outDir, setup, sample_name, anaCache, snapshotOptions,range, evtIds,
+def createAnatuple(inFile, inFileName, treeName, outDir, setup, sample_name, anaCache, snapshotOptions,range, evtIds,
                    store_noncentral, compute_unc_variations, uncertainties, anaTupleDef,channels):
     start_time = datetime.datetime.now()
     compression_settings = snapshotOptions.fCompressionAlgorithm * 100 + snapshotOptions.fCompressionLevel
@@ -68,9 +68,8 @@ def createAnatuple(inFile, treeName, outDir, setup, sample_name, anaCache, snaps
     #                    (static_cast<ULong64_t>({fastcrc.crc16.xmodem(inFile.encode())}) << 32) |
     #                    (static_cast<ULong64_t>(rdfentry_)); return packed; """)
     #  following def to be removed when fastcrc is available
-    df = df.Define("FullEventId", f"""ULong64_t packed = (static_cast<ULong64_t>({Utilities.crc16(sample_name.encode())}) << 48) |
-                       (static_cast<ULong64_t>({Utilities.crc16(inFile.encode())}) << 32) |
-                       (static_cast<ULong64_t>(rdfentry_)); return packed; """)
+
+    df = df.Define("FullEventId", f"""eventId::computeFullEventId(static_cast<ULong64_t>({Utilities.crc16(sample_name.encode())}), static_cast<ULong64_t>({Utilities.crc16(inFile.encode())}), rdfentry_)""")
 
     is_data = 'true' if isData else 'false'
     df = df.Define("isData", is_data)
@@ -171,6 +170,7 @@ if __name__ == "__main__":
     parser.add_argument('--period', required=True, type=str)
     parser.add_argument('--inFile', required=True, type=str)
     parser.add_argument('--outDir', required=True, type=str)
+    parser.add_argument('--inFileName', required=True, type=str)
     parser.add_argument('--sample', required=True, type=str)
     parser.add_argument('--anaCache', required=True, type=str)
     parser.add_argument('--anaTupleDef', required=True, type=str)
@@ -210,6 +210,6 @@ if __name__ == "__main__":
     snapshotOptions.fMode="RECREATE"
     snapshotOptions.fCompressionAlgorithm = getattr(ROOT.ROOT, 'k' + args.compressionAlgo)
     snapshotOptions.fCompressionLevel = args.compressionLevel
-    createAnatuple(args.inFile, args.treeName, args.outDir, setup, args.sample, anaCache, snapshotOptions,
+    createAnatuple(args.inFile, args.inFileName, args.treeName, args.outDir, setup, args.sample, anaCache, snapshotOptions,
                    args.nEvents, args.evtIds, args.store_noncentral, args.compute_unc_variations,
                    args.uncertainties.split(","), anaTupleDef,channels)

--- a/AnaProd/anaTupleProducer.py
+++ b/AnaProd/anaTupleProducer.py
@@ -57,14 +57,13 @@ def createAnatuple(inFile, inFileName, treeName, outDir, setup, sample_name, ana
     if isData and 'lumiFile' in setup.global_params:
         lumiFilter = LumiFilter(setup.global_params['lumiFile'])
         df = lumiFilter.filter(df)
-
     df = df.Define("sample_type", f"static_cast<int>(SampleType::{sample_config['sampleType']})")
     isSignal = sample_config['sampleType'] in setup.global_params['signal_types']
     applyTriggerFilter = sample_config.get('applyTriggerFilter', True)
     df = df.Define("period", f"static_cast<int>(Period::{period})")
     df = df.Define("X_mass", f"static_cast<int>({mass})") # this has to be moved in specific analyses def
     df = df.Define("X_spin", f"static_cast<int>({spin})") # this has to be moved in specific analyses def
-    df = df.Define("FullEventId", f"""eventId::computeFullEventId({Utilities.crc16(sample_name.encode())}, {Utilities.crc16(inFile.encode())}, rdfentry_)""")
+    df = df.Define("FullEventId", f"""eventId::encodeFullEventId({Utilities.crc16(sample_name.encode())}, {Utilities.crc16(inFile.encode())}, rdfentry_)""")
 
     is_data = 'true' if isData else 'false'
     df = df.Define("isData", is_data)

--- a/AnaProd/anaTupleProducer.py
+++ b/AnaProd/anaTupleProducer.py
@@ -64,7 +64,7 @@ def createAnatuple(inFile, inFileName, treeName, outDir, setup, sample_name, ana
     df = df.Define("period", f"static_cast<int>(Period::{period})")
     df = df.Define("X_mass", f"static_cast<int>({mass})") # this has to be moved in specific analyses def
     df = df.Define("X_spin", f"static_cast<int>({spin})") # this has to be moved in specific analyses def
-    df = df.Define("FullEventId", f"""eventId::computeFullEventId(static_cast<ULong64_t>({Utilities.crc16(sample_name.encode())}), static_cast<ULong64_t>({Utilities.crc16(inFile.encode())}), rdfentry_)""")
+    df = df.Define("FullEventId", f"""eventId::computeFullEventId({Utilities.crc16(sample_name.encode())}, {Utilities.crc16(inFile.encode())}, rdfentry_)""")
 
     is_data = 'true' if isData else 'false'
     df = df.Define("isData", is_data)

--- a/AnaProd/anaTupleProducer.py
+++ b/AnaProd/anaTupleProducer.py
@@ -95,7 +95,7 @@ def createAnatuple(inFile, inFileName, treeName, outDir, setup, sample_name, ana
         # https://twiki.cern.ch/twiki/bin/view/CMS/MissingETOptionalFilters#Analysis_Recommendations_for_any
         if "MET_flags" in setup.global_params:
             dfw.Apply(Baseline.applyMETFlags, setup.global_params["MET_flags"], setup.global_params.get("badMET_flag_runs", []), isData)
-        anaTupleDef.addAllVariables(dfw, syst_name, isData, trigger_class, lepton_legs, isSignal, setup.global_params, channels)
+        anaTupleDef.addAllVariables(dfw, syst_name, isData, trigger_class, lepton_legs, isSignal, applyTriggerFilter, setup.global_params, channels)
         if setup.global_params['nano_version'] == 'v12':
             dfw.DefineAndAppend("weight_L1PreFiring_Central","L1PreFiringWeight_Nom")
             dfw.DefineAndAppend("weight_L1PreFiring_ECAL_Central","L1PreFiringWeight_ECAL_Nom")

--- a/AnaProd/anaTupleProducer.py
+++ b/AnaProd/anaTupleProducer.py
@@ -64,12 +64,6 @@ def createAnatuple(inFile, inFileName, treeName, outDir, setup, sample_name, ana
     df = df.Define("period", f"static_cast<int>(Period::{period})")
     df = df.Define("X_mass", f"static_cast<int>({mass})") # this has to be moved in specific analyses def
     df = df.Define("X_spin", f"static_cast<int>({spin})") # this has to be moved in specific analyses def
-    #  following def to be uncommented when fastcrc is available
-    # df = df.Define("FullEventId", f"""ULong64_t packed = (static_cast<ULong64_t>({fastcrc.crc16.xmodem(sample_name.encode())}) << 48) |
-    #                    (static_cast<ULong64_t>({fastcrc.crc16.xmodem(inFile.encode())}) << 32) |
-    #                    (static_cast<ULong64_t>(rdfentry_)); return packed; """)
-    #  following def to be removed when fastcrc is available
-
     df = df.Define("FullEventId", f"""eventId::computeFullEventId(static_cast<ULong64_t>({Utilities.crc16(sample_name.encode())}), static_cast<ULong64_t>({Utilities.crc16(inFile.encode())}), rdfentry_)""")
 
     is_data = 'true' if isData else 'false'

--- a/AnaProd/tasks.py
+++ b/AnaProd/tasks.py
@@ -211,6 +211,7 @@ class AnaTupleTask(Task, HTCondorWorkflow, law.LocalWorkflow):
                 centralFileName = os.path.basename(local_input.path)
                 if self.test:
                     anatuple_cmd.extend(['--nEvents', '100'])
+                # ps_call(anatuple_cmd, verbose=1) # this will be uncommented when the anatuple producer will be fully independent on cmsEnv.
                 ps_call(anatuple_cmd, env=self.cmssw_env, verbose=1)
 
             print("step 2: anaTupleS -> skimTuplE")

--- a/AnaProd/tasks.py
+++ b/AnaProd/tasks.py
@@ -166,10 +166,6 @@ class AnaTupleTask(Task, HTCondorWorkflow, law.LocalWorkflow):
         sample_id, sample_name, sample_type, input_file = self.branch_data
         output_name = os.path.basename(input_file.path)
         output_path = os.path.join('anaTuples', self.version, self.period, sample_name, output_name)
-        # customisation_dict = getCustomisationSplit(self.customisations)
-        # deepTauVersion = customisation_dict['deepTauVersion'] if 'deepTauVersion' in customisation_dict.keys() else self.global_params['deepTauVersion']
-        # if '2p5' in deepTauVersion:
-        #     return self.remote_target(output_path, fs=self.fs_anaTuple2p5)
         return self.remote_target(output_path, fs=self.fs_anaTuple)
 
     def run(self):
@@ -180,16 +176,12 @@ class AnaTupleTask(Task, HTCondorWorkflow, law.LocalWorkflow):
         thread.start()
         anaCache_remote = self.input()[0]
         customisation_dict = getCustomisationSplit(self.customisations)
-        # print(customisation_dict)
         channels = customisation_dict['channels'] if 'channels' in customisation_dict.keys() else self.global_params['channelSelection']
         if type(channels) == list: channels = ','.join(channels)
         store_noncentral = customisation_dict['store_noncentral']=='True' if 'store_noncentral' in customisation_dict.keys() else self.global_params.get('store_noncentral', False)
-        # print(store_noncentral)
         compute_unc_variations = customisation_dict['compute_unc_variations']=='True' if 'compute_unc_variations' in customisation_dict.keys() else self.global_params.get('compute_unc_variations', False)
-        #bbww does not use a deepTauVersion
         deepTauVersion = ''
         if self.global_params['analysis_config_area'] == 'config/HH_bbtautau': deepTauVersion = customisation_dict['deepTauVersion'] if 'deepTauVersion' in customisation_dict.keys() else self.global_params['deepTauVersion']
-        #deepTauVersion = customisation_dict['deepTauVersion'] if 'deepTauVersion' in customisation_dict.keys() else self.global_params['deepTauVersion']
         try:
             job_home, remove_job_home = self.law_job_home()
             print(f"sample_id = {sample_id}\nsample_name = {sample_name}\nsample_type = {sample_type}\n"
@@ -199,16 +191,17 @@ class AnaTupleTask(Task, HTCondorWorkflow, law.LocalWorkflow):
             outdir_anatuples = os.path.join(job_home, 'anaTuples', sample_name)
             anaTupleDef = os.path.join(self.ana_path(), self.global_params['anaTupleDef'])
             with input_file.localize("r") as local_input, anaCache_remote.localize("r") as anaCache_input:
+                centralFileName = os.path.basename(local_input.path)
                 anatuple_cmd = [ 'python3', '-u', producer_anatuples, '--period', self.period,
                                  '--inFile', local_input.path, '--outDir', outdir_anatuples, '--sample', sample_name,
-                                 '--anaTupleDef', anaTupleDef, '--anaCache', anaCache_input.path, '--channels', channels ]
+                                 '--anaTupleDef', anaTupleDef, '--anaCache', anaCache_input.path, '--channels', channels, '--inFileName', centralFileName ]
                 if deepTauVersion!="":
                     anatuple_cmd.extend([ '--customisations', f"deepTauVersion={deepTauVersion}" ])
                 if compute_unc_variations:
                     anatuple_cmd.append('--compute-unc-variations')
                 if store_noncentral:
                     anatuple_cmd.append('--store-noncentral')
-                centralFileName = os.path.basename(local_input.path)
+
                 if self.test:
                     anatuple_cmd.extend(['--nEvents', '100'])
                 # ps_call(anatuple_cmd, verbose=1) # this will be uncommented when the anatuple producer will be fully independent on cmsEnv.

--- a/Analysis/HistMerger.py
+++ b/Analysis/HistMerger.py
@@ -176,7 +176,7 @@ if __name__ == "__main__":
     categories = list(global_cfg_dict['categories'])
 
     boosted_categories = list(global_cfg_dict.get('apply_btag_shape_weights', [])) # list(global_cfg_dict['boosted_categories'])
-    QCDregions =  list(global_cfg_dict['SignRegions']) # list(global_cfg_dict['QCDRegions'])
+    QCDregions = list(global_cfg_dict['QCDRegions'])
 
     #Controlregions = list(global_cfg_dict['ControlRegions']) #Later maybe we want to separate Controls from QCDs
     global_cfg_dict['channelSelection']=args.channels.split(',')

--- a/Analysis/HistMerger.py
+++ b/Analysis/HistMerger.py
@@ -176,7 +176,7 @@ if __name__ == "__main__":
     categories = list(global_cfg_dict['categories'])
 
     boosted_categories = list(global_cfg_dict.get('apply_btag_shape_weights', [])) # list(global_cfg_dict['boosted_categories'])
-    QCDregions = list(global_cfg_dict['QCDRegions'])
+    QCDregions = list(global_cfg_dict.get('QCDRegions', []))
 
     #Controlregions = list(global_cfg_dict['ControlRegions']) #Later maybe we want to separate Controls from QCDs
     global_cfg_dict['channelSelection']=args.channels.split(',')

--- a/Analysis/HistPlotter.py
+++ b/Analysis/HistPlotter.py
@@ -261,17 +261,11 @@ if __name__ == "__main__":
         custom1= {'cat_text':cat_txt, 'ch_text':page_cfg_custom_dict['channel_text'][args.channel], 'datasim_text':'CMS simulation', 'scope_text':''}
     inFile_root = ROOT.TFile.Open(args.inFile, "READ")
     dir_0 = inFile_root.Get(args.channel)
-    # print(f"dir_0 = {dir_0}")
     keys_0 = [str(k) for k in dir_0.GetListOfKeys()]
-    # print(f"keys = {keys_0}")
     dir_0p1 = dir_0.Get(args.qcdregion)
     keys_0p1 = [str(k) for k in dir_0p1.GetListOfKeys()]
-    # print(f"keys = {keys_0p1}")
-    # print(f"dir_0p1 = {args.qcdregion}")
     dir_1 = dir_0p1.Get(args.category)
     keys_1 = [str(k) for k in dir_1.GetListOfKeys()]
-    # print(f"keys = {keys_1}")
-    # print(f"dir_1 = {args.category}")
 
     # dir_1 = dir_0.Get(args.category) # --> uncomment if QCD regions are not included in the histograms
     #hist_cfg_dict[args.var]['max_y_sf'] = 1.4

--- a/Analysis/HistPlotter.py
+++ b/Analysis/HistPlotter.py
@@ -163,7 +163,7 @@ if __name__ == "__main__":
 
     with open(page_cfg_custom, 'r') as f:
         page_cfg_custom_dict = yaml.safe_load(f)
-    inputs_cfg = os.path.join(os.environ['ANALYSIS_PATH'],"config", "plot/inputs.yaml")
+    inputs_cfg = os.path.join(os.environ['ANALYSIS_PATH'],"config", "plot","inputs.yaml")
     with open(inputs_cfg, 'r') as f:
         inputs_cfg_dict = yaml.safe_load(f)
 
@@ -288,6 +288,7 @@ if __name__ == "__main__":
         sample_type = sample_content['type']
         sample_plot_name = sample_content['plot']
         if args.uncSource != 'Central': continue # to be fixed
+
         sample_histname = (GetHistName(sample_name, sample_type, 'Central','Central', global_cfg_dict))
         if sample_histname not in dir_1.GetListOfKeys():
             print(f"ERRORE: {sample_histname} non è nelle keys")

--- a/Analysis/HistProducerFile.py
+++ b/Analysis/HistProducerFile.py
@@ -264,7 +264,7 @@ if __name__ == "__main__":
             kwargset['region'] = args.region
             kwargset['isData'] = isData
             kwargset['isCentral'] = True
-            kwargset['whichType'] = datasetType
+
 
 
         all_dataframes = {}

--- a/Analysis/HistProducerFile.py
+++ b/Analysis/HistProducerFile.py
@@ -261,7 +261,7 @@ if __name__ == "__main__":
             kwargset['wantTriggerSFErrors'] = compute_rel_weights_not_data
             kwargset['whichType'] = datasetType
         if analysis_import == "Analysis.H_mumu":
-            kwargset['region'] = args.region
+            ROOT.gInterpreter.Declare(f'#include "include/Helper.h"') # not related to FullEvtId definition but needed for analysis specific purpose. At a certain point it will be moved to analysis specific section.
             kwargset['isData'] = isData
             kwargset['isCentral'] = True
 

--- a/config/crossSections13p6TeV.yaml
+++ b/config/crossSections13p6TeV.yaml
@@ -551,7 +551,7 @@ WminusH_Hto2Mu_WtoAll:
   reference: https://indico.cern.ch/event/1119741/contributions/4715908/attachments/2383849/4073592/YR4_13p6_VH_update.pdf
   unc: +0.4% -0.7% (QCD scale) ±1.8% (PDF+alphas) ±1.6 (PDF) ±0.9 (alpha s) ; +1.23% -1.2% (theory) +0.97% -0.99% (mq) +0.59% -0.64% (alphas)
 
-WminusH_Hto2Mu_WtoAll:
+WplusH_Hto2Mu_WtoAll:
   crossSec: 0.8889 * (0.0002176) # 1.457 (total)
   reference: https://indico.cern.ch/event/1119741/contributions/4715908/attachments/2383849/4073592/YR4_13p6_VH_update.pdf
   unc: +0.4% -0.7% (QCD scale) ±1.8% (PDF+alphas) ±1.6 (PDF) ±0.9 (alpha s) ; +1.23% -1.2% (theory) +0.97% -0.99% (mq) +0.59% -0.64% (alphas)

--- a/env.sh
+++ b/env.sh
@@ -140,7 +140,7 @@ install_inference() {
 
 load_flaf_env() {
 
-  [ -z "$FLAF_ENVIRONMENT_PATH" ] && export FLAF_ENVIRONMENT_PATH="/afs/cern.ch/work/k/kandroso/public/flaf_env_2024_08"
+  [ -z "$FLAF_ENVIRONMENT_PATH" ] && export FLAF_ENVIRONMENT_PATH="/afs/cern.ch/work/k/kandroso/public/flaf_env_2025_04"
 
   [ -z "$LAW_HOME" ] && export LAW_HOME="$ANALYSIS_PATH/.law"
   [ -z "$LAW_CONFIG_FILE" ] && export LAW_CONFIG_FILE="$ANALYSIS_PATH/config/law.cfg"

--- a/env.sh
+++ b/env.sh
@@ -147,7 +147,7 @@ load_flaf_env() {
   local this_dir="$( cd "$( dirname "$this_file" )" && pwd )"
 
   export FLAF_PATH="$this_dir"
-  [ -z "$FLAF_ENVIRONMENT_PATH" ] && export FLAF_ENVIRONMENT_PATH="/afs/cern.ch/work/k/kandroso/public/flaf_env_2024_08"
+  [ -z "$FLAF_ENVIRONMENT_PATH" ] && export FLAF_ENVIRONMENT_PATH="/afs/cern.ch/work/k/kandroso/public/flaf_env_2025_04"
 
   [ -z "$LAW_HOME" ] && export LAW_HOME="$ANALYSIS_PATH/.law"
   [ -z "$LAW_CONFIG_FILE" ] && export LAW_CONFIG_FILE="$ANALYSIS_PATH/config/law.cfg"

--- a/include/AnalysisTools.h
+++ b/include/AnalysisTools.h
@@ -346,4 +346,30 @@ namespace v_ops{
       }
       return m;
   }
+
+  template<typename LV>
+  RVecF energy(const LV& p4){
+      RVecF en(p4.size());
+      for(int p4_idx=0;p4_idx<p4.size();++p4_idx){
+        en[p4_idx] = p4.at(p4_idx).energy();
+      }
+      return en;
+  }
+  template<typename LV>
+  RVecF Et(const LV& p4){
+      RVecF et(p4.size());
+      for(int p4_idx=0;p4_idx<p4.size();++p4_idx){
+        et[p4_idx] = p4.at(p4_idx).Et();
+      }
+      return et;
+  }
+
+}
+
+namespace eventId{
+
+  ULong64_t computeFullEventId(ULong64_t sample_name_crc, ULong64_t infile_crc, ULong64_t rdfentry) {
+    return (sample_name_crc << 48) | (static_cast<ULong64_t>(infile_crc) << 32) | rdfentry;
+  }
+
 }

--- a/include/AnalysisTools.h
+++ b/include/AnalysisTools.h
@@ -398,7 +398,7 @@ namespace v_ops{
 
 namespace eventId {
 
-  ULong64_t computeFullEventId(ULong64_t sample_name_crc, ULong64_t infile_crc, ULong64_t rdfentry) {
+  ULong64_t encodeFullEventId(ULong64_t sample_name_crc, ULong64_t infile_crc, ULong64_t rdfentry) {
     if (sample_name_crc >> 16)
       throw std::runtime_error("sample_name_crc overflows 16 bits");
     if (infile_crc >> 16)

--- a/include/HistHelper.h
+++ b/include/HistHelper.h
@@ -28,11 +28,12 @@ using RVecF = ROOT::VecOps::RVec<float>;
 using RVecI = ROOT::VecOps::RVec<int>;
 using RVecUC = ROOT::VecOps::RVec<unsigned char>;
 using RVecUL = ROOT::VecOps::RVec<unsigned long>;
+using RVecULL = ROOT::VecOps::RVec<unsigned long long>;
 using RVecSh = ROOT::VecOps::RVec<short>;
 //using RVecB = ROOT::VecOps::RVec<bool>;
 
 namespace analysis {
-typedef std::variant<int,float,bool, unsigned long,unsigned long long,long long, long,unsigned int, RVecI, RVecF,RVecUC,RVecUL, RVecSh, double, unsigned char> MultiType; // Removed kin_fit::FitResults from the variant
+typedef std::variant<int,float,bool, unsigned long,unsigned long long,long long, long,unsigned int, RVecI, RVecF,RVecUC,RVecUL, RVecULL, RVecSh, double, unsigned char> MultiType; // Removed kin_fit::FitResults from the variant
 
 struct Entry {
   std::vector<MultiType> var_values;
@@ -60,13 +61,13 @@ template<typename T>
 };
 
 struct StopLoop {};
-static std::map<std::tuple<int, unsigned int,unsigned long long ,unsigned int>, std::shared_ptr<Entry>>& GetEntriesMap(){
-      static std::map<std::tuple<int, unsigned int,unsigned long long ,unsigned int>, std::shared_ptr<Entry>> entries;
+static std::map<std::tuple<unsigned long long, unsigned int,unsigned long long ,unsigned int>, std::shared_ptr<Entry>>& GetEntriesMap(){
+      static std::map<std::tuple<unsigned long long, unsigned int,unsigned long long ,unsigned int>, std::shared_ptr<Entry>> entries;
       return entries;
   }
 
-static std::map<std::tuple<int, unsigned int,unsigned long long ,unsigned int>, std::shared_ptr<Entry>>& GetCacheEntriesMap(){
-      static std::map<std::tuple<int, unsigned int,unsigned long long ,unsigned int>, std::shared_ptr<Entry>> cache_entries;
+static std::map<std::tuple<unsigned long long, unsigned int,unsigned long long ,unsigned int>, std::shared_ptr<Entry>>& GetCacheEntriesMap(){
+      static std::map<std::tuple<unsigned long long, unsigned int,unsigned long long ,unsigned int>, std::shared_ptr<Entry>> cache_entries;
       return cache_entries;
   }
 
@@ -78,15 +79,15 @@ struct MapCreator {
   {
       auto df_node = df_in.Define("_entry", [=](const Args& ...args) {
               auto entry = std::make_shared<Entry>(var_names.size());
-              int index = 0;
-              (void) std::initializer_list<int>{ (entry->Add(index++, args), 0)... };
+              unsigned long long index = 0;
+              (void) std::initializer_list<unsigned long long>{ (entry->Add(index++, args), 0)... };
               return entry;
           }, var_names).Define("map_placeholder", [&](const std::shared_ptr<Entry>& entry) {
-              const auto idx = entry->GetValue<int>(0);
+              const auto idx = entry->GetValue<unsigned long long>(0);
               const auto run = entry->GetValue<unsigned int>(1);
               const auto evt = entry->GetValue<unsigned long long>(2);
               const auto lumi = entry->GetValue<unsigned int>(3);
-              std::tuple<int,unsigned int,unsigned long long ,unsigned int> tupletofind = {idx,run, evt, lumi};
+              std::tuple<unsigned long long,unsigned int,unsigned long long ,unsigned int> tupletofind = {idx,run, evt, lumi};
               if(GetEntriesMap().find(tupletofind)!=GetEntriesMap().end()) {
                 //if(checkDuplicates){
                 std::cout << idx << "\t" << run << "\t" << evt << "\t" << lumi << std::endl;
@@ -113,11 +114,11 @@ struct CacheCreator {
               (void) std::initializer_list<int>{ (cache_entry->Add(index++, args), 0)... };
               return cache_entry;
           }, var_names).Define(map_name, [&](const std::shared_ptr<Entry>& cache_entry) {
-              const auto idx = cache_entry->GetValue<int>(0);
+              const auto idx = cache_entry->GetValue<unsigned long long>(0);
               const auto run = cache_entry->GetValue<unsigned int>(1);
               const auto evt = cache_entry->GetValue<unsigned long long>(2);
               const auto lumi = cache_entry->GetValue<unsigned int>(3);
-              std::tuple<int,unsigned int,unsigned long long ,unsigned int> tupletofind = {idx,run, evt, lumi};
+              std::tuple<unsigned long long,unsigned int,unsigned long long ,unsigned int> tupletofind = {idx,run, evt, lumi};
               if(GetCacheEntriesMap().find(tupletofind)!=GetCacheEntriesMap().end()) {
                 //if(checkDuplicates){
                 //std::cout << idx << "\t" << run << "\t" << evt << "\t" << lumi << std::endl;

--- a/include/Utilities.h
+++ b/include/Utilities.h
@@ -13,6 +13,8 @@
 using RVecF = ROOT::VecOps::RVec<float>;
 using RVecI = ROOT::VecOps::RVec<int>;
 using RVecUC = ROOT::VecOps::RVec<unsigned char>;
+using RVecUL = ROOT::VecOps::RVec<unsigned long>;
+using RVecULL = ROOT::VecOps::RVec<unsigned long long>;
 
 
 namespace detail {

--- a/test/CheckAnaTuplesCompatibility.py
+++ b/test/CheckAnaTuplesCompatibility.py
@@ -1,0 +1,159 @@
+import ROOT
+import sys
+import os
+import math
+import shutil
+import time
+ROOT.EnableThreadSafety()
+
+if __name__ == "__main__":
+    sys.path.append(os.environ['ANALYSIS_PATH'])
+
+import FLAF.Common.Utilities as Utilities
+
+snapshotOptions = ROOT.RDF.RSnapshotOptions()
+snapshotOptions.fOverwriteIfExists=False
+snapshotOptions.fLazy=False
+snapshotOptions.fMode="RECREATE"
+snapshotOptions.fCompressionAlgorithm = getattr(ROOT.ROOT, 'k' + 'ZLIB')
+snapshotOptions.fCompressionLevel = 4
+
+def createCentralQuantities(df_central, central_col_types, central_columns):
+    map_creator = ROOT.analysis.MapCreator(*central_col_types)()
+    df_central = map_creator.processCentral(ROOT.RDF.AsRNode(df_central), Utilities.ListToVector(central_columns), 1)
+    return df_central
+if __name__ == "__main__":
+    import argparse
+    import yaml
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--inFile', required=True, type=str)
+    parser.add_argument('--outDir', required=True, type=str)
+    parser.add_argument('--uncConfig', required=True, type=str)
+    args = parser.parse_args()
+
+
+    startTime = time.time()
+    headers_dir = os.path.dirname(os.path.abspath(__file__))
+    ROOT.gROOT.ProcessLine(f".include {os.environ['ANALYSIS_PATH']}")
+    ROOT.gInterpreter.Declare(f'#include "FLAF/include/HistHelper.h"')
+    ROOT.gInterpreter.Declare(f'#include "FLAF/include/Utilities.h"')
+    ROOT.gROOT.ProcessLine('#include "FLAF/include/AnalysisTools.h"')
+    ROOT.gROOT.ProcessLine('#include "FLAF/include/AnalysisMath.h"')
+
+
+    unc_cfg_dict = {}
+    with open(args.uncConfig, 'r') as f:
+        unc_cfg_dict = yaml.safe_load(f)
+
+    inFile_root = ROOT.TFile.Open(args.inFile,"READ")
+    inFile_keys = [k.GetName() for k in inFile_root.GetListOfKeys()]
+    if 'Events' not in inFile_keys:
+        key_not_exist = True
+    inFile_root.Close()
+
+    dfWrapped_central = Utilities.DataFrameBuilderBase(ROOT.RDataFrame('Events',args.inFile))
+
+    snaps = []
+    col_names_central =  dfWrapped_central.colNames
+    col_types_central =  dfWrapped_central.colTypes
+
+    # central quantities definition
+    dfWrapped_central.df = createCentralQuantities(dfWrapped_central.df, col_types_central, col_names_central)
+    if dfWrapped_central.df.Filter("map_placeholder > 0").Count().GetValue() <= 0 : raise RuntimeError("no events passed map placeolder")
+
+    # remove relative weights as they are not included in the varied ttrees (by construction)
+    col_to_remove = []
+    for col in col_names_central:
+        if col.endswith("rel"):
+            col_to_remove.append(col)
+    for col_name in col_to_remove:
+        col_idx = col_names_central.index(col_name)
+        col_type = col_types_central[col_idx]
+        col_names_central.pop(col_idx)
+        col_types_central.pop(col_idx)
+
+
+    for uncName in ["JER"] : #unc_cfg_dict['shape']:
+        files = {}
+        # print(f"uncname is {uncName}")
+        for scale in ['Up', 'Down'] :
+            if scale not in files.keys():
+                files[scale] = []
+            treeName = f"Events_{uncName}{scale}"
+
+            treeName_noDiff = f"{treeName}_noDiff"
+            if treeName_noDiff in inFile_keys:
+                print(treeName_noDiff)
+                dfWrapped_noDiff = Utilities.DataFrameBuilderBase(ROOT.RDataFrame(treeName_noDiff, args.inFile))
+                dfWrapped_noDiff.AddMissingColumns(col_names_central, col_types_central)
+                dfWrapped_noDiff.df.Snapshot("Events", f"{args.outDir}{treeName_noDiff}.root",Utilities.ListToVector(col_names_central), snapshotOptions)
+                files[scale].append(f"{args.outDir}{treeName_noDiff}.root")
+
+            treeName_Valid = f"{treeName}_Valid"
+            if treeName_Valid in inFile_keys:
+                print(treeName_Valid)
+                dfWrapped_Valid = Utilities.DataFrameBuilderBase(ROOT.RDataFrame(treeName_Valid, args.inFile))
+                dfWrapped_Valid.CreateFromDelta(col_names_central, col_types_central)
+                dfWrapped_Valid.AddMissingColumns(col_names_central, col_types_central)
+                dfWrapped_Valid.df.Snapshot("Events", f"{args.outDir}{treeName_Valid}.root", Utilities.ListToVector(col_names_central), snapshotOptions)
+                files[scale].append(f"{args.outDir}{treeName_Valid}.root")
+
+            treeName_nonValid = f"{treeName}_nonValid"
+            if treeName_nonValid in inFile_keys:
+                print(treeName_nonValid)
+                dfWrapped_nonValid = Utilities.DataFrameBuilderBase(ROOT.RDataFrame(treeName_nonValid, args.inFile))
+                for col in col_names_central:
+                    col_idx = col_names_central.index(col)
+                    col_type = col_types_central[col_idx]
+                    dfWrapped_nonValid.df = dfWrapped_nonValid.df.Redefine(col, f"static_cast<{col_type}>({col})")
+                dfWrapped_nonValid.df.Snapshot("Events", f"{args.outDir}{treeName_nonValid}.root",Utilities.ListToVector(col_names_central), snapshotOptions)
+
+                files[scale].append(f"{args.outDir}{treeName_nonValid}.root")
+
+
+        for scale in ['Up', 'Down'] :
+            columns = {}
+            for fileName in files[scale]:
+                dfw = Utilities.DataFrameBuilderBase(ROOT.RDataFrame('Events',fileName))
+                columns[fileName] = {}
+                col_names_central =  dfw.colNames
+                col_types_central =  dfw.colTypes
+                columns[fileName]["col"] = col_names_central
+                columns[fileName]["type"] = col_types_central
+            # first element is the reference
+            reference_name = next(iter(columns))  # reference name
+            reference = columns[reference_name]
+            ref_cols = reference["col"]
+            ref_types = reference["type"]
+            for fileName, entry in columns.items():
+                if fileName == reference_name:
+                    continue # skip the reference file
+                cols = entry["col"]
+                types = entry["type"]
+                # different columns check
+                missing_cols = set(ref_cols) - set(cols)
+                extra_cols = set(cols) - set(ref_cols)
+                if missing_cols or extra_cols:
+                    print(f"\n[file: {fileName}] different columns:")
+                    if missing_cols:
+                        print(f"  - missing columns: {missing_cols}")
+                    if extra_cols:
+                        print(f"  - extra columns: {extra_cols}")
+                # type differences in columns check
+                common_cols = set(ref_cols) & set(cols)
+                type_mismatches = []
+                for col in common_cols:
+                    ref_index = ref_cols.index(col)
+                    cur_index = cols.index(col)
+                    if ref_types[ref_index] != types[cur_index]:
+                        type_mismatches.append((col, ref_types[ref_index], types[cur_index]))
+                if type_mismatches:
+                    print(f"\n[file: {fileName}] different types:")
+                    for col, ref_t, cur_t in type_mismatches:
+                        print(f"  - col '{col}': ref={ref_t}, current={cur_t}")
+            df_total = ROOT.RDataFrame("Events", Utilities.ListToVector(files[scale]))
+            df_total.Snapshot("Events", f"{args.outDir}test_hAdded_{uncName}{scale}.root", Utilities.ListToVector(col_names_central), snapshotOptions)
+
+    executionTime = (time.time() - startTime)
+    print('Execution time in seconds: ' + str(executionTime))


### PR DESCRIPTION
This PR is intended to define a Full event ID to allow the direct Hadd between AnaTuple files. 
The substantial changes are:
- switch from eventIndex to a FullEvtID, which is a 64 bit integer containing
    - dataset name in the first 16 bits
    - fileID in the subsequent 16 bits
    - entry index in the final 32 bits
- introduction of custom function for crc16 conversion. In the next future, this will be removed and fastcrc lib will be included. It is actually half-included, in the sense that the code is implemented but it is commented. The reason is that the inclusion of fastcrc lib is not compatible (for some reason I still haven't clear) with the cmsEnv command (a.k.a. submitting anatuples with `env=cmssw`  enabled). The cmsEnv is still needed for anatuple production as the JEC application fails if removing it.  For the moment, this patch is working. 
- switch to new flaf env (including fastcrc but not yet compatible with cmsEnv + **fixing the voms incompatibility with new lcg java related settings**)
- minor inclusion of some H_mumu related include in HistProducerFile (I know it should belong to a separate PR, if needed I can remove from this PR) 

Moreover, some future changes or patch fix are included and commented in the specific scripts.
