### PR TITLE
Fixed formatting

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -5,7 +5,7 @@ rules:
   line-length: disable
   indentation:
     spaces: 2
-    indent-sequences: consistent
+    indent-sequences: true
   float-values:
     require-numeral-before-decimal: false
   octal-values: enable
@@ -24,3 +24,7 @@ rules:
   truthy:
     allowed-values: [ 'true', 'false', 'True', 'False' ]
     check-keys: false
+  comments:
+    require-starting-space: true
+    ignore-shebangs: true
+    min-spaces-from-content: 1

--- a/bbtt-linux.yaml
+++ b/bbtt-linux.yaml
@@ -330,4 +330,3 @@ dependencies:
   - zstandard=0.18.0=py38h0a891b7_0
   - zstd=1.5.2=h8a70e8d_2
 prefix: /eos/home-k/kandroso/conda/envs/bbtt
-

--- a/config/Run2_2016/samples.yaml
+++ b/config/Run2_2016/samples.yaml
@@ -1,10 +1,10 @@
 GLOBAL:
-  era: 'Run2_2016' # https://twiki.cern.ch/twiki/bin/view/CMS/PdmVDatasetsUL2016
-  luminosity : 16800 # pb^-1 2016 postVFP
+  era: 'Run2_2016'  # https://twiki.cern.ch/twiki/bin/view/CMS/PdmVDatasetsUL2016
+  luminosity: 16800  # pb^-1 2016 postVFP
   fs_nanoAOD:
-  - 'T2_CH_CERN:/store/group/phys_higgs/HLepRare/HTT_skim_v1/Run2_2016'
+    - 'T2_CH_CERN:/store/group/phys_higgs/HLepRare/HTT_skim_v1/Run2_2016'
   nano_version: v12
-  MET_flags: # https://twiki.cern.ch/twiki/bin/viewauth/CMS/MissingETOptionalFiltersRun2#2016_data_and_MC_UL
+  MET_flags:  # https://twiki.cern.ch/twiki/bin/viewauth/CMS/MissingETOptionalFiltersRun2#2016_data_and_MC_UL
     - Flag_goodVertices
     - Flag_globalSuperTightHalo2016Filter
     - Flag_HBHENoiseFilter
@@ -13,11 +13,11 @@ GLOBAL:
     - Flag_BadPFMuonFilter
     - Flag_BadPFMuonDzFilter
     - Flag_eeBadScFilter
-    #- Flag_hfNoisyHitsFilter
-    #- Flag_BadChargedCandidateFilter
+    # - Flag_hfNoisyHitsFilter
+    # - Flag_BadChargedCandidateFilter
   met_type: MET
   triggerFile: config/Run2_2016/triggers.yaml
-  crossSectionsFile : config/crossSections13TeV.yaml
+  crossSectionsFile: config/crossSections13TeV.yaml
   # from https://twiki.cern.ch/twiki/bin/viewauth/CMS/DCUserPage
   # useful link: https://twiki.cern.ch/twiki/bin/view/CMS/DCUserPage2016Analysis
   lumiFile: /afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/Legacy_2016/Cert_271036-284044_13TeV_Legacy2016_Collisions16_JSON.txt
@@ -56,7 +56,6 @@ GLOBAL:
     - drop ^W2JetsToLNu-amcatnloFXFX$
 
 
-
 ############## Data ##############
 SingleElectron_Run2016F:
   sampleType: data
@@ -88,7 +87,6 @@ MET_Run2016G:
   sampleType: data
 MET_Run2016H:
   sampleType: data
-
 
 
 ############## Signals ##############
@@ -545,151 +543,151 @@ VBFToRadionToHHTo2B2Tau_M-3000:
 VBFToBulkGravitonToHHTo2B2Tau_M-250:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 250
+  mass: 250
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-260:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 260
+  mass: 260
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-270:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 270
+  mass: 270
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-280:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 280
+  mass: 280
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-300:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 300
+  mass: 300
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-320:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 320
+  mass: 320
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-350:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 350
+  mass: 350
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-400:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 400
+  mass: 400
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-450:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 450
+  mass: 450
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-500:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 500
+  mass: 500
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-550:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 550
+  mass: 550
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-600:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 600
+  mass: 600
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-650:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 650
+  mass: 650
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-700:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 700
+  mass: 700
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-750:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 750
+  mass: 750
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-800:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 800
+  mass: 800
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-850:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 850
+  mass: 850
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-900:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 900
+  mass: 900
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-1000:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 1000
+  mass: 1000
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-1250:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 1250
+  mass: 1250
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-1500:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 1500
+  mass: 1500
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-1750:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 1750
+  mass: 1750
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-2000:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 2000
+  mass: 2000
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-2500:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 2500
+  mass: 2500
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-3000:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 3000
+  mass: 3000
   spin: 2
   crossSection: 1pb
 
@@ -767,7 +765,6 @@ WJetsToLNu_HT-800To1200:
   crossSectionStitch: WJetsToLNu_HT-800To1200_LO
 
 
-
 WJetsToLNu-amcatnloFXFX:
   sampleType: W
   generator: amcatnlo
@@ -781,7 +778,7 @@ W0JetsToLNu-amcatnloFXFX:
 W1JetsToLNu-amcatnloFXFX:
   sampleType: W
   generator: amcatnlo
-  crossSectionStitch:  W1JetsToLNu_NLO
+  crossSectionStitch: W1JetsToLNu_NLO
 W2JetsToLNu-amcatnloFXFX:
   sampleType: W
   generator: amcatnlo
@@ -919,7 +916,7 @@ ZHToTauTau_M125:
   sampleType: VH
   generator: powheg
   crossSection: ZHToTauTau
-  ext: ['ZHToTauTau_M125_ext1']
+  ext: [ 'ZHToTauTau_M125_ext1' ]
 ZHToTauTau_M125_ext1:
   sampleType: VH
   generator: powheg
@@ -944,7 +941,7 @@ HZJ_HToWW_M125:
   sampleType: VH
   generator: powheg
   crossSection: HZJ_HToWW
-  ext: ['HZJ_HToWW_M125_ext1']
+  ext: [ 'HZJ_HToWW_M125_ext1' ]
 HZJ_HToWW_M125_ext1:
   sampleType: VH
   generator: powheg
@@ -953,7 +950,7 @@ GluGluZH_HToWW_ZTo2L_M125:
   sampleType: VH
   generator: powheg
   crossSection: GluGluZH_HToWW_ZTo2L
-  ext: ['GluGluZH_HToWW_ZTo2L_M125_ext1']
+  ext: [ 'GluGluZH_HToWW_ZTo2L_M125_ext1' ]
 GluGluZH_HToWW_ZTo2L_M125_ext1:
   sampleType: VH
   generator: powheg
@@ -1029,7 +1026,7 @@ WWW_4F:
   sampleType: VVV
   generator: amcatnlo
   crossSection: WWW_4F
-  ext: ['WWW_4F_ext1']
+  ext: [ 'WWW_4F_ext1' ]
 WWW_4F_ext1:
   sampleType: VVV
   generator: amcatnlo
@@ -1038,7 +1035,7 @@ WWZ_4F:
   sampleType: VVV
   generator: amcatnlo
   crossSection: WWZ_4F
-  ext: ['WWZ_4F_ext1']
+  ext: [ 'WWZ_4F_ext1' ]
 WWZ_4F_ext1:
   sampleType: VVV
   generator: amcatnlo
@@ -1047,7 +1044,7 @@ WZZ:
   sampleType: VVV
   generator: amcatnlo
   crossSection: WZZ
-  ext: ['WZZ_ext1']
+  ext: [ 'WZZ_ext1' ]
 WZZ_ext1:
   sampleType: VVV
   generator: amcatnlo
@@ -1056,7 +1053,7 @@ ZZZ:
   sampleType: VVV
   generator: amcatnlo
   crossSection: ZZZ
-  ext: ['ZZZ_ext1']
+  ext: [ 'ZZZ_ext1' ]
 ZZZ_ext1:
   sampleType: VVV
   generator: amcatnlo
@@ -1127,7 +1124,7 @@ TTGJets:
   sampleType: TTX
   generator: amcatnlo
   crossSection: TTGJets
-  ext: ['TTGJets_ext1']
+  ext: [ 'TTGJets_ext1' ]
 TTGJets_ext1:
   sampleType: TTX
   generator: amcatnlo
@@ -1203,7 +1200,7 @@ TTZHTo4b:
   sampleType: TTX
   generator: madgraph
   crossSection: TTZHTo4b
-  ext: ['TTZHTo4b_ext1']
+  ext: [ 'TTZHTo4b_ext1' ]
 TTZHTo4b_ext1:
   sampleType: TTX
   generator: madgraph
@@ -1217,7 +1214,7 @@ TTZZTo4b:
   sampleType: TTX
   generator: madgraph
   crossSection: TTZZTo4b
