### PR TITLE
Redefine {obj}_legType

### DIFF
--- a/AnaProd/anaTupleProducer.py
+++ b/AnaProd/anaTupleProducer.py
@@ -134,6 +134,11 @@ def createAnatuple(inFile, treeName, outDir, setup, sample_name, anaCache, snaps
                         dfw.DefineAndAppend(f"{new_branch_name}_b{bjet_idx}", f"Hbb_isValid ? {puIDbranch}[b{bjet_idx}_idx] : -100.f")
                 if puIDbranch in weight_branches: weight_branches.remove(puIDbranch)
             dfw.colToSave.extend(weight_branches)
+
+        # Analysis anaTupleDef should define a legType as a leg obj
+        # But to save with RDF, it needs to be converted to an int
+        for leg_name in lepton_legs:
+            dfw.Redefine(f"{leg_name}_legType", f"static_cast<int>({leg_name}_legType)")
         varToSave = Utilities.ListToVector(dfw.colToSave)
         outfile_prefix = inFile.split('/')[-1]
         outfile_prefix = outfile_prefix.split('.')[0]

--- a/Analysis/HistMerger.py
+++ b/Analysis/HistMerger.py
@@ -78,6 +78,7 @@ def getHistDict(var, all_histograms, inFileRoot,channels, QCDregions, all_catego
                         if sample_name=='data':
                             key_final = 'data'
                         obj=dir_2.Get(key_final)
+                        if not hasattr(obj, 'SetDirectory'): continue
                         obj.SetDirectory(0)
                         if not obj.IsA().InheritsFrom(ROOT.TH1.Class()): continue
                         key_total = ((channel, qcdRegion, cat), (uncSource, scale))


### PR DESCRIPTION
Due to change of use from _type to _legType in anaTupleDef (analysis specific) we want to change to using the Leg:: struct in Corrections. This requires the Leg:: struct object to exist OUTSIDE of anaTupleDef

For all other analysis, you will need to remove your redefine of legType from anaTupleDef