### PR TITLE
Samples skim 2025 v1

### DIFF
--- a/config/Run3_2022/samples.yaml
+++ b/config/Run3_2022/samples.yaml
@@ -2,7 +2,7 @@ GLOBAL:
   era: Run3_2022
   luminosity: 7980.4 # pb-1
   fs_nanoAOD:
-  - 'T2_CH_CERN:/store/group/phys_higgs/HLepRare/skim_2024_v2/Run3_2022'
+  - 'T2_CH_CERN:/store/group/phys_higgs/HLepRare/skim_2025_v1/Run3_2022'
   nano_version: v14
   crossSectionsFile : FLAF/config/crossSections13p6TeV.yaml
   use_stitching: false
@@ -673,90 +673,90 @@ QCD_PT_3200:
   sampleType: QCD_PT
 
 ############## ST ##############
-ST_s_channel_antitop_4f_leptonDecays:
-  crossSection: ST_s_channel_antitop_LNu
+TbarBtoLminusNuB_s_channel_4FS: 
+  crossSection: TbarBtoLminusNuB_s_channel_4FS
   generator: amcatnlo
   miniAOD: /TbarBtoLminusNuB-s-channel-4FS_TuneCP5_13p6TeV_amcatnlo-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: ST
-ST_s_channel_top_4f_leptonDecays:
-  crossSection: ST_s_channel_top_LNu
+TBbartoLplusNuBbar_s_channel_4FS:
+  crossSection: TBbartoLplusNuBbar_s_channel_4FS
   generator: amcatnlo
   miniAOD: /TBbartoLplusNuBbar-s-channel-4FS_TuneCP5_13p6TeV_amcatnlo-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: ST
 
-ST_t_channel_antitop_4f_InclusiveDecays:
-  crossSection: ST_t_channel_antitop
+TbarBQ_t_channel_4FS:
+  crossSection: TbarBQ_t_channel_4FS
   generator: powheg
   miniAOD: /TbarBQ_t-channel_4FS_TuneCP5_13p6TeV_powheg-madspin-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: ST
-ST_t_channel_top_4f_InclusiveDecays:
-  crossSection: ST_t_channel_top
+TBbarQ_t_channel_4FS:
+  crossSection: TBbarQ_t_channel_4FS
   generator: powheg
   miniAOD: /TBbarQ_t-channel_4FS_TuneCP5_13p6TeV_powheg-madspin-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: ST
 
-ST_tW_antitop_2L2Nu:
-  crossSection: ST_tW_antitop_2L2Nu
+TbarWplusto2L2Nu:
+  crossSection: TbarWplusto2L2Nu
   generator: powheg
   miniAOD: /TbarWplusto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: ST
-ST_tW_antitop_2L2Nu_ext1:
-  crossSection: ST_tW_antitop_2L2Nu
+TbarWplusto2L2Nu_ext1:
+  crossSection: TbarWplusto2L2Nu
   generator: powheg
   miniAOD: /TbarWplusto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5_ext1-v2/MINIAODSIM
   sampleType: ST
 
-ST_tW_antitop_4Q:
-  crossSection: ST_tW_antitop_4Q
+TbarWplusto4Q:
+  crossSection: TbarWplusto4Q
   generator: powheg
   miniAOD: /TbarWplusto4Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: ST
-ST_tW_antitop_4Q_ext1:
-  crossSection: ST_tW_antitop_4Q
+TbarWplusto4Q_ext1:
+  crossSection: TbarWplusto4Q
   generator: powheg
   miniAOD: /TbarWplusto4Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5_ext1-v2/MINIAODSIM
   sampleType: ST
 
-ST_tW_antitop_LNu2Q:
-  crossSection: ST_tW_antitop_LNu2Q
+TbarWplustoLNu2Q:
+  crossSection: TbarWplustoLNu2Q
   generator: powheg
   miniAOD: /TbarWplustoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: ST