-  ext: ['TTZZTo4b_ext1']
+  ext: [ 'TTZZTo4b_ext1' ]
 TTZZTo4b_ext1:
   sampleType: TTX
   generator: madgraph
@@ -1547,7 +1544,6 @@ DYJetsToTauTauToMuTauh-madgraphMLM_ext2:
   sampleType: DY
   generator: madgraph
   crossSection: DY_muTau_LO
-
 
 
 DYJetsToLL_M-100to200-amcatnloFXFX:

--- a/config/Run2_2016/triggers.yaml
+++ b/config/Run2_2016/triggers.yaml
@@ -1,4 +1,4 @@
-#https://twiki.cern.ch/twiki/bin/view/CMS/PdmVDataReprocessingUL2016#Run2016F_part2
+# https://twiki.cern.ch/twiki/bin/view/CMS/PdmVDataReprocessingUL2016#Run2016F_part2
 # extra bits of associated information: 0 => HLT_AK8PFJetX_SoftDropMass40_PFAK8ParticleNetTauTau0p30, 1 => hltAK8SinglePFJets230SoftDropMass40PNetTauTauTag0p03 for BoostedTau;
 # 0 => CaloIdL_TrackIdL_IsoVL, 1 => 1e (WPTight), 2 => 1e (WPLoose), 3 => OverlapFilter PFTau, 4 => 2e, 5 => 1e-1mu, 6 => 1e-1tau, 7 => 3e, 8 => 2e-1mu, 9 => 1e-2mu, 10 => 1e (32_L1DoubleEG_AND_L1SingleEGOr), 11 => 1e (CaloIdVT_GsfTrkIdT), 12 => 1e (PFJet), 13 => 1e (Photon175_OR_Photon200) for Electron;
 # 0 => , 1 => hltAK8SingleCaloJet200, 2 => , 3 => hltAK8SinglePFJets230SoftDropMass40BTagParticleNetBB0p35 OR hltAK8SinglePFJets250SoftDropMass40BTagParticleNetBB0p35 OR hltAK8SinglePFJets275SoftDropMass40BTagParticleNetBB0p35, 4 => hltAK8DoublePFJetSDModMass30, 5 => hltAK8DoublePFJetSDModMass50 for FatJet;
@@ -28,20 +28,20 @@ ditau:
     - ref_leg: 0
 
 singleTau:
-    channels:
-      - tauTau
-      - muTau
-      - eTau
-    path:
-      - HLT_VLooseIsoPFTau120_Trk50_eta2p1
-      - HLT_VLooseIsoPFTau140_Trk50_eta2p1
-    legs:
-      - offline_obj:
-          type: Tau
-          cut: v_ops::pt(Tau_p4) > 130 && abs(v_ops::eta(Tau_p4)) < 2.1 # for next prod
-        online_obj:
-          cut: TrigObj_id == 15 && (TrigObj_filterBits&4)!=0
-        doMatching: True
+  channels:
+    - tauTau
+    - muTau
+    - eTau
+  path:
+    - HLT_VLooseIsoPFTau120_Trk50_eta2p1
+    - HLT_VLooseIsoPFTau140_Trk50_eta2p1
+  legs:
+    - offline_obj:
+        type: Tau
+        cut: v_ops::pt(Tau_p4) > 130 && abs(v_ops::eta(Tau_p4)) < 2.1  # for next prod
+      online_obj:
+        cut: TrigObj_id == 15 && (TrigObj_filterBits&4)!=0
+      doMatching: True
 
 singleMu:
   channels:
@@ -50,13 +50,13 @@ singleMu:
     - eMu
   path:
     - HLT_IsoMu24
-    #- HLT_IsoMu24_eta2p1
+    # - HLT_IsoMu24_eta2p1
     - HLT_IsoTkMu24
-    #- HLT_IsoTkMu24_eta2p1
+    # - HLT_IsoTkMu24_eta2p1
   legs:
     - offline_obj:
         type: Muon
-        cut:  v_ops::pt(Muon_p4) > 26 #&& abs(v_ops::eta(Muon_p4)) < 2.1
+        cut: v_ops::pt(Muon_p4) > 26  # && abs(v_ops::eta(Muon_p4)) < 2.1
       online_obj:
         cut: TrigObj_id == 13 && ((TrigObj_filterBits&2) != 0 || (TrigObj_filterBits&8) != 0 )
       doMatching: True
@@ -82,19 +82,17 @@ mutau:
       doMatching: True
 
 MET:
-    channels:
-      - tauTau
-      - muTau
-      - eTau
-    path:
-      - HLT_PFMETNoMu120_PFMHTNoMu120_IDTight
-    legs:
-      - offline_obj:
-          type: MET
-          cut: metnomu_pt > 130
-        doMatching: False
-
-
+  channels:
+    - tauTau
+    - muTau
+    - eTau
+  path:
+    - HLT_PFMETNoMu120_PFMHTNoMu120_IDTight
+  legs:
+    - offline_obj:
+        type: MET
+        cut: metnomu_pt > 130
+      doMatching: False
 
 singleEle:
   channels:
@@ -103,7 +101,7 @@ singleEle:
     - eMu
   path:
     - HLT_Ele25_eta2p1_WPTight_Gsf
-    #- HLT_Ele35_WPTight_Gsf ? understand
+    # - HLT_Ele35_WPTight_Gsf ? understand
   legs:
     - offline_obj:
         type: Electron
@@ -132,5 +130,5 @@ etau:
         type: Tau
         cut: v_ops::pt(Tau_p4) > 25 && abs(v_ops::eta(Tau_p4)) < 2.1
       online_obj:
-        cut:  TrigObj_id==15 && (TrigObj_filterBits&64)!=0 && (TrigObj_filterBits&1)!=0
+        cut: TrigObj_id==15 && (TrigObj_filterBits&64)!=0 && (TrigObj_filterBits&1)!=0
       doMatching: True

--- a/config/Run2_2016_HIPM/samples.yaml
+++ b/config/Run2_2016_HIPM/samples.yaml
@@ -1,10 +1,10 @@
-GLOBAL: # preVFP == APV == HIPM
-  era: 'Run2_2016_HIPM' # https://twiki.cern.ch/twiki/bin/view/CMS/PdmVDatasetsUL2016
-  luminosity: 19500 #36310.
+GLOBAL:  # preVFP == APV == HIPM
+  era: 'Run2_2016_HIPM'  # https://twiki.cern.ch/twiki/bin/view/CMS/PdmVDatasetsUL2016
+  luminosity: 19500  # 36310.
   fs_nanoAOD:
-  - 'T2_CH_CERN:/store/group/phys_higgs/HLepRare/HTT_skim_v1/Run2_2016_HIPM'
+    - 'T2_CH_CERN:/store/group/phys_higgs/HLepRare/HTT_skim_v1/Run2_2016_HIPM'
   nano_version: v12
-  MET_flags: # https://twiki.cern.ch/twiki/bin/viewauth/CMS/MissingETOptionalFiltersRun2#2016_data_and_MC_UL
+  MET_flags:  # https://twiki.cern.ch/twiki/bin/viewauth/CMS/MissingETOptionalFiltersRun2#2016_data_and_MC_UL
     - Flag_goodVertices
     - Flag_globalSuperTightHalo2016Filter
     - Flag_HBHENoiseFilter
@@ -13,14 +13,14 @@ GLOBAL: # preVFP == APV == HIPM
     - Flag_BadPFMuonFilter
     - Flag_BadPFMuonDzFilter
     - Flag_eeBadScFilter
-    #- Flag_hfNoisyHitsFilter
-    #- Flag_BadChargedCandidateFilter
+    # - Flag_hfNoisyHitsFilter
+    # - Flag_BadChargedCandidateFilter
   met_type: MET
   triggerFile: config/Run2_2016_HIPM/triggers.yaml
-  crossSectionsFile : config/crossSections13TeV.yaml
+  crossSectionsFile: config/crossSections13TeV.yaml
   # from https://twiki.cern.ch/twiki/bin/viewauth/CMS/DCUserPage
   # useful link: https://twiki.cern.ch/twiki/bin/view/CMS/DCUserPage2016Analysis
-  #lumiFile: /afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/Final/Cert_271036-284044_13TeV_PromptReco_Collisions16_JSON.txt
+  # lumiFile: /afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/Final/Cert_271036-284044_13TeV_PromptReco_Collisions16_JSON.txt
   lumiFile: /afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions16/13TeV/Legacy_2016/Cert_271036-284044_13TeV_Legacy2016_Collisions16_JSON.txt
   sampleSelection:
     - drop ^VBFToRadion*
@@ -55,7 +55,7 @@ GLOBAL: # preVFP == APV == HIPM
     - drop ^W0JetsToLNu-amcatnloFXFX$
     - drop ^W1JetsToLNu-amcatnloFXFX$
     - drop ^W2JetsToLNu-amcatnloFXFX$
