### PR TITLE
Update Hist Fake Structure

### DIFF
--- a/Analysis/HistProducerFromNTuple.py
+++ b/Analysis/HistProducerFromNTuple.py
@@ -191,6 +191,7 @@ def SaveTmpFileUnc(
     tmp_file_root.Close()
     tmp_files.append(tmp_file)
 
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("inputFiles", nargs="+", type=str)


### PR DESCRIPTION
For the past month (Konstantin's fault) the Fake Structure histograms have been broken. In PR 205 the ```hist_list[0]``` was changed to 3 values instead of 2, but the FakeStructure version never added this third RDF variable
https://github.com/cms-flaf/FLAF/pull/205/changes#diff-cb839516eb4b14295ac1b51b6d5475b3a0e580fc15d6565a88a36f1a22c20985


This PR puts a catch on this RDF (it was only needed for debug, so it is quite useless), as well as adds a 'fake' option to the UnitBin function so the multi-dimensional plots also can create fake structure.

This bug was unseen as it only exists for files that have 0 entries in a selection. I found this using QCD. In the future, maybe the robot should also include a QCD test for these types of bugs?