-ST_tW_antitop_LNu2Q_ext1:
-  crossSection: ST_tW_antitop_LNu2Q
+TbarWplustoLNu2Q_ext1:
+  crossSection: TbarWplustoLNu2Q
   generator: powheg
   miniAOD: /TbarWplustoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5_ext1-v2/MINIAODSIM
   sampleType: ST
 
-ST_tW_top_2L2Nu:
-  crossSection: ST_tW_top_2L2Nu
+TWminusto2L2Nu:
+  crossSection: TWminusto2L2Nu
   generator: powheg
   miniAOD: /TWminusto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: ST
-ST_tW_top_2L2Nu_ext1:
-  crossSection: ST_tW_top_2L2Nu
+TWminusto2L2Nu_ext1:
+  crossSection: TWminusto2L2Nu
   generator: powheg
   miniAOD: /TWminusto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5_ext1-v2/MINIAODSIM
   sampleType: ST
 
-ST_tW_top_4Q:
-  crossSection: ST_tW_top_4Q
+TWminusto4Q:
+  crossSection: TWminusto4Q
   generator: powheg
   miniAOD: /TWminusto4Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: ST
-ST_tW_top_4Q_ext1:
-  crossSection: ST_tW_top_4Q
+TWminusto4Q_ext1:
+  crossSection: TWminusto4Q
   generator: powheg
   miniAOD: /TWminusto4Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5_ext1-v2/MINIAODSIM
   sampleType: ST
 
-ST_tW_top_LNu2Q:
-  crossSection: ST_tW_top_LNu2Q
+TWminustoLNu2Q:
+  crossSection: TWminustoLNu2Q
   generator: powheg
   miniAOD: /TWminustoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: ST
-ST_tW_top_LNu2Q_ext1:
-  crossSection: ST_tW_top_LNu2Q
+TWminustoLNu2Q_ext1:
+  crossSection: TWminustoLNu2Q
   generator: powheg
   miniAOD: /TWminustoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5_ext1-v2/MINIAODSIM
   sampleType: ST
@@ -1200,12 +1200,12 @@ Zto2Q_HT_800toInf:
   miniAOD: /Zto2Q-4Jets_HT-800_TuneCP5_13p6TeV_madgraphMLM-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v2/MINIAODSIM
   sampleType: ZQQ
 
-ttHToNonbb_M125:
+TTHtoNon2B_M125:
   crossSection: ttHToNonbb_M125
   generator: powheg
   miniAOD: /TTHtoNon2B_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v4/MINIAODSIM
   sampleType: ttH
-ttHTobb_M125:
+TTHto2B_M125:
   crossSection: ttHTobb_M125
   generator: powheg
   miniAOD: /TTHto2B_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22MiniAODv4-130X_mcRun3_2022_realistic_v5-v3/MINIAODSIM

--- a/config/Run3_2022EE/samples.yaml
+++ b/config/Run3_2022EE/samples.yaml
@@ -2,7 +2,7 @@ GLOBAL:
   era: Run3_2022EE
   luminosity: 26671.7 # pb-1
   fs_nanoAOD:
-  - 'T2_CH_CERN:/store/group/phys_higgs/HLepRare/skim_2024_v2/Run3_2022EE'
+  - 'T2_CH_CERN:/store/group/phys_higgs/HLepRare/skim_2025_v1/Run3_2022EE'
   nano_version: v14
   crossSectionsFile : FLAF/config/crossSections13p6TeV.yaml
   use_stitching: false
@@ -650,96 +650,96 @@ QCD_PT_3200:
   miniAOD: /QCD_PT-3200_TuneCP5_13p6TeV_pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6_ext1-v2/MINIAODSIM
 
 ############## ST ##############
-ST_s_channel_antitop_4f_leptonDecays:
+TbarBtoLminusNuB_s_channel_4FS:
   sampleType: ST