-    #- drop ^W[0-2]Jets*amcatnlo*
+    # - drop ^W[0-2]Jets*amcatnlo*
 
 
 ############## Data ##############
@@ -570,151 +570,151 @@ VBFToRadionToHHTo2B2Tau_M-3000:
 VBFToBulkGravitonToHHTo2B2Tau_M-250:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 250
+  mass: 250
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-260:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 260
+  mass: 260
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-270:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 270
+  mass: 270
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-280:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 280
+  mass: 280
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-300:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 300
+  mass: 300
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-320:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 320
+  mass: 320
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-350:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 350
+  mass: 350
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-400:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 400
+  mass: 400
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-450:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 450
+  mass: 450
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-500:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 500
+  mass: 500
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-550:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 550
+  mass: 550
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-600:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 600
+  mass: 600
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-650:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 650
+  mass: 650
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-700:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 700
+  mass: 700
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-750:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 750
+  mass: 750
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-800:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 800
+  mass: 800
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-850:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 850
+  mass: 850
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-900:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 900
+  mass: 900
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-1000:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 1000
+  mass: 1000
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-1250:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 1250
+  mass: 1250
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-1500:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 1500
+  mass: 1500
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-1750:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 1750
+  mass: 1750
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-2000:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 2000
+  mass: 2000
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-2500:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 2500
+  mass: 2500
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-3000:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 3000
+  mass: 3000
   spin: 2
   crossSection: 1pb
 
@@ -792,7 +792,6 @@ WJetsToLNu_HT-800To1200:
   crossSectionStitch: WJetsToLNu_HT-800To1200_LO
 
 
-
 WJetsToLNu-amcatnloFXFX:
   sampleType: W
   generator: amcatnlo
@@ -806,7 +805,7 @@ W0JetsToLNu-amcatnloFXFX:
 W1JetsToLNu-amcatnloFXFX:
   sampleType: W
   generator: amcatnlo
-  crossSectionStitch:  W1JetsToLNu_NLO
+  crossSectionStitch: W1JetsToLNu_NLO
 W2JetsToLNu-amcatnloFXFX:
   sampleType: W
   generator: amcatnlo
@@ -944,7 +943,7 @@ ZHToTauTau_M125:
   sampleType: VH
   generator: powheg
   crossSection: ZHToTauTau
-  ext: ['ZHToTauTau_M125_ext1']
+  ext: [ 'ZHToTauTau_M125_ext1' ]
 ZHToTauTau_M125_ext1:
   sampleType: VH
   generator: powheg
@@ -969,7 +968,7 @@ HZJ_HToWW_M125:
   sampleType: VH
   generator: powheg
   crossSection: HZJ_HToWW
-  ext: ['HZJ_HToWW_M125_ext1']
+  ext: [ 'HZJ_HToWW_M125_ext1' ]
 HZJ_HToWW_M125_ext1:
   sampleType: VH
   generator: powheg
@@ -978,7 +977,7 @@ GluGluZH_HToWW_ZTo2L_M125:
   sampleType: VH
   generator: powheg
   crossSection: GluGluZH_HToWW_ZTo2L
-  ext: ['GluGluZH_HToWW_ZTo2L_M125_ext1']
+  ext: [ 'GluGluZH_HToWW_ZTo2L_M125_ext1' ]
 GluGluZH_HToWW_ZTo2L_M125_ext1:
   sampleType: VH
   generator: powheg
@@ -1054,7 +1053,7 @@ WWW_4F:
   sampleType: VVV
   generator: amcatnlo
   crossSection: WWW_4F
-  ext: ['WWW_4F_ext1']
+  ext: [ 'WWW_4F_ext1' ]
 WWW_4F_ext1:
   sampleType: VVV
   generator: amcatnlo
@@ -1063,7 +1062,7 @@ WWZ_4F:
   sampleType: VVV
   generator: amcatnlo
   crossSection: WWZ_4F
-  ext: ['WWZ_4F_ext1']
+  ext: [ 'WWZ_4F_ext1' ]
 WWZ_4F_ext1:
   sampleType: VVV
   generator: amcatnlo
@@ -1072,7 +1071,7 @@ WZZ:
   sampleType: VVV
   generator: amcatnlo
   crossSection: WZZ
-  ext: ['WZZ_ext1']
+  ext: [ 'WZZ_ext1' ]
 WZZ_ext1:
   sampleType: VVV
   generator: amcatnlo
@@ -1081,7 +1080,7 @@ ZZZ:
   sampleType: VVV
   generator: amcatnlo
   crossSection: ZZZ
-  ext: ['ZZZ_ext1']
+  ext: [ 'ZZZ_ext1' ]
 ZZZ_ext1:
   sampleType: VVV
   generator: amcatnlo
@@ -1152,7 +1151,7 @@ TTGJets:
   sampleType: TTX
   generator: amcatnlo
   crossSection: TTGJets
-  ext: ['TTGJets_ext1']
+  ext: [ 'TTGJets_ext1' ]
 TTGJets_ext1:
   sampleType: TTX
   generator: amcatnlo
@@ -1228,7 +1227,7 @@ TTZHTo4b:
   sampleType: TTX
   generator: madgraph
   crossSection: TTZHTo4b
-  ext: ['TTZHTo4b_ext1']
+  ext: [ 'TTZHTo4b_ext1' ]
 TTZHTo4b_ext1:
   sampleType: TTX
   generator: madgraph
@@ -1242,7 +1241,7 @@ TTZZTo4b:
   sampleType: TTX
   generator: madgraph
   crossSection: TTZZTo4b
-  ext: ['TTZZTo4b_ext1']
+  ext: [ 'TTZZTo4b_ext1' ]
 TTZZTo4b_ext1:
   sampleType: TTX
   generator: madgraph
@@ -1573,7 +1572,6 @@ DYJetsToTauTauToMuTauh-madgraphMLM_ext2:
   sampleType: DY
   generator: madgraph
   crossSection: DY_muTau_LO
-
 
 
 DYJetsToLL_M-100to200-amcatnloFXFX:

--- a/config/Run2_2017/samples.yaml
+++ b/config/Run2_2017/samples.yaml
@@ -1,10 +1,10 @@
 GLOBAL:
-  era: 'Run2_2017' # https://twiki.cern.ch/twiki/bin/view/CMS/PdmVDatasetsUL2017
-  luminosity : 41480.
+  era: 'Run2_2017'  # https://twiki.cern.ch/twiki/bin/view/CMS/PdmVDatasetsUL2017
+  luminosity: 41480.
   fs_nanoAOD:
-  - 'T2_CH_CERN:/store/group/phys_higgs/HLepRare/HTT_skim_v1/Run2_2017'
+    - 'T2_CH_CERN:/store/group/phys_higgs/HLepRare/HTT_skim_v1/Run2_2017'
   nano_version: v12
-  MET_flags: # https://twiki.cern.ch/twiki/bin/viewauth/CMS/MissingETOptionalFiltersRun2#2017_data_and_MC_UL
+  MET_flags:  # https://twiki.cern.ch/twiki/bin/viewauth/CMS/MissingETOptionalFiltersRun2#2017_data_and_MC_UL
     - Flag_goodVertices
     - Flag_globalSuperTightHalo2016Filter
     - Flag_HBHENoiseFilter
@@ -13,11 +13,11 @@ GLOBAL:
     - Flag_BadPFMuonFilter
     - Flag_BadPFMuonDzFilter
     - Flag_eeBadScFilter
-    #- Flag_hfNoisyHitsFilter
-    #- Flag_BadChargedCandidateFilter
+    # - Flag_hfNoisyHitsFilter
+    # - Flag_BadChargedCandidateFilter
   met_type: MET
   triggerFile: config/Run2_2017/triggers.yaml
-  crossSectionsFile : config/crossSections13TeV.yaml
+  crossSectionsFile: config/crossSections13TeV.yaml
   # from https://twiki.cern.ch/twiki/bin/viewauth/CMS/DCUserPage
   # useful link: https://twiki.cern.ch/twiki/bin/view/CMS/DCUserPage2017Analysis
   lumiFile: /afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions17/13TeV/Legacy_2017/Cert_294927-306462_13TeV_UL2017_Collisions17_GoldenJSON.txt
@@ -54,8 +54,7 @@ GLOBAL:
     - drop ^W0JetsToLNu-amcatnloFXFX$
     - drop ^W1JetsToLNu-amcatnloFXFX$
     - drop ^W2JetsToLNu-amcatnloFXFX$
-    #- drop ^W[0-2]Jets*amcatnlo*
-
+    # - drop ^W[0-2]Jets*amcatnlo*
 
 
 ############## Data ##############
@@ -138,7 +137,6 @@ MET_Run2017E:
 MET_Run2017F:
   miniAOD: /MET/Run2017F-UL2017_MiniAODv2-v1/MINIAOD
   sampleType: data
-
 
 
 ############## Signals ##############
