### PR TITLE
Plot task bug fix

### DIFF
--- a/Analysis/tasks.py
+++ b/Analysis/tasks.py
@@ -478,7 +478,7 @@ class PlotTask(Task, HTCondorWorkflow, law.LocalWorkflow):
         plot_analysis     = customisation_dict.get('plot_analysis', self.global_params.get('plot_analysis', ''))
 
         remote_in = (
-            self.remote_target(os.path.join(ver, era, "merged", var, "tmp", f"all_histograms_{var}_hadded.root"), fs=self.fs_histograms)
+            self.remote_target(os.path.join(ver, era, "merged", var, f"{var}.root"), fs=self.fs_histograms)
             if plot_unc else self.input()
         )
 


### PR DESCRIPTION
We do not have 'HaddMergedTask' in framework (which suppose to produce files like all_histograms_{var}_hadded.root). So this task must run one step before that, which needs input file naming adjustment