-  crossSection: ST_s_channel_antitop_LNu
+  crossSection: TbarBtoLminusNuB_s_channel_4FS
   generator: amcatnlo
   miniAOD: /TbarBtoLminusNuB-s-channel-4FS_TuneCP5_13p6TeV_amcatnlo-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-ST_s_channel_top_4f_leptonDecays:
+TBbartoLplusNuBbar_s_channel_4FS:
   sampleType: ST
-  crossSection: ST_s_channel_top_LNu
+  crossSection: TBbartoLplusNuBbar_s_channel_4FS
   generator: amcatnlo
   miniAOD: /TBbartoLplusNuBbar-s-channel-4FS_TuneCP5_13p6TeV_amcatnlo-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-ST_t_channel_antitop_4f_InclusiveDecays:
+TbarBQ_t_channel_4FS:
   sampleType: ST
-  crossSection: ST_t_channel_antitop
+  crossSection: TbarBQ_t_channel_4FS
   generator: powheg
   miniAOD: /TbarBQ_t-channel_4FS_TuneCP5_13p6TeV_powheg-madspin-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-ST_t_channel_top_4f_InclusiveDecays:
+TBbarQ_t_channel_4FS:
   sampleType: ST
-  crossSection: ST_t_channel_top
+  crossSection: TBbarQ_t_channel_4FS
   generator: powheg
   miniAOD: /TBbarQ_t-channel_4FS_TuneCP5_13p6TeV_powheg-madspin-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-ST_tW_antitop_2L2Nu:
+TbarWplusto2L2Nu:
   sampleType: ST
-  crossSection: ST_tW_antitop_2L2Nu
+  crossSection: TbarWplusto2L2Nu
   generator: powheg
   miniAOD: /TbarWplusto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-ST_tW_antitop_2L2Nu_ext1:
+TbarWplusto2L2Nu_ext1:
   sampleType: ST
-  crossSection: ST_tW_antitop_2L2Nu
+  crossSection: TbarWplusto2L2Nu
   generator: powheg
   miniAOD: /TbarWplusto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6_ext1-v2/MINIAODSIM
-ST_tW_antitop_4Q:
+TbarWplusto4Q:
   sampleType: ST
-  crossSection: ST_tW_antitop_4Q
+  crossSection: TbarWplusto4Q
   generator: powheg
   miniAOD: /TbarWplusto4Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-ST_tW_antitop_4Q_ext1:
+TbarWplusto4Q_ext1:
   sampleType: ST
-  crossSection: ST_tW_antitop_4Q
+  crossSection: TbarWplusto4Q
   generator: powheg
   miniAOD: /TbarWplusto4Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6_ext1-v2/MINIAODSIM
-ST_tW_antitop_LNu2Q:
+TbarWplustoLNu2Q:
   sampleType: ST
-  crossSection: ST_tW_antitop_LNu2Q
+  crossSection: TbarWplustoLNu2Q
   generator: powheg
   miniAOD: /TbarWplustoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-ST_tW_antitop_LNu2Q_ext1:
+TbarWplustoLNu2Q_ext1:
   sampleType: ST
-  crossSection: ST_tW_antitop_LNu2Q
+  crossSection: TbarWplustoLNu2Q
   generator: powheg
   miniAOD: /TbarWplustoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6_ext1-v2/MINIAODSIM
-ST_tW_top_2L2Nu:
+TWminusto2L2Nu:
   sampleType: ST
-  crossSection: ST_tW_top_2L2Nu
+  crossSection: TWminusto2L2Nu
   generator: powheg
   miniAOD: /TWminusto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-ST_tW_top_2L2Nu_ext1:
+TWminusto2L2Nu_ext1:
   sampleType: ST
-  crossSection: ST_tW_top_2L2Nu
+  crossSection: TWminusto2L2Nu
   generator: powheg
   miniAOD: /TWminusto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6_ext1-v2/MINIAODSIM