@@ -595,151 +593,151 @@ VBFToRadionToHHTo2B2Tau_M-3000:
 VBFToBulkGravitonToHHTo2B2Tau_M-250:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 250
+  mass: 250
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-260:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 260
+  mass: 260
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-270:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 270
+  mass: 270
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-280:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 280
+  mass: 280
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-300:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 300
+  mass: 300
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-320:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 320
+  mass: 320
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-350:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 350
+  mass: 350
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-400:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 400
+  mass: 400
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-450:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 450
+  mass: 450
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-500:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 500
+  mass: 500
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-550:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 550
+  mass: 550
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-600:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 600
+  mass: 600
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-650:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 650
+  mass: 650
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-700:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 700
+  mass: 700
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-750:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 750
+  mass: 750
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-800:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 800
+  mass: 800
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-850:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 850
+  mass: 850
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-900:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 900
+  mass: 900
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-1000:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 1000
+  mass: 1000
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-1250:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 1250
+  mass: 1250
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-1500:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 1500
+  mass: 1500
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-1750:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 1750
+  mass: 1750
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-2000:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 2000
+  mass: 2000
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-2500:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 2500
+  mass: 2500
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-3000:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 3000
+  mass: 3000
   spin: 2
   crossSection: 1pb
 
@@ -817,7 +815,6 @@ WJetsToLNu_HT-800To1200:
   crossSectionStitch: WJetsToLNu_HT-800To1200_LO
 
 
-
 WJetsToLNu-amcatnloFXFX:
   sampleType: W
   generator: amcatnlo
@@ -831,7 +828,7 @@ W0JetsToLNu-amcatnloFXFX:
 W1JetsToLNu-amcatnloFXFX:
   sampleType: W
   generator: amcatnlo
-  crossSectionStitch:  W1JetsToLNu_NLO
+  crossSectionStitch: W1JetsToLNu_NLO
 W2JetsToLNu-amcatnloFXFX:
   sampleType: W
   generator: amcatnlo
@@ -969,7 +966,7 @@ ZHToTauTau_M125:
   sampleType: VH
   generator: powheg
   crossSection: ZHToTauTau
-  ext: ['ZHToTauTau_M125_ext1']
+  ext: [ 'ZHToTauTau_M125_ext1' ]
 ZHToTauTau_M125_ext1:
   sampleType: VH
   generator: powheg
@@ -994,7 +991,7 @@ HZJ_HToWW_M125:
   sampleType: VH
   generator: powheg
   crossSection: HZJ_HToWW
-  ext: ['HZJ_HToWW_M125_ext1']
+  ext: [ 'HZJ_HToWW_M125_ext1' ]
 HZJ_HToWW_M125_ext1:
   sampleType: VH
   generator: powheg
@@ -1003,7 +1000,7 @@ GluGluZH_HToWW_ZTo2L_M125:
   sampleType: VH
   generator: powheg
   crossSection: GluGluZH_HToWW_ZTo2L
-  ext: ['GluGluZH_HToWW_ZTo2L_M125_ext1']
+  ext: [ 'GluGluZH_HToWW_ZTo2L_M125_ext1' ]
 GluGluZH_HToWW_ZTo2L_M125_ext1:
   sampleType: VH
   generator: powheg
@@ -1079,7 +1076,7 @@ WWW_4F:
   sampleType: VVV
   generator: amcatnlo
   crossSection: WWW_4F
-  ext: ['WWW_4F_ext1']
+  ext: [ 'WWW_4F_ext1' ]
 WWW_4F_ext1:
   sampleType: VVV
   generator: amcatnlo
@@ -1088,7 +1085,7 @@ WWZ_4F:
   sampleType: VVV
   generator: amcatnlo
   crossSection: WWZ_4F
-  ext: ['WWZ_4F_ext1']
+  ext: [ 'WWZ_4F_ext1' ]
 WWZ_4F_ext1:
   sampleType: VVV
   generator: amcatnlo
@@ -1097,7 +1094,7 @@ WZZ:
   sampleType: VVV
   generator: amcatnlo
   crossSection: WZZ
-  ext: ['WZZ_ext1']
+  ext: [ 'WZZ_ext1' ]
 WZZ_ext1:
   sampleType: VVV
   generator: amcatnlo
@@ -1106,7 +1103,7 @@ ZZZ:
   sampleType: VVV
   generator: amcatnlo
   crossSection: ZZZ
-  ext: ['ZZZ_ext1']
+  ext: [ 'ZZZ_ext1' ]
 ZZZ_ext1:
   sampleType: VVV
   generator: amcatnlo
@@ -1177,7 +1174,7 @@ TTGJets:
   sampleType: TTX
   generator: amcatnlo
   crossSection: TTGJets
-  ext: ['TTGJets_ext1']
+  ext: [ 'TTGJets_ext1' ]
 TTGJets_ext1:
   sampleType: TTX
   generator: amcatnlo
@@ -1253,7 +1250,7 @@ TTZHTo4b:
   sampleType: TTX
   generator: madgraph
   crossSection: TTZHTo4b
-  ext: ['TTZHTo4b_ext1']
+  ext: [ 'TTZHTo4b_ext1' ]
 TTZHTo4b_ext1:
   sampleType: TTX
   generator: madgraph
@@ -1267,7 +1264,7 @@ TTZZTo4b:
   sampleType: TTX
   generator: madgraph
   crossSection: TTZZTo4b
-  ext: ['TTZZTo4b_ext1']
+  ext: [ 'TTZZTo4b_ext1' ]
 TTZZTo4b_ext1:
   sampleType: TTX
   generator: madgraph
@@ -1597,7 +1594,6 @@ DYJetsToTauTauToMuTauh-madgraphMLM_ext2:
   sampleType: DY
   generator: madgraph
   crossSection: DY_muTau_LO
-
 
 
 DYJetsToLL_M-100to200-amcatnloFXFX:

--- a/config/Run2_2017/triggers.yaml
+++ b/config/Run2_2017/triggers.yaml
@@ -21,35 +21,35 @@ ditau:
       online_obj:
         cuts:
           - cut: TrigObj_id == 15 && (TrigObj_filterBits&64)!=0 && ( ( (TrigObj_filterBits&4)!=0 && (TrigObj_filterBits&16)!=0 ) || ( TrigObj_pt > 40 && ( (TrigObj_filterBits&2)!=0 && (TrigObj_filterBits&16)!=0 ) || (TrigObj_filterBits&4)!=0 ) )
-          #- cut: TrigObj_id == 15 && (TrigObj_filterBits&64)!=0 && (( (TrigObj_filterBits&4)!=0 && (TrigObj_filterBits&8)!=0 ) || ( TrigObj_pt > 40 && ( (TrigObj_filterBits&2)!=0 && (TrigObj_filterBits&8)!=0 ) || (TrigObj_filterBits&4)!=0 ) )
+          # - cut: TrigObj_id == 15 && (TrigObj_filterBits&64)!=0 && (( (TrigObj_filterBits&4)!=0 && (TrigObj_filterBits&8)!=0 ) || ( TrigObj_pt > 40 && ( (TrigObj_filterBits&2)!=0 && (TrigObj_filterBits&8)!=0 ) || (TrigObj_filterBits&4)!=0 ) )
       doMatching: True
     - ref_leg: 0
 MET:
-    channels:
-      - tauTau
-      - muTau
-      - eTau
-    path:
-      - HLT_PFMETNoMu120_PFMHTNoMu120_IDTight
-    legs:
-      - offline_obj:
-          type: MET
-          cut: metnomu_pt > 150
-        doMatching: False
+  channels:
+    - tauTau
+    - muTau
+    - eTau
+  path:
+    - HLT_PFMETNoMu120_PFMHTNoMu120_IDTight
+  legs:
+    - offline_obj:
+        type: MET
+        cut: metnomu_pt > 150
+      doMatching: False
 singleTau:
-    channels:
-      - tauTau
-      - muTau
-      - eTau
-    path:
-      - HLT_MediumChargedIsoPFTau180HighPtRelaxedIso_Trk50_eta2p1
-    legs:
-      - offline_obj:
-          type: Tau
-          cut: v_ops::pt(Tau_p4) > 190 && abs(v_ops::eta(Tau_p4)) < 2.1
-        online_obj:
-          cut: TrigObj_id == 15 && (TrigObj_filterBits&1024)!=0
-        doMatching: True
+  channels:
+    - tauTau
+    - muTau
+    - eTau
+  path:
+    - HLT_MediumChargedIsoPFTau180HighPtRelaxedIso_Trk50_eta2p1
+  legs:
+    - offline_obj:
+        type: Tau
+        cut: v_ops::pt(Tau_p4) > 190 && abs(v_ops::eta(Tau_p4)) < 2.1
+      online_obj:
+        cut: TrigObj_id == 15 && (TrigObj_filterBits&1024)!=0
+      doMatching: True
 
 singleMu:
   channels:
@@ -61,7 +61,7 @@ singleMu:
   legs:
     - offline_obj:
         type: Muon
