### PR TITLE
HistProducerFile MemoryIssue Fix

### DIFF
--- a/Analysis/HistProducerFile.py
+++ b/Analysis/HistProducerFile.py
@@ -249,7 +249,7 @@ def GetShapeDataFrameDict(all_dataframes, global_cfg_dict, key, key_central, fil
             # print(treeName_nonValid)
             dfWrapped_nonValid = analysis.DataFrameBuilderForHistograms(ROOT.RDataFrame(treeName_nonValid, inFile),global_cfg_dict, period, **kwargset)
             if hasCache:
-                dfWrapped_cache_nonValid = analysis.DataFrameBuilderForHistograms(ROOT.RDataFrame(treeName_nonValid,global_cfg_dict, period, **kwargset) )
+                dfWrapped_cache_nonValid = analysis.DataFrameBuilderForHistograms(ROOT.RDataFrame(treeName_nonValid,inFileCache),global_cfg_dict, period, **kwargset)
                 AddCacheColumnsInDf(dfWrapped_nonValid, dfWrapped_cache_nonValid, f"cache_map_{uncName}{scale}_nonValid")
             dfWrapped_nonValid.AddMissingColumns(colNames, colTypes)
             dfWrapped_nonValid = analysis.PrepareDfForHistograms(dfWrapped_nonValid)


### PR DESCRIPTION
HistProducerFile was giving a seg violation for JES_TotalUp_nonValid

Found that it is likely due to python making bad memory decisions and could be fixed by inverting two for loops
its ridiculous, and there are still a lot of comments in there so don't merge this right away. I want to talk to you about it, but I also am just happy to have a solution right now.