-ST_tW_top_4Q:
+TWminusto4Q:
   sampleType: ST
-  crossSection: ST_tW_top_4Q
+  crossSection: TWminusto4Q
   generator: powheg
   miniAOD: /TWminusto4Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-ST_tW_top_4Q_ext1:
+TWminusto4Q_ext1:
   sampleType: ST
-  crossSection: ST_tW_top_4Q
+  crossSection: TWminusto4Q
   generator: powheg
   miniAOD: /TWminusto4Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6_ext1-v2/MINIAODSIM
-ST_tW_top_LNu2Q:
+TWminustoLNu2Q:
   sampleType: ST
-  crossSection: ST_tW_top_LNu2Q
+  crossSection: TWminustoLNu2Q
   generator: powheg
   miniAOD: /TWminustoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
-ST_tW_top_LNu2Q_ext1:
+TWminustoLNu2Q_ext1:
   sampleType: ST
-  crossSection: ST_tW_top_LNu2Q
+  crossSection: TWminustoLNu2Q
   generator: powheg
   miniAOD: /TWminustoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6_ext1-v2/MINIAODSIM
 
 ############## ttH ##############
-ttHTobb_M125:
+TTHto2B_M125:
   sampleType: ttH
-  crossSection: ttHTobb_M125
+  crossSection: TTHto2B_M125
   generator: powheg
   miniAOD: /TTHto2B_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v3/MINIAODSIM
-ttHToNonbb_M125:
+TTHtoNon2B_M125:
   sampleType: ttH
-  crossSection: ttHToNonbb_M125
+  crossSection: TTHtoNon2B_M125
   generator: powheg
   miniAOD: /TTHtoNon2B_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer22EEMiniAODv4-130X_mcRun3_2022_realistic_postEE_v6-v2/MINIAODSIM
 

--- a/config/Run3_2023/samples.yaml
+++ b/config/Run3_2023/samples.yaml
@@ -663,52 +663,52 @@ QCD_PT_3200:
 ############## ST ##############
 ST_s_channel_antitop_4f_leptonDecays:
   sampleType: ST
-  crossSection: ST_s_channel_antitop_LNu
+  crossSection: TbarBtoLminusNuB_s_channel_4FS
   generator: amcatnlo
   miniAOD: /TbarBtoLminusNuB-s-channel-4FS_TuneCP5_13p6TeV_amcatnlo-pythia8/Run3Summer23MiniAODv4-130X_mcRun3_2023_realistic_v15-v2/MINIAODSIM
 ST_s_channel_top_4f_leptonDecays:
   sampleType: ST
-  crossSection: ST_s_channel_top_LNu
+  crossSection: TBbartoLplusNuBbar_s_channel_4FS
   generator: amcatnlo
   miniAOD: /TBbartoLplusNuBbar-s-channel-4FS_TuneCP5_13p6TeV_amcatnlo-pythia8/Run3Summer23MiniAODv4-130X_mcRun3_2023_realistic_v15-v2/MINIAODSIM
 ST_t_channel_antitop_4f_InclusiveDecays:
   sampleType: ST
-  crossSection: ST_t_channel_antitop
+  crossSection: TbarBQ_t_channel_4FS
   generator: powheg
   miniAOD: /TbarBQ_t-channel_4FS_TuneCP5_13p6TeV_powheg-madspin-pythia8/Run3Summer23MiniAODv4-130X_mcRun3_2023_realistic_v15-v2/MINIAODSIM
 ST_t_channel_top_4f_InclusiveDecays:
   sampleType: ST
-  crossSection: ST_t_channel_top
+  crossSection: TBbarQ_t_channel_4FS
   generator: powheg
   miniAOD: /TBbarQ_t-channel_4FS_TuneCP5_13p6TeV_powheg-madspin-pythia8/Run3Summer23MiniAODv4-130X_mcRun3_2023_realistic_v15-v2/MINIAODSIM
 ST_tW_antitop_2L2Nu:
   sampleType: ST