-        cut:  v_ops::pt(Muon_p4) > 29 #&& abs(v_ops::eta(Muon_p4)) < 2.1
+        cut: v_ops::pt(Muon_p4) > 29  # && abs(v_ops::eta(Muon_p4)) < 2.1
       online_obj:
         cut: TrigObj_id == 13 && ((TrigObj_filterBits&8)!=0 || (TrigObj_filterBits&2)!=0)
       doMatching: True
@@ -96,14 +96,13 @@ singleEle:
     - HLT_Ele32_WPTight_Gsf_L1DoubleEG && run< 302026
   path_MC:
     - HLT_Ele32_WPTight_Gsf
-    #- HLT_Ele35_WPTight_Gsf ? understand
+    # - HLT_Ele35_WPTight_Gsf ? understand
   legs:
     - offline_obj:
         type: Electron
         cut: v_ops::pt(Electron_p4) > 34 && abs(v_ops::eta(Electron_p4)) < 2.5
       online_obj:
-        cut: TrigObj_id == 11 && (TrigObj_filterBits&2)!=0
-        cut:  (run >= 302026 || (run< 302026 && (TrigObj_filterBits&1024)!=0 ))
+        cut: TrigObj_id == 11 && (TrigObj_filterBits&2)!=0 && (run >= 302026 || (run< 302026 && (TrigObj_filterBits&1024)!=0 ))
       doMatching: True
 
 etau:
@@ -122,5 +121,5 @@ etau:
         type: Tau
         cut: v_ops::pt(Tau_p4) > 35 && abs(v_ops::eta(Tau_p4)) < 2.1
       online_obj:
-        cut:  TrigObj_id==15 && (TrigObj_filterBits&256)!=0
+        cut: TrigObj_id==15 && (TrigObj_filterBits&256)!=0
       doMatching: True

--- a/config/Run2_2018/samples.yaml
+++ b/config/Run2_2018/samples.yaml
@@ -1,10 +1,10 @@
 GLOBAL:
-  era: 'Run2_2018' # https://twiki.cern.ch/twiki/bin/view/CMS/PdmVDatasetsUL2018
+  era: 'Run2_2018'  # https://twiki.cern.ch/twiki/bin/view/CMS/PdmVDatasetsUL2018
   luminosity: 59830.
   fs_nanoAOD:
-  - 'T2_CH_CERN:/store/group/phys_higgs/HLepRare/HTT_skim_v1/Run2_2018'
+    - 'T2_CH_CERN:/store/group/phys_higgs/HLepRare/HTT_skim_v1/Run2_2018'
   nano_version: v12
-  MET_flags: # https://twiki.cern.ch/twiki/bin/view/CMS/MissingETOptionalFiltersRun2
+  MET_flags:  # https://twiki.cern.ch/twiki/bin/view/CMS/MissingETOptionalFiltersRun2
     - Flag_goodVertices
     - Flag_globalSuperTightHalo2016Filter
     - Flag_HBHENoiseFilter
@@ -16,7 +16,7 @@ GLOBAL:
     - Flag_ecalBadCalibFilter
   met_type: MET
   triggerFile: config/Run2_2018/triggers.yaml
-  crossSectionsFile : config/crossSections13TeV.yaml
+  crossSectionsFile: config/crossSections13TeV.yaml
   # https://twiki.cern.ch/twiki/bin/viewauth/CMS/DCUserPage
   # https://twiki.cern.ch/twiki/bin/view/CMS/DCUserPage2018Analysis
   # lumiFile: /afs/cern.ch/cms/CAF/CMSCOMM/COMM_DQM/certification/Collisions18/13TeV/ReReco/Cert_314472-325175_13TeV_17SeptEarlyReReco2018ABC_PromptEraD_Collisions18_JSON.txt
@@ -556,151 +556,151 @@ VBFToRadionToHHTo2B2Tau_M-3000:
 VBFToBulkGravitonToHHTo2B2Tau_M-250:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 250
+  mass: 250
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-260:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 260
+  mass: 260
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-270:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 270
+  mass: 270
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-280:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 280
+  mass: 280
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-300:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 300
+  mass: 300
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-320:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 320
+  mass: 320
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-350:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 350
+  mass: 350
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-400:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 400
+  mass: 400
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-450:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 450
+  mass: 450
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-500:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 500
+  mass: 500
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-550:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 550
+  mass: 550
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-600:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 600
+  mass: 600
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-650:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 650
+  mass: 650
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-700:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 700
+  mass: 700
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-750:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 750
+  mass: 750
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-800:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 800
+  mass: 800
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-850:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 850
+  mass: 850
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-900:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 900
+  mass: 900
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-1000:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 1000
+  mass: 1000
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-1250:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 1250
+  mass: 1250
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-1500:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 1500
+  mass: 1500
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-1750:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 1750
+  mass: 1750
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-2000:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 2000
+  mass: 2000
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-2500:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 2500
+  mass: 2500
   spin: 2
   crossSection: 1pb
 VBFToBulkGravitonToHHTo2B2Tau_M-3000:
   sampleType: VBFToBulkGraviton
   generator: madgraph
-  mass : 3000
+  mass: 3000
   spin: 2
   crossSection: 1pb
 
@@ -778,7 +778,6 @@ WJetsToLNu_HT-800To1200:
   crossSectionStitch: WJetsToLNu_HT-800To1200_LO
 
 
-
 WJetsToLNu-amcatnloFXFX:
   sampleType: W
   generator: amcatnlo
@@ -792,7 +791,7 @@ W0JetsToLNu-amcatnloFXFX:
 W1JetsToLNu-amcatnloFXFX:
   sampleType: W
   generator: amcatnlo
-  crossSectionStitch:  W1JetsToLNu_NLO
+  crossSectionStitch: W1JetsToLNu_NLO
 W2JetsToLNu-amcatnloFXFX:
   sampleType: W
   generator: amcatnlo
@@ -930,7 +929,7 @@ ZHToTauTau_M125:
   sampleType: VH
   generator: powheg
   crossSection: ZHToTauTau
-  ext: ['ZHToTauTau_M125_ext1']
+  ext: [ 'ZHToTauTau_M125_ext1' ]
 ZHToTauTau_M125_ext1:
   sampleType: VH
   generator: powheg
@@ -955,7 +954,7 @@ HZJ_HToWW_M125:
   sampleType: VH
   generator: powheg
   crossSection: HZJ_HToWW
-  ext: ['HZJ_HToWW_M125_ext1']
+  ext: [ 'HZJ_HToWW_M125_ext1' ]
 HZJ_HToWW_M125_ext1:
   sampleType: VH
   generator: powheg
@@ -964,7 +963,7 @@ GluGluZH_HToWW_ZTo2L_M125:
   sampleType: VH
   generator: powheg
   crossSection: GluGluZH_HToWW_ZTo2L
-  ext: ['GluGluZH_HToWW_ZTo2L_M125_ext1']
+  ext: [ 'GluGluZH_HToWW_ZTo2L_M125_ext1' ]
 GluGluZH_HToWW_ZTo2L_M125_ext1:
   sampleType: VH
   generator: powheg
@@ -1040,7 +1039,7 @@ WWW_4F:
   sampleType: VVV
   generator: amcatnlo
   crossSection: WWW_4F
-  ext: ['WWW_4F_ext1']
+  ext: [ 'WWW_4F_ext1' ]
 WWW_4F_ext1:
   sampleType: VVV
   generator: amcatnlo
@@ -1049,7 +1048,7 @@ WWZ_4F:
   sampleType: VVV
   generator: amcatnlo
   crossSection: WWZ_4F
-  ext: ['WWZ_4F_ext1']
+  ext: [ 'WWZ_4F_ext1' ]
 WWZ_4F_ext1:
   sampleType: VVV
   generator: amcatnlo
@@ -1058,7 +1057,7 @@ WZZ:
   sampleType: VVV
   generator: amcatnlo
   crossSection: WZZ
-  ext: ['WZZ_ext1']
+  ext: [ 'WZZ_ext1' ]
 WZZ_ext1:
   sampleType: VVV
   generator: amcatnlo
@@ -1067,7 +1066,7 @@ ZZZ:
   sampleType: VVV
   generator: amcatnlo
   crossSection: ZZZ
-  ext: ['ZZZ_ext1']
+  ext: [ 'ZZZ_ext1' ]
 ZZZ_ext1:
   sampleType: VVV
   generator: amcatnlo
@@ -1138,7 +1137,7 @@ TTGJets:
   sampleType: TTX
   generator: amcatnlo
   crossSection: TTGJets
-  ext: ['TTGJets_ext1']
+  ext: [ 'TTGJets_ext1' ]
 TTGJets_ext1:
   sampleType: TTX
   generator: amcatnlo
@@ -1214,7 +1213,7 @@ TTZHTo4b:
   sampleType: TTX
   generator: madgraph
   crossSection: TTZHTo4b