-  crossSection: ST_tW_antitop_2L2Nu
+  crossSection: TbarWplusto2L2Nu
   generator: powheg
   miniAOD: /TbarWplusto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23MiniAODv4-130X_mcRun3_2023_realistic_v15-v4/MINIAODSIM
 ST_tW_antitop_4Q:
   sampleType: ST
-  crossSection: ST_tW_antitop_4Q
+  crossSection: TbarWplusto4Q
   generator: powheg
   miniAOD: /TbarWplusto4Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23MiniAODv4-130X_mcRun3_2023_realistic_v15-v4/MINIAODSIM
 ST_tW_antitop_LNu2Q:
   sampleType: ST
-  crossSection: ST_tW_antitop_LNu2Q
+  crossSection: TbarWplustoLNu2Q
   generator: powheg
   miniAOD: /TbarWplustoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23MiniAODv4-130X_mcRun3_2023_realistic_v15-v6/MINIAODSIM
 ST_tW_top_2L2Nu:
   sampleType: ST
-  crossSection: ST_tW_top_2L2Nu
+  crossSection: TWminusto2L2Nu
   generator: powheg
   miniAOD: /TWminusto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23MiniAODv4-130X_mcRun3_2023_realistic_v14-v2/MINIAODSIM
 ST_tW_top_4Q:
   sampleType: ST
-  crossSection: ST_tW_top_4Q
+  crossSection: TWminusto4Q
   generator: powheg
   miniAOD: /TWminusto4Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23MiniAODv4-130X_mcRun3_2023_realistic_v14-v2/MINIAODSIM
 ST_tW_top_LNu2Q:
   sampleType: ST
-  crossSection: ST_tW_top_LNu2Q
+  crossSection: TWminustoLNu2Q
   generator: powheg
   miniAOD: /TWminustoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23MiniAODv4-130X_mcRun3_2023_realistic_v14-v2/MINIAODSIM
 ############## TT ##############
@@ -720,12 +720,12 @@ TTH_Hto2Mu:
 
 ttHTobb_M125:
   sampleType: ttH
-  crossSection: ttHTobb_M125
+  crossSection: TTHto2B_M125
   generator: powheg
   miniAOD: /TTHto2B_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23MiniAODv4-130X_mcRun3_2023_realistic_v14-v3/MINIAODSIM
 ttHToNonbb_M125:
   sampleType: ttH
-  crossSection: ttHToNonbb_M125
+  crossSection: TTHtoNon2B_M125
   generator: powheg
   miniAOD: /TTHtoNon2B_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23MiniAODv4-130X_mcRun3_2023_realistic_v14-v2/MINIAODSIM
 TTto2L2Nu:

--- a/config/Run3_2023BPix/samples.yaml
+++ b/config/Run3_2023BPix/samples.yaml
@@ -641,52 +641,52 @@ QCD_PT_3200:
 ############## ST ##############
 ST_s_channel_antitop_4f_leptonDecays:
   sampleType: ST
-  crossSection: ST_s_channel_antitop_LNu
+  crossSection: TbarBtoLminusNuB_s_channel_4FS
   generator: amcatnlo
   miniAOD: /TbarBtoLminusNuB-s-channel-4FS_TuneCP5_13p6TeV_amcatnlo-pythia8/Run3Summer23BPixMiniAODv4-130X_mcRun3_2023_realistic_postBPix_v6-v2/MINIAODSIM
 ST_s_channel_top_4f_leptonDecays:
   sampleType: ST
-  crossSection: ST_s_channel_top_LNu
+  crossSection: TBbartoLplusNuBbar_s_channel_4FS
   generator: amcatnlo
   miniAOD: /TBbartoLplusNuBbar-s-channel-4FS_TuneCP5_13p6TeV_amcatnlo-pythia8/Run3Summer23BPixMiniAODv4-130X_mcRun3_2023_realistic_postBPix_v6-v2/MINIAODSIM
 ST_t_channel_antitop_4f_InclusiveDecays:
   sampleType: ST