-  ext: ['TTZHTo4b_ext1']
+  ext: [ 'TTZHTo4b_ext1' ]
 TTZHTo4b_ext1:
   sampleType: TTX
   generator: madgraph
@@ -1228,7 +1227,7 @@ TTZZTo4b:
   sampleType: TTX
   generator: madgraph
   crossSection: TTZZTo4b
-  ext: ['TTZZTo4b_ext1']
+  ext: [ 'TTZZTo4b_ext1' ]
 TTZZTo4b_ext1:
   sampleType: TTX
   generator: madgraph
@@ -1559,7 +1558,6 @@ DYJetsToTauTauToMuTauh-madgraphMLM_ext2:
   sampleType: DY
   generator: madgraph
   crossSection: DY_muTau_LO
-
 
 
 DYJetsToLL_M-100to200-amcatnloFXFX:

--- a/config/Run2_2018/triggers.yaml
+++ b/config/Run2_2018/triggers.yaml
@@ -39,34 +39,34 @@ ditau:
       doMatching: True
     - ref_leg: 0
 MET:
-    channels:
-      - tauTau
-      - muTau
-      - eTau
-      - eMu
-      - muMu
-      - eE
-    path:
-      - HLT_PFMETNoMu120_PFMHTNoMu120_IDTight
-    legs:
-      - offline_obj:
-          type: MET
-          cut: metnomu_pt > 150
-        doMatching: False
+  channels:
+    - tauTau
+    - muTau
+    - eTau
+    - eMu
+    - muMu
+    - eE
+  path:
+    - HLT_PFMETNoMu120_PFMHTNoMu120_IDTight
+  legs:
+    - offline_obj:
+        type: MET
+        cut: metnomu_pt > 150
+      doMatching: False
 singleTau:
-    channels:
-      - tauTau
-      - muTau
-      - eTau
-    path:
-      - HLT_MediumChargedIsoPFTau180HighPtRelaxedIso_Trk50_eta2p1
-    legs:
-      - offline_obj:
-          type: Tau
-          cut: v_ops::pt(Tau_p4) > 190 && abs(v_ops::eta(Tau_p4)) < 2.1
-        online_obj:
-          cut: TrigObj_id == 15 && (TrigObj_filterBits&1024)!=0
-        doMatching: True
+  channels:
+    - tauTau
+    - muTau
+    - eTau
+  path:
+    - HLT_MediumChargedIsoPFTau180HighPtRelaxedIso_Trk50_eta2p1
+  legs:
+    - offline_obj:
+        type: Tau
+        cut: v_ops::pt(Tau_p4) > 190 && abs(v_ops::eta(Tau_p4)) < 2.1
+      online_obj:
+        cut: TrigObj_id == 15 && (TrigObj_filterBits&1024)!=0
+      doMatching: True
 
 singleMu:
   channels:
@@ -78,12 +78,12 @@ singleMu:
   legs:
     - offline_obj:
         type: Muon
-        cut:  v_ops::pt(Muon_p4) > 26 #&& abs(v_ops::eta(Muon_p4)) < 2.1
+        cut: v_ops::pt(Muon_p4) > 26  # && abs(v_ops::eta(Muon_p4)) < 2.1
       online_obj:
         cut: TrigObj_id == 13 && ((TrigObj_filterBits&8)!=0 || (TrigObj_filterBits&2)!=0)
       doMatching: True
 
-#singleMu50:
+# singleMu50:
 #  channels:
 #    - muTau
 #    - muMu
@@ -128,7 +128,7 @@ singleEle:
     - eMu
   path:
     - HLT_Ele32_WPTight_Gsf
-    #- HLT_Ele35_WPTight_Gsf ? understand
+    # - HLT_Ele35_WPTight_Gsf ? understand
   legs:
     - offline_obj:
         type: Electron
@@ -156,5 +156,5 @@ etau:
         type: Tau
         cut: v_ops::pt(Tau_p4) > 35 && abs(v_ops::eta(Tau_p4)) < 2.1
       online_obj:
-        cut:  TrigObj_id==15 && (TrigObj_filterBits&256)!=0
+        cut: TrigObj_id==15 && (TrigObj_filterBits&256)!=0
       doMatching: True

--- a/config/Run3_2022/samples.yaml
+++ b/config/Run3_2022/samples.yaml
@@ -2,20 +2,20 @@ GLOBAL:
   era: Run3_2022
   luminosity: 7980.4  # pb-1
   fs_nanoAOD:
-  - 'T2_CH_CERN:/store/group/phys_higgs/HLepRare/skim_2025_v1/Run3_2022'
+    - 'T2_CH_CERN:/store/group/phys_higgs/HLepRare/skim_2025_v1/Run3_2022'
   nano_version: v14
   crossSectionsFile: FLAF/config/crossSections13p6TeV.yaml
   use_stitching: false
   met_type: PFMET
   MET_flags:  # https://twiki.cern.ch/twiki/bin/view/CMS/MissingETOptionalFiltersRun2#Run_3_2022_and_2023_data_and_MC
-  - Flag_goodVertices
-  - Flag_globalSuperTightHalo2016Filter
-  - Flag_EcalDeadCellTriggerPrimitiveFilter
-  - Flag_BadPFMuonFilter
-  - Flag_BadPFMuonDzFilter
-  - Flag_hfNoisyHitsFilter
-  - Flag_eeBadScFilter
-  - Flag_ecalBadCalibFilter
+    - Flag_goodVertices
+    - Flag_globalSuperTightHalo2016Filter
+    - Flag_EcalDeadCellTriggerPrimitiveFilter
+    - Flag_BadPFMuonFilter
+    - Flag_BadPFMuonDzFilter
+    - Flag_hfNoisyHitsFilter
+    - Flag_eeBadScFilter
+    - Flag_ecalBadCalibFilter
   lumiFile: /eos/user/c/cmsdqm/www/CAF/certification/Collisions22/Cert_Collisions2022_355100_362760_Golden.json
 
 ############## Data ##############

--- a/config/Run3_2022EE/samples.yaml
+++ b/config/Run3_2022EE/samples.yaml
@@ -2,23 +2,23 @@ GLOBAL:
   era: Run3_2022EE
   luminosity: 26671.7  # pb-1
   fs_nanoAOD:
-  - 'T2_CH_CERN:/store/group/phys_higgs/HLepRare/skim_2025_v1/Run3_2022EE'
+    - 'T2_CH_CERN:/store/group/phys_higgs/HLepRare/skim_2025_v1/Run3_2022EE'
   nano_version: v14
   crossSectionsFile: FLAF/config/crossSections13p6TeV.yaml
   use_stitching: false
   met_type: PFMET
   MET_flags:  # https://twiki.cern.ch/twiki/bin/view/CMS/MissingETOptionalFiltersRun2#Run_3_2022_and_2023_data_and_MC
-  - Flag_goodVertices
-  - Flag_globalSuperTightHalo2016Filter
-  - Flag_EcalDeadCellTriggerPrimitiveFilter
-  - Flag_BadPFMuonFilter
-  - Flag_BadPFMuonDzFilter
-  - Flag_hfNoisyHitsFilter
-  - Flag_eeBadScFilter
-  - Flag_ecalBadCalibFilter
+    - Flag_goodVertices
+    - Flag_globalSuperTightHalo2016Filter
+    - Flag_EcalDeadCellTriggerPrimitiveFilter
+    - Flag_BadPFMuonFilter
+    - Flag_BadPFMuonDzFilter
+    - Flag_hfNoisyHitsFilter
+    - Flag_eeBadScFilter
+    - Flag_ecalBadCalibFilter
   badMET_flag_runs:  # https://twiki.cern.ch/twiki/bin/view/CMS/MissingETOptionalFiltersRun2#ECal_BadCalibration_Filter_Flag
-  - 362433
-  - 362760  # for 2022, Flag_ecalBadCalibFilter should not be used for a range of these two run numbers.
+    - 362433
+    - 362760  # for 2022, Flag_ecalBadCalibFilter should not be used for a range of these two run numbers.
   lumiFile: /eos/user/c/cmsdqm/www/CAF/certification/Collisions22/Cert_Collisions2022_355100_362760_Golden.json
 
 

--- a/config/Run3_2023/samples.yaml
+++ b/config/Run3_2023/samples.yaml
@@ -2,23 +2,23 @@ GLOBAL:
   era: Run3_2023
   luminosity: 18063.0  # pb-1
   fs_nanoAOD:
-  - 'T2_CH_CERN:/store/group/phys_higgs/HLepRare/skim_2024_v2/Run3_2023'
+    - 'T2_CH_CERN:/store/group/phys_higgs/HLepRare/skim_2024_v2/Run3_2023'
   nano_version: v14
   crossSectionsFile: FLAF/config/crossSections13p6TeV.yaml
   use_stitching: false
   met_type: PFMET
   MET_flags:  # https://twiki.cern.ch/twiki/bin/view/CMS/MissingETOptionalFiltersRun2#Run_3_2022_and_2023_data_and_MC