-  crossSection: ST_t_channel_antitop
+  crossSection: TbarBQ_t_channel_4FS
   generator: powheg
   miniAOD: /TbarBQ_t-channel_4FS_TuneCP5_13p6TeV_powheg-madspin-pythia8/Run3Summer23BPixMiniAODv4-130X_mcRun3_2023_realistic_postBPix_v6-v2/MINIAODSIM
 ST_t_channel_top_4f_InclusiveDecays:
   sampleType: ST
-  crossSection: ST_t_channel_top
+  crossSection: TBbarQ_t_channel_4FS
   generator: powheg
   miniAOD: /TBbarQ_t-channel_4FS_TuneCP5_13p6TeV_powheg-madspin-pythia8/Run3Summer23BPixMiniAODv4-130X_mcRun3_2023_realistic_postBPix_v6-v2/MINIAODSIM
 ST_tW_antitop_2L2Nu:
   sampleType: ST
-  crossSection: ST_tW_antitop_2L2Nu
+  crossSection: TbarWplusto2L2Nu
   generator: powheg
   miniAOD: /TbarWplusto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23BPixMiniAODv4-130X_mcRun3_2023_realistic_postBPix_v6-v2/MINIAODSIM
 ST_tW_antitop_4Q:
   sampleType: ST
-  crossSection: ST_tW_antitop_4Q
+  crossSection: TbarWplusto4Q
   generator: powheg
   miniAOD: /TbarWplusto4Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23BPixMiniAODv4-130X_mcRun3_2023_realistic_postBPix_v6-v2/MINIAODSIM
 ST_tW_antitop_LNu2Q:
   sampleType: ST
-  crossSection: ST_tW_antitop_LNu2Q
+  crossSection: TbarWplustoLNu2Q
   generator: powheg
   miniAOD: /TbarWplustoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23BPixMiniAODv4-130X_mcRun3_2023_realistic_postBPix_v6-v2/MINIAODSIM
 ST_tW_top_2L2Nu:
   sampleType: ST
-  crossSection: ST_tW_top_2L2Nu
+  crossSection: TWminusto2L2Nu
   generator: powheg
   miniAOD: /TWminusto2L2Nu_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23BPixMiniAODv4-130X_mcRun3_2023_realistic_postBPix_v2-v3/MINIAODSIM
 ST_tW_top_4Q:
   sampleType: ST
-  crossSection: ST_tW_top_4Q
+  crossSection: TWminusto4Q
   generator: powheg
   miniAOD: /TWminusto4Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23BPixMiniAODv4-130X_mcRun3_2023_realistic_postBPix_v2-v3/MINIAODSIM
 ST_tW_top_LNu2Q:
   sampleType: ST
-  crossSection: ST_tW_top_LNu2Q
+  crossSection: TWminustoLNu2Q
   generator: powheg
   miniAOD: /TWminustoLNu2Q_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23BPixMiniAODv4-130X_mcRun3_2023_realistic_postBPix_v2-v3/MINIAODSIM
 ############## TT ##############
@@ -702,12 +702,12 @@ TTH_Hto2Mu:
   miniAOD: /TTH_Hto2Mu_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23BPixMiniAODv4-130X_mcRun3_2023_realistic_postBPix_v6-v2/MINIAODSIM
 ttHTobb_M125:
   sampleType: ttH
-  crossSection: ttHTobb_M125
+  crossSection: TTHto2B_M125
   generator: powheg
   miniAOD: /TTHto2B_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23BPixMiniAODv4-130X_mcRun3_2023_realistic_postBPix_v2-v3/MINIAODSIM
 ttHToNonbb_M125:
   sampleType: ttH
-  crossSection: ttHToNonbb_M125
+  crossSection: TTHtoNon2B_M125
   generator: powheg
   miniAOD: /TTHtoNon2B_M-125_TuneCP5_13p6TeV_powheg-pythia8/Run3Summer23BPixMiniAODv4-130X_mcRun3_2023_realistic_postBPix_v2-v2/MINIAODSIM
 TTto2L2Nu:

--- a/config/crossSections13p6TeV.yaml
+++ b/config/crossSections13p6TeV.yaml
@@ -541,11 +541,11 @@ TTZZ:
   reference: XSDB TTZZ_TuneCP5_13p6TeV_madgraph-madspin-pythia8 modifiedOn 2023-05-26 21:19:17
   unc: 3.248e-06
 
-ttHTobb_M125:
+TTHto2B_M125:
   crossSec: 0.57 * (0.5824)
   reference: https://twiki.cern.ch/twiki/bin/view/LHCPhysics/LHCHWG136TeVxsec_extrap
   unc: +6% -9.3% (QCD Scale) +-3.5% (PDF alpha s) +-3% (PDF) +-2 (alpha s)
-ttHToNonbb_M125:
+TTHtoNon2B_M125:
   crossSec: 0.57 * (1 - 0.5824)
   reference: https://twiki.cern.ch/twiki/bin/view/LHCPhysics/LHCHWG136TeVxsec_extrap
   unc: +6% -9.3% (QCD Scale) +-3.5% (PDF alpha s) +-3% (PDF) +-2 (alpha s)

--- a/config/crossSections13p6TeV.yaml
+++ b/config/crossSections13p6TeV.yaml
@@ -457,43 +457,43 @@ QCD_PT_3200:
   reference: XSDB QCD_PT-3200_TuneCP5_13p6TeV_pythia8 modifiedOn 2023-03-26 13:58:43
   unc: 1.208e-06
 
-ST_s_channel_antitop_LNu:
+TbarBtoLminusNuB_s_channel_4FS:
   crossSec: 4.534 * (1-0.6741)
   reference: https://twiki.cern.ch/twiki/bin/view/LHCPhysics/SingleTopNNLORef#Single_top_quark_t_channel_cross top ratio taken from XSDB, BR taken from W->LNu pdg (t->Wb 100%)
   unc: +0.059 -0.043 (scale) # These are the combined values, as of 9May2025 they are still not available
-ST_s_channel_top_LNu:
+TBbartoLplusNuBbar_s_channel_4FS:
   crossSec: 7.244 * (1-0.6741)
   reference: https://twiki.cern.ch/twiki/bin/view/LHCPhysics/SingleTopNNLORef#Single_top_quark_t_channel_cross top ratio taken from XSDB, BR taken from W->LNu pdg (t->Wb 100%)
   unc: +0.059 - 0.043 (scale) # These are the combined values, as of 9May2025 they are still not available
-ST_t_channel_antitop:
+TbarBQ_t_channel_4FS:
   crossSec: '87.2'
   reference: https://twiki.cern.ch/twiki/bin/view/LHCPhysics/SingleTopNNLORef
   unc: +0.9 -0.8 (scale) +1.5 -1.3(PDF+alphaS) +1.8 -1.5(Total) +0.6 -0.7(mass) +0.2 -0.2 (Ebeam) +/-0.1 (Integration)
-ST_t_channel_top:
+TBbarQ_t_channel_4FS:
   crossSec: '145.0'
   reference: https://twiki.cern.ch/twiki/bin/view/LHCPhysics/SingleTopNNLORef
   unc: +1.7 -1.1 (scale) +2.3 -1.5(PDF+alphaS) +2.8 -1.9(Total) +1.3 -0.9(mass) +0.4 -0.3 (Ebeam) +/-0.1 (Integration)