-  - Flag_goodVertices
-  - Flag_globalSuperTightHalo2016Filter
-  - Flag_EcalDeadCellTriggerPrimitiveFilter
-  - Flag_BadPFMuonFilter
-  - Flag_BadPFMuonDzFilter
-  - Flag_hfNoisyHitsFilter
-  - Flag_eeBadScFilter
-  - Flag_ecalBadCalibFilter
+    - Flag_goodVertices
+    - Flag_globalSuperTightHalo2016Filter
+    - Flag_EcalDeadCellTriggerPrimitiveFilter
+    - Flag_BadPFMuonFilter
+    - Flag_BadPFMuonDzFilter
+    - Flag_hfNoisyHitsFilter
+    - Flag_eeBadScFilter
+    - Flag_ecalBadCalibFilter
   badMET_flag_runs:  # https://twiki.cern.ch/twiki/bin/view/CMS/MissingETOptionalFiltersRun2#ECal_BadCalibration_Filter_Flag
-  - 366727
-  - 367144  # for 2023, Flag_ecalBadCalibFilter should not be used for a range of these two run numbers.
+    - 366727
+    - 367144  # for 2023, Flag_ecalBadCalibFilter should not be used for a range of these two run numbers.
   lumiFile: /eos/user/c/cmsdqm/www/CAF/certification/Collisions23/Cert_Collisions2023_366442_370790_Golden.json
 ############## Data ##############
 EGamma0_Run2023C_v1:

--- a/config/crossSections13TeV.yaml
+++ b/config/crossSections13TeV.yaml
@@ -6,7 +6,7 @@
 
 ############## TT ##############
 TTTo2L2Nu:
-  crossSec:  833.9 * (1 - 0.6741) * (1 - 0.6741)
+  crossSec: 833.9 * (1 - 0.6741) * (1 - 0.6741)
   reference: https://twiki.cern.ch/twiki/bin/view/LHCPhysics/TtbarNNLO#Proposed_citation_and_list_of_re
   unc: +20.5 -30.0 (scale) +/-  21.0 (PDF alphas) -22.5 +23.2 (mass) (to be multiplied by the BR)
 TTToSemiLeptonic:
@@ -25,9 +25,9 @@ WJetsToLNu_NNLO:
   reference: https://twiki.cern.ch/twiki/bin/viewauth/CMS/StandardModelCrossSectionsat13TeV?rev=27
   unc: (+165.7 -88.2 (scale), +/- 770.9 (PDF)) *3
 WJetsToLNu_NLO:
-  crossSec: 66680.0  #67350.0
-  reference: XSDB WJetsToLNu_TuneCP5_13TeV-amcatnloFXFX-pythia8 modifiedOn 2023-02-13 12:26:36 #2021-10-11 11:27:01
-  unc: 792.7 #286.2
+  crossSec: 66680.0  # 67350.0
+  reference: XSDB WJetsToLNu_TuneCP5_13TeV-amcatnloFXFX-pythia8 modifiedOn 2023-02-13 12:26:36  # 2021-10-11 11:27:01
+  unc: 792.7  # 286.2
 WJetsToLNu_LO:
   crossSec: 53870.0
   reference: XSDB WJetsToLNu_TuneCP5_13TeV-madgraphMLM-pythia8 modifiedOn 2021-06-21 10:00:29
@@ -90,17 +90,13 @@ DY_NNLO:
   reference: https://twiki.cern.ch/twiki/bin/viewauth/CMS/StandardModelCrossSectionsat13TeV?rev=27
   unc: +-1.49 (integration) +- 14.78 (pdf) +- 2% (scale)
 DY_NLO:
-  crossSec: 6424.0 # 6404.0
-  reference:  XSDB DYJetsToLL_M-50_TuneCP5_13TeV-amcatnloFXFX-pythia8 modifiedOn 2023-02-12 07:28:47 # 2021-06-21 09:27:12
-  unc: 81.95 # 27.69
+  crossSec: 6424.0  # 6404.0
+  reference: XSDB DYJetsToLL_M-50_TuneCP5_13TeV-amcatnloFXFX-pythia8 modifiedOn 2023-02-12 07:28:47  # 2021-06-21 09:27:12
+  unc: 81.95  # 27.69
 DY_LO:
-    crossSec: 5379.0 # 5398.0
-    reference: XSDB DYJetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8 modifiedOn 2023-02-12 07:28:48 # 2021-06-21 09:27:15
-    unc: 40.44 # 13.12
-DY_LO_M-10to50:
-  crossSec: 15810.0
-  reference: XSDB DYJetsToLL_M-10to50_TuneCP5_13TeV-madgraphMLM-pythia8 modifiedOn 2021-07-16 14:49:00
-  unc: 5.764
+  crossSec: 5379.0  # 5398.0
+  reference: XSDB DYJetsToLL_M-50_TuneCP5_13TeV-madgraphMLM-pythia8 modifiedOn 2023-02-12 07:28:48  # 2021-06-21 09:27:15
+  unc: 40.44 # 13.12
 
 DY_NLO_0J:
   crossSec: 5090.0 # 5129.0
@@ -111,9 +107,9 @@ DY_NLO_1J:
   reference: XSDB DYJetsToLL_1J_TuneCP5_13TeV-amcatnloFXFX-pythia8 modifiedOn 2023-02-12 07:28:33 # 2021-06-21 09:27:02
   unc: 951.5 # 6.067
 DY_NLO_2J:
-  crossSec: 353.6 #361.4
-  reference: XSDB DYJetsToLL_1J_TuneCP5_13TeV-amcatnloFXFX-pythia8 modifiedOn 2023-02-12 07:28:34 #2021-06-21 09:27:03
-  unc: 10.47 #3.704
+  crossSec: 353.6 # 361.4
+  reference: XSDB DYJetsToLL_1J_TuneCP5_13TeV-amcatnloFXFX-pythia8 modifiedOn 2023-02-12 07:28:34 # 2021-06-21 09:27:03
+  unc: 10.47 # 3.704
 DY_LO_1J:
   crossSec: 928.3
   reference: XSDB DY1JetsToLL_M-50_MatchEWPDG20_TuneCP5_13TeV-madgraphMLM-pythia8 modifiedOn 2021-06-21 09:26:40
@@ -163,7 +159,7 @@ DY_NLO_LHEFilterPtZ-650ToInf:
 
 
 DY_muTau_LO:
-  crossSec: 1 #to be fixed
+  crossSec: 1 # to be fixed
   reference:
   unc: 0.1 # to be fixed
 
@@ -333,7 +329,7 @@ ggHToZZTo2L2Q:
   crossSec: 48.58 * 0.02619 * (0.03658 * 3) * 0.6911 * 2
   ref: Higgs_XSBR_YR4_update https://twiki.cern.ch/twiki/bin/view/LHCPhysics/CERNYellowReportPageAt13TeV + https://pdg.lbl.gov/2022/listings/rpp2022-list-z-boson.pdf
   unc: ggH (+4.6 -6.7  +/-3.9 +/-3.2 +/-1.9 +/-2.6) (th pos [%] neg [%] Gauss [%],  PDF+ alfas, PDF, alfas) * HZZ (+0,99 -0,99 +0,99 -0,98 +0,66 -0,63 ) (thu, pu[mq], pu[alphas]) others are too small, can be neglected
-#ggHToZZTo2L2Q:
+# ggHToZZTo2L2Q:
 #  crossSec: 28.87
 #  ref: XSDB GluGluHToZZTo2L2Q_M125_TuneCP5_13TeV_powheg2_JHUGenV7011_pythia8 modifiedOn 2022-03-02 06:36:47
 #  unc: 0.02027
@@ -342,15 +338,15 @@ GluGluHToWWTo2L2Nu:
   crossSec: 48.58 * 0.2137 * 0.1086 * 3 * 0.1086 * 3
   reference: Higgs_XSBR_YR4_update https://twiki.cern.ch/twiki/bin/view/LHCPhysics/CERNYellowReportPageAt13TeV + https://pdg.lbl.gov/2019/listings/rpp2019-list-w-boson.pdf
   unc: ggH (+4.6 -6.7  +/-3.9 +/-3.2 +/-1.9 +/-2.6) (th pos [%] neg [%] Gauss [%],  PDF+ alfas, PDF, alfas) HWW (+0,99 -0,99 +0,99 -0,98 +0,66 -0,63) (thu, pu[mq], pu[alphas]) Wlnu (0.0009)
-#GluGluHToWWTo2L2Nu:
+# GluGluHToWWTo2L2Nu:
 #  crossSec: 21.47
 #  ref: XSDB GluGluHToWWTo2L2Nu_M-125_TuneCP5_13TeV-powheg-jhugen727-pythia8 modifiedOn 2021-10-11 11:23:02
 #  unc: 0.01033
 
 VBFHToWWTo2L2Nu:
-  crossSec:  3.782  * 0.2137 * 0.1086 * 3 * 0.1086 * 3
+  crossSec: 3.782  * 0.2137 * 0.1086 * 3 * 0.1086 * 3
   reference: Higgs_XSBR_YR4_update https://twiki.cern.ch/twiki/bin/view/LHCPhysics/CERNYellowReportPageAt13TeV + https://pdg.lbl.gov/2019/listings/rpp2019-list-w-boson.pdf
-  unc:  VBF (+0,4 -0,3 +/-2,1 +/-2,1 +/-0,5) (scale,  PDF+ alfas, PDF, alfas) HWW (+0,99 -0,99 +0,99 -0,98 +0,66 -0,63) (thu, pu[mq], pu[alphas]) Wlnu (0.0009)
+  unc: VBF (+0,4 -0,3 +/-2,1 +/-2,1 +/-0,5) (scale,  PDF+ alfas, PDF, alfas) HWW (+0,99 -0,99 +0,99 -0,98 +0,66 -0,63) (thu, pu[mq], pu[alphas]) Wlnu (0.0009)
 #  crossSec: 3.892
 #  ref: XSDB VBFHToWWTo2L2Nu_M-125_TuneCP5_13TeV-powheg-jhugen727-pythia8 modifiedOn 2021-10-11 11:26:47
 #  unc: 0.01575
@@ -372,12 +368,12 @@ ZHToTauTau:
   unc: ZH (+3,8 -3,1 +/-1,6 +/-1,3 +/-0,9) HTauTau (+1.17 -1.16 +0.98 -0.99 +0.62 -0.62) (thu, pu[mq], pu[alphas])
 
 ZH_Hbb_Zll:
-  crossSec:  0.8839 * 0.5824 * 0.03658 * 3
+  crossSec: 0.8839 * 0.5824 * 0.03658 * 3
   reference: Higgs_XSBR_YR4_update https://twiki.cern.ch/twiki/bin/view/LHCPhysics/CERNYellowReportPageAt13TeV + https://pdg.lbl.gov/2022/listings/rpp2022-list-z-boson.pdf
   unc: ZH (+3,8 -3,1 +/-1,6 +/-1,3 +/-0,9) Hbb (+0,65 -0,65 +0,72 -0,74 +0,78 -0,80) (thu, pu[mq], pu[alphas]) others are too small, can be neglected
 
 ZH_Hbb_Zqq:
-  crossSec:  0.8839 * 0.5824 * 0.6911
+  crossSec: 0.8839 * 0.5824 * 0.6911
   reference: Higgs_XSBR_YR4_update https://twiki.cern.ch/twiki/bin/view/LHCPhysics/CERNYellowReportPageAt13TeV + https://pdg.lbl.gov/2022/listings/rpp2022-list-z-boson.pdf
   unc: ZH (+3,8 -3,1 +/-1,6 +/-1,3 +/-0,9) Hbb (+0,65 -0,65 +0,72 -0,74 +0,78 -0,80) (thu, pu[mq], pu[alphas]) others are too small, can be neglected
 
@@ -398,23 +394,22 @@ GluGluZH_HToWW_ZTo2L:
   crossSec: 0.1227 * 0.2137 * 0.03658 * 3
   reference: Higgs_XSBR_YR4_update https://twiki.cern.ch/twiki/bin/view/LHCPhysics/CERNYellowReportPageAt13TeV + https://pdg.lbl.gov/2022/listings/rpp2022-list-z-boson.pdf
   unc: ZH (+3,8 -3,1 +/-1,6 +/-1,3 +/-0,9) HWW (+0,99 -0,99 +0,99 -0,98 +0,66 -0,63) others are too small, can be neglected
-#GluGluZH_HToWW_ZTo2L:
+# GluGluZH_HToWW_ZTo2L:
 #  crossSec: 0.006185
 #  ref: XSDB GluGluZH_HToWW_ZTo2L_M-125_TuneCP5_13TeV-powheg-pythia8 modifiedOn 2021-10-11 11:23:32
 #  unc: 6.763e-06
 
 
-
 ############## VV inclusive ##############
 WW:
-  crossSec: 118.7 #75.95
+  crossSec: 118.7 # 75.95
   ref: https://twiki.cern.ch/twiki/bin/viewauth/CMS/StandardModelCrossSectionsat13TeV?rev=27 # arXiv:1408.5243 # XSDB WW_TuneCP5_13TeV-pythia8 modifiedOn 2021-06-21 10:00:53
-  unc: +2.5%-2.2% #0.1124
+  unc: +2.5%-2.2% # 0.1124
 
 WZ:
   crossSec: 46.74
   reference: JHEP07(2011)018 https://link.springer.com/article/10.1007/JHEP07(2011)018
-  unc:  +4.1% -3.3%
+  unc: +4.1% -3.3%
 
 ZZ:
   crossSec: 15.99
@@ -433,7 +428,7 @@ WWTo2L2Nu:
   unc: 0.00704
 
 WWTo4Q:
-  crossSec: 51.55  #51.723
+  crossSec: 51.55  # 51.723
   reference: from GenXSecAnalyzer /WWTo4Q_4f_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v3/MINIAODSIM
   unc: 4.849e-02
 
@@ -466,7 +461,7 @@ ZZTo2L2Nu:
   reference: XSDB ZZTo2L2Nu_TuneCP5_13TeV_powheg_pythia8 modifiedOn 2021-09-28 13:26:27
   unc: 0.0009971
 ZZTo2Q2L:
-  crossSec:  2.214
+  crossSec: 2.214
   reference: XSDB ZZTo2Q2L_14TeV_powheg_pythia8 modifiedOn 2019-11-11 18:49:02 mll>4GeV
   unc: 0.001657
 ZZTo2Q2Nu:
@@ -474,7 +469,7 @@ ZZTo2Q2Nu:
   reference: XSDB ZZTo2Q2Nu_TuneCP5_13TeV modifiedOn 2020-09-25 05:03:18
   unc: 0.01533
 ZZTo4Q:
-  crossSec:  3.302 #6.912 <-- previous value. The new one has been evaluated on many MiniAOD
+  crossSec: 3.302 # 6.912 <-- previous value. The new one has been evaluated on many MiniAOD
   reference: from GenXSecAnalyzer /ZZTo4Q_5f_TuneCP5_13TeV-amcatnloFXFX-pythia8/RunIISummer20UL18MiniAODv2-106X_upgrade2018_realistic_v16_L1v1-v2/MINIAODSIM
   unc: 6.328e-03
 
@@ -524,11 +519,11 @@ ST_s-channel_had:
   reference: https://twiki.cern.ch/twiki/bin/view/LHCPhysics/SingleTopRefXsec
   unc: +0.29 -0.24 +0.27 -0.27 +0.40 -0.36 +0.23 -0.22 ±0.01
 
-#ST_tW_antitop:
+# ST_tW_antitop:
 #  crossSec: 32.51
 #  reference: XSDB ST_tW_antitop_5f_NoFullyHadronicDecays_TuneCP5_13TeV-powheg-pythia8 modifiedOn 2021-06-21 09:55:28
 #  unc: 0.02346
-#ST_tW_top:
+# ST_tW_top:
 #  crossSec: 34.91
 #  reference: XSDB ST_tW_top_5f_inclusiveDecays_TuneCP5_13TeV-powheg-pythia8 - modifiedOn 2018-07-10 12:47:14,
 #  unc: 0.02817
@@ -683,7 +678,6 @@ ttHToNonbb:
   unc: ttH (+5,8 -9,2 +/-3,6 +/-3,0 +/-2,0) (Scale  PDF+αs PDF αs) Hbb (+0,65 -0,65 +0,72 -0,74 +0,78 -0,80)
 
 
-
 ############## HHbbTauTau NonRes ##############
 
 ggHH_bbTauTau_SM:
@@ -706,9 +700,9 @@ QCD_HT200to300:
   reference: XSDB QCD_HT200to300_TuneCP5_13TeV-madgraphMLM-pythia8 modifiedOn 2020-10-10 11:36:12
   unc: 4600.0
 QCD_HT300to500:
-  crossSec: 324500.0 #323400.0
+  crossSec: 324500.0 # 323400.0
   reference: XSDB QCD_HT300to500_TuneCP5_13TeV-madgraphMLM-pythia8 modifedOn 2020-10-10 11:36:13
-  unc: 967.7 #967.9
+  unc: 967.7 # 967.9
 QCD_HT500to700:
   crossSec: 30140.0
   reference: XSDB QCD_HT500to700_TuneCP5_13TeV-madgraphMLM-pythia8 modifiedOn 2020-10-10 11:36:14


### PR DESCRIPTION
Fixed remaining formatting issues for Python, C++, and YAML. No functional changes.
No problems were found for Python and C++.
Changed rules for YAML:
- always require indent for sequences
- relaxed condition on the number of spaces before the comment to 1.