-ST_tW_antitop_2L2Nu:
+TbarWplusto2L2Nu:
   crossSec: 87.9 * (0.5005) * (1-0.6741) * (1-0.6741)
   reference: Value taken from https://twiki.cern.ch/twiki/bin/view/LHCPhysics/SingleTopNNLORef, top/antitop % taken from XSDB, BRs taken from pdg, assume t->Wb 100%
   unc: +2.0 -1.9 (scale) +-2.4 (PDF AlphaS) +3.1 -3.1 (Total) +1.3 -1.3 (mass) +0.2 -0.2 (Ebeam)
-ST_tW_antitop_4Q:
+TbarWplusto4Q:
   crossSec: 87.9 * (0.5005) * (0.6741) * (0.6741)
   reference: Value taken from https://twiki.cern.ch/twiki/bin/view/LHCPhysics/SingleTopNNLORef, top/antitop % taken from XSDB, BRs taken from pdg, assume t->Wb 100%
   unc: +2.0 -1.9 (scale) +-2.4 (PDF AlphaS) +3.1 -3.1 (Total) +1.3 -1.3 (mass) +0.2 -0.2 (Ebeam)
-ST_tW_antitop_LNu2Q:
+TbarWplustoLNu2Q:
   crossSec: 87.9 * (0.5005) * ( ((1-0.6741) * (0.6741)) + ((0.6741) * (1-0.6741)) )
   reference: Value taken from https://twiki.cern.ch/twiki/bin/view/LHCPhysics/SingleTopNNLORef, top/antitop % taken from XSDB, BRs taken from pdg, assume t->Wb 100%
   unc: +2.0 -1.9 (scale) +-2.4 (PDF AlphaS) +3.1 -3.1 (Total) +1.3 -1.3 (mass) +0.2 -0.2 (Ebeam)
-ST_tW_top_2L2Nu:
+TWminusto2L2Nu:
   crossSec: 87.9 * (0.4995) * (1-0.6741) * (1-0.6741)
   reference: Value taken from https://twiki.cern.ch/twiki/bin/view/LHCPhysics/SingleTopNNLORef, top/antitop % taken from XSDB, BRs taken from pdg, assume t->Wb 100%
   unc: +2.0 -1.9 (scale) +-2.4 (PDF AlphaS) +3.1 -3.1 (Total) +1.3 -1.3 (mass) +0.2 -0.2 (Ebeam)
-ST_tW_top_4Q:
+TWminusto4Q:
   crossSec: 87.9 * (0.4995) * (0.6741) * (0.6741)
   reference: Value taken from https://twiki.cern.ch/twiki/bin/view/LHCPhysics/SingleTopNNLORef, top/antitop % taken from XSDB, BRs taken from pdg, assume t->Wb 100%
   unc: +2.0 -1.9 (scale) +-2.4 (PDF AlphaS) +3.1 -3.1 (Total) +1.3 -1.3 (mass) +0.2 -0.2 (Ebeam)
-ST_tW_top_LNu2Q:
+TWminustoLNu2Q:
   crossSec: 87.9 * (0.4995) * ( ((1-0.6741) * (0.6741)) + ((0.6741) * (1-0.6741)) )
   reference: Value taken from https://twiki.cern.ch/twiki/bin/view/LHCPhysics/SingleTopNNLORef, top/antitop % taken from XSDB, BRs taken from pdg, assume t->Wb 100%
   unc: +2.0 -1.9 (scale) +-2.4 (PDF AlphaS) +3.1 -3.1 (Total) +1.3 -1.3 (mass) +0.2 -0.2 (Ebeam)


### PR DESCRIPTION
The path to the HLep Skim file has been changed for 2022pre/postEE and 2023pre/postBPix.

- ST samples are now saved in a folder with the same string as the dataset (the local sample name no longer includes 'ST').
- The ttH samples have been changed to tt->TT and bb->2b.
- The cross section naming has been changed to be compatible with the sample names.