### PR TITLE
Duplicated events removal for MC + more robust copyFileContent

### DIFF
--- a/AnaProd/AnaTupleFileList.py
+++ b/AnaProd/AnaTupleFileList.py
@@ -163,6 +163,148 @@ class RunCluster:
         return clusters
 
 
+def mwis_branch_and_bound(nodes, adj, weights):
+    """Maximum weight independent set (MWIS) via branch-and-bound.
+
+    Finds the subset of nodes with maximum total weight such that no two nodes
+    share a conflict edge. Uses a greedy solution as the initial lower bound and
+    prunes branches whose upper bound (sum of all candidate weights) cannot
+    improve on the best solution found.
+
+    nodes   : frozenset of nodes to consider.
+    adj     : dict {node -> frozenset of neighbors} restricted to this node set.
+    weights : dict {node -> int event count}.
+
+    Returns a frozenset of nodes forming the optimal independent set.
+    """
+    best = [0, frozenset()]  # [best_weight, best_set]
+
+    # Greedy initialisation: add highest-weight non-conflicting nodes in order.
+    excluded = set()
+    greedy_set = set()
+    for v in sorted(nodes, key=lambda n: (-weights[n], n.name)):
+        if v not in excluded:
+            greedy_set.add(v)
+            excluded.update(adj[v])
+    best[0] = sum(weights[v] for v in greedy_set)
+    best[1] = frozenset(greedy_set)
+
+    def bb(cands, cur_w, incl):
+        # Upper-bound check: even keeping all candidates cannot beat best.
+        ub = cur_w + sum(weights[v] for v in cands)
+        if ub <= best[0]:
+            return
+
+        # Find all candidates that still conflict with another candidate.
+        conflicted = [v for v in cands if adj[v] & cands]
+
+        if not conflicted:
+            # Conflict-free residual: include everything and record.
+            if ub > best[0]:
+                best[0] = ub
+                best[1] = incl | cands
+            return
+
+        # Branch on the highest-weight conflicted node (finds heavy solutions
+        # early, improving the lower bound and enabling aggressive pruning).
+        v = max(conflicted, key=lambda n: (weights[n], n.name))
+
+        # Branch 1: include v — exclude v and all its neighbours.
+        bb(cands - {v} - adj[v], cur_w + weights[v], incl | frozenset({v}))
+        # Branch 2: exclude v.
+        bb(cands - {v}, cur_w, incl)
+
+    bb(frozenset(nodes), 0, frozenset())
+    return best[1]
+
+
+def RemoveOverlappingMCFiles(input_files):
+    """For MC, drop the minimum events needed to eliminate (run,lumi) overlaps.
+
+    Builds the conflict graph (files as nodes, edges between any two files
+    sharing a lumi section), decomposes it into connected components, and solves
+    the maximum-weight independent set (MWIS) problem on each component via
+    branch-and-bound, where node weights are file event counts.  Files with no
+    overlaps are kept unconditionally.
+
+    Returns (remaining_files, ignored_file_names) where ignored_file_names is a
+    sorted list of file names.
+    """
+    lumi_to_files = {}
+    for file in input_files:
+        for run, lumis in file.run_lumi.items():
+            for lumi in lumis:
+                key = (run, lumi)
+                if key not in lumi_to_files:
+                    lumi_to_files[key] = set()
+                lumi_to_files[key].add(file)
+
+    conflict_adj = {}
+    for files in lumi_to_files.values():
+        if len(files) > 1:
+            for a in files:
+                if a not in conflict_adj:
+                    conflict_adj[a] = set()
+                for b in files:
+                    if b is not a:
+                        conflict_adj[a].add(b)
+
+    if not conflict_adj:
+        return set(input_files), []
+
+    conflicting_files = frozenset(conflict_adj.keys())
+
+    # Decompose into connected components (deterministic: sorted by name).
+    visited = set()
+    components = []
+    for start in sorted(conflicting_files, key=lambda f: f.name):
+        if start in visited:
+            continue
+        component = set()
+        stack = [start]
+        while stack:
+            node = stack.pop()
+            if node in visited:
+                continue
+            visited.add(node)
+            component.add(node)
+            for nb in conflict_adj[node]:
+                if nb not in visited:
+                    stack.append(nb)
+        components.append(frozenset(component))
+
+    n_comp = len(components)
+    print(
+        f"RemoveOverlappingMCFiles: {len(conflicting_files)} files form "
+        f"{n_comp} conflict component(s). Solving MWIS to maximise kept events..."
+    )
+
+    # Files with no conflicts are always kept.
+    kept_files = set(f for f in input_files if f not in conflicting_files)
+
+    for comp_idx, component in enumerate(components):
+        adj = {f: conflict_adj[f] & component for f in component}
+        weights = {f: f.nEvents for f in component}
+        kept = mwis_branch_and_bound(component, adj, weights)
+        kept_files.update(kept)
+        n_kept_ev = sum(weights[f] for f in kept)
+        n_total_ev = sum(weights[f] for f in component)
+        print(
+            f"  Component {comp_idx + 1}/{n_comp}: {len(component)} files, "
+            f"kept {len(kept)} files ({n_kept_ev:,}/{n_total_ev:,} events)"
+        )
+
+    ignored_set = frozenset(f for f in input_files if f not in kept_files)
+    ignored_file_names = sorted(f.name for f in ignored_set)
+    n_ignored_ev = sum(f.nEvents for f in ignored_set)
+    print(
+        f"RemoveOverlappingMCFiles: removed {len(ignored_set)} files "
+        f"({n_ignored_ev:,} events dropped). {len(kept_files)} files remaining."
+    )
+    return set(kept_files), ignored_file_names
+
+
+
 def ToRunLumiRanges(run_lumi):
     """Convert {run: set_of_lumis} to the [[start, end], ...] range format used in JSON output."""
     run_lumi_ranges = {}
@@ -541,6 +683,10 @@ def CreateMergePlan(
         )
         input_files.add(file)
 
+    ignored_file_names = []
+    if not is_data:
+        input_files, ignored_file_names = RemoveOverlappingMCFiles(input_files)
+
     run_clusters = RunCluster.create(input_files)
     cluster_groups = {}
     for cluster in run_clusters:
@@ -644,7 +790,17 @@ def CreateMergePlan(
             f"Some (file, run) pairs were not scheduled for merging: {missing}"
         )
 
-    return {"plan": merge_plan, "reports": combined_reports}
+    n_events_plan = sum(item["n_events"] for item in merge_plan)
+    n_events_ignored = sum(
+        combined_reports[name]["n_events"] for name in ignored_file_names
+    )
+    return {
+        "plan": merge_plan,
+        "ignored_files": ignored_file_names,
+        "n_events_plan": n_events_plan,
+        "n_events_ignored": n_events_ignored,
+        "reports": combined_reports,
+    }
 
 
 if __name__ == "__main__":
@@ -656,6 +812,7 @@ if __name__ == "__main__":
     parser.add_argument("--output", required=True, type=str)
     parser.add_argument("--max-steps", required=False, type=int, default=1000)
     parser.add_argument("--is-data", action="store_true")
+    parser.add_argument("--output-plan-only", action="store_true")
     args = parser.parse_args()
 
     result = CreateMergePlan(
@@ -665,5 +822,16 @@ if __name__ == "__main__":
         max_steps=args.max_steps,
     )
 
+    if args.output_plan_only:
+        output = result["plan"]
+    else:
+        output = {
+            "n_events_plan": result["n_events_plan"],
+            "n_events_ignored": result["n_events_ignored"],
+            "plan": result["plan"],
+            "ignored_files": result.get("ignored_files", []),
+        }
+
+
     with open(args.output, "w") as file:
-        json.dump(result["plan"], file, indent=2)
+        json.dump(output, file, indent=2)

--- a/AnaProd/AnaTupleFileList.py
+++ b/AnaProd/AnaTupleFileList.py
@@ -304,7 +304,6 @@ def RemoveOverlappingMCFiles(input_files):
     return set(kept_files), ignored_file_names
 
 
-
 def ToRunLumiRanges(run_lumi):
     """Convert {run: set_of_lumis} to the [[start, end], ...] range format used in JSON output."""
     run_lumi_ranges = {}
@@ -831,7 +830,6 @@ if __name__ == "__main__":
             "plan": result["plan"],
             "ignored_files": result.get("ignored_files", []),
         }
-
 
     with open(args.output, "w") as file:
         json.dump(output, file, indent=2)

--- a/AnaProd/tasks.py
+++ b/AnaProd/tasks.py
@@ -726,7 +726,7 @@ class AnaTupleMergeTask(Task, HTCondorWorkflow, law.LocalWorkflow):
                 print(
                     f"  {ds_name}: selected {len(selected_ds_reports)} out of {len(ds_reports)} reports"
                 )
-                reports[ds_name] = list(ds_reports.values())
+                reports[ds_name] = selected_ds_reports
             print(f"Localized reports from {len(reports)} datasets")
 
             mergeAnaTuples(

--- a/AnaProd/tasks.py
+++ b/AnaProd/tasks.py
@@ -449,7 +449,7 @@ class AnaTupleFileListBuilderTask(Task, HTCondorWorkflow, law.LocalWorkflow):
                     "ignored_files": raw_result["ignored_files"],
                     "n_events_plan": raw_result["n_events_plan"],
                     "n_events_ignored": raw_result["n_events_ignored"],
-                }
+                },
             }
 
             for output_name, output_remote in self.output().items():
@@ -723,7 +723,9 @@ class AnaTupleMergeTask(Task, HTCondorWorkflow, law.LocalWorkflow):
                     for key, report in ds_reports.items()
                     if key not in ignored_files
                 ]
-                print(f"  {ds_name}: selected {len(selected_ds_reports)} out of {len(ds_reports)} reports")
+                print(
+                    f"  {ds_name}: selected {len(selected_ds_reports)} out of {len(ds_reports)} reports"
+                )
                 reports[ds_name] = list(ds_reports.values())
             print(f"Localized reports from {len(reports)} datasets")
 

--- a/AnaProd/tasks.py
+++ b/AnaProd/tasks.py
@@ -435,12 +435,22 @@ class AnaTupleFileListBuilderTask(Task, HTCondorWorkflow, law.LocalWorkflow):
                 nEventsPerFile = nEventsPerFile.get(process_group, 100_000)
             is_data = process_group == "data"
 
-            result = CreateMergePlan(
+            raw_result = CreateMergePlan(
                 setup=self.setup,
                 local_inputs=local_inputs,
                 n_events_per_file=nEventsPerFile,
                 is_data=is_data,
             )
+
+            result = {
+                "plan": raw_result["plan"],
+                "reports": {
+                    "reports": raw_result["reports"],
+                    "ignored_files": raw_result["ignored_files"],
+                    "n_events_plan": raw_result["n_events_plan"],
+                    "n_events_ignored": raw_result["n_events_ignored"],
+                }
+            }
 
             for output_name, output_remote in self.output().items():
                 output_path_tmp = os.path.join(job_home, f"{output_name}_tmp.json")
@@ -699,9 +709,23 @@ class AnaTupleMergeTask(Task, HTCondorWorkflow, law.LocalWorkflow):
                     file_list["reports"].localize("r")
                 ).abspath
                 with open(report_file, "r") as f:
-                    ds_reports = yaml.safe_load(f)
+                    ds_details = yaml.safe_load(f)
+
+                if "reports" in ds_details:
+                    ignored_files = set(ds_details["ignored_files"])
+                    ds_reports = ds_details["reports"]
+                else:
+                    # workaround for a backward compatibility with the old report format
+                    ignored_files = set()
+                    ds_reports = ds_details
+                selected_ds_reports = [
+                    report
+                    for key, report in ds_reports.items()
+                    if key not in ignored_files
+                ]
+                print(f"  {ds_name}: selected {len(selected_ds_reports)} out of {len(ds_reports)} reports")
                 reports[ds_name] = list(ds_reports.values())
-            print(f"Localized {len(reports)} reports")
+            print(f"Localized reports from {len(reports)} datasets")
 
             mergeAnaTuples(
                 setup=self.setup,

--- a/Common/TupleHelpers.py
+++ b/Common/TupleHelpers.py
@@ -3,6 +3,7 @@ import os
 import re
 import ROOT
 
+
 def parseColumnName(column_name):
     if len(column_name) == 0:
         raise RuntimeError("Empty column name")
@@ -185,13 +186,17 @@ def copyFileContent(
             # Prefix/suffix apply to the leaf name only; directory path is preserved.
             out_path = f"{dir_prefix}{inp['name_prefix']}{obj_name}{inp['name_suffix']}"
 
-            if not ((inp["copyTrees"] and is_tree) or (inp["copyHistograms"] and is_hist)):
+            if not (
+                (inp["copyTrees"] and is_tree) or (inp["copyHistograms"] and is_hist)
+            ):
                 if verbose > 1:
                     print(f'Skipping object "{internal_path}" of type "{classname}"')
                 continue
 
             if verbose > 0:
-                print(f"{inp['file']}/{internal_path} -> {out_path} (type='{classname}')")
+                print(
+                    f"{inp['file']}/{internal_path} -> {out_path} (type='{classname}')"
+                )
 
             if is_hist:
                 obj = key.ReadObj()
@@ -226,7 +231,9 @@ def copyFileContent(
 
     if appendIfExists and os.path.exists(outputFile):
         comp_settings = ROOT.ROOT.CompressionSettings(
-            getattr(ROOT.ROOT.RCompressionSetting.EAlgorithm, "k" + compression_algorithm),
+            getattr(
+                ROOT.ROOT.RCompressionSetting.EAlgorithm, "k" + compression_algorithm
+            ),
             compression_level,
         )
         open_args = ("UPDATE", "", comp_settings)

--- a/Common/TupleHelpers.py
+++ b/Common/TupleHelpers.py
@@ -1,9 +1,7 @@
-import uproot
 import awkward as ak
 import os
 import re
 import ROOT
-
 
 def parseColumnName(column_name):
     if len(column_name) == 0:
@@ -98,23 +96,15 @@ def copyFileContent(
     copyHistograms=True,
     appendIfExists=False,
     verbose=1,
-    step_size="100MB",
     compression_algorithm="LZMA",
     compression_level=9,
 ):
-    compression = getattr(uproot, compression_algorithm)(compression_level)
-    snapshotOptions = ROOT.RDF.RSnapshotOptions()
-    snapshotOptions.fOverwriteIfExists = False
-    snapshotOptions.fLazy = False
-    snapshotOptions.fMode = "UPDATE"
-    snapshotOptions.fCompressionAlgorithm = getattr(
-        ROOT.ROOT.RCompressionSetting.EAlgorithm, "k" + compression_algorithm
-    )
-    snapshotOptions.fCompressionLevel = compression_level
     if verbose > 0:
         print(f"copyFileContent: {inputs} -> {outputFile}")
         print(
-            f"copyFileContent: copyTrees={copyTrees}, copyHistograms={copyHistograms}, appendIfExists={appendIfExists}, compression={compression}, step_size={step_size}"
+            f"copyFileContent: copyTrees={copyTrees}, copyHistograms={copyHistograms}, "
+            f"appendIfExists={appendIfExists}, "
+            f"compression={compression_algorithm}({compression_level})"
         )
 
     def processInputs(original_inputs):
@@ -158,83 +148,126 @@ def copyFileContent(
                 return obj_type
         return None
 
+    saved_dir = ROOT.gDirectory
+
+    # First pass: read all input objects, recursing into TDirectoryFile.
+    # Histograms are accumulated (added) across inputs with the same out_path.
+    # Trees are collected as a list of (file_path, internal_path) sources for TChain.
+    histograms = {}  # out_path -> ROOT TH1
+    trees = {}  # out_path -> [(file_path, internal_path), ...]
+
+    def collect_objects(directory, inp, dir_prefix=""):
+        # Build a map of name -> latest-cycle key to avoid processing stale cycles.
+        latest_keys = {}
+        for key in directory.GetListOfKeys():
+            name = key.GetName()
+            if name not in latest_keys or key.GetCycle() > latest_keys[name].GetCycle():
+                latest_keys[name] = key
+
+        for obj_name, key in latest_keys.items():
+            classname = key.GetClassName()
+            internal_path = f"{dir_prefix}{obj_name}"
+
+            if classname in ("TDirectory", "TDirectoryFile"):
+                subdir = directory.Get(obj_name)
+                if subdir:
+                    collect_objects(subdir, inp, f"{internal_path}/")
+                continue
+
+            obj_type = get_obj_type(classname)
+            if obj_type is None:
+                raise RuntimeError(
+                    f"{inp['file']}/{internal_path}: unknown object type='{classname}'"
+                )
+            is_tree = obj_type == "tree"
+            is_hist = obj_type == "histogram"
+
+            # Prefix/suffix apply to the leaf name only; directory path is preserved.
+            out_path = f"{dir_prefix}{inp['name_prefix']}{obj_name}{inp['name_suffix']}"
+
+            if not ((inp["copyTrees"] and is_tree) or (inp["copyHistograms"] and is_hist)):
+                if verbose > 1:
+                    print(f'Skipping object "{internal_path}" of type "{classname}"')
+                continue
+
+            if verbose > 0:
+                print(f"{inp['file']}/{internal_path} -> {out_path} (type='{classname}')")
+
+            if is_hist:
+                obj = key.ReadObj()
+                obj.SetDirectory(ROOT.nullptr)
+                if out_path in histograms:
+                    histograms[out_path].Add(obj)
+                else:
+                    histograms[out_path] = obj
+            else:
+                if out_path not in trees:
+                    trees[out_path] = []
+                trees[out_path].append((inp["file"], internal_path))
+
+    for inp in inputs:
+        input_file = ROOT.TFile.Open(inp["file"], "READ")
+        if not input_file or input_file.IsZombie():
+            raise RuntimeError(f"Cannot open input file: {inp['file']}")
+        try:
+            collect_objects(input_file, inp)
+        finally:
+            input_file.Close()
+
+    def get_or_create_dir(root_file, path_parts):
+        current = root_file
+        for part in path_parts:
+            d = current.Get(part)
+            if not d:
+                current.mkdir(part)
+                d = current.Get(part)
+            current = d
+        return current
+
     if appendIfExists and os.path.exists(outputFile):
-        open_fn = uproot.update
-        open_args = {}
+        comp_settings = ROOT.ROOT.CompressionSettings(
+            getattr(ROOT.ROOT.RCompressionSetting.EAlgorithm, "k" + compression_algorithm),
+            compression_level,
+        )
+        open_args = ("UPDATE", "", comp_settings)
     else:
-        open_fn = uproot.recreate
-        open_args = {"compression": compression}
-    histograms = {}
-    to_store_with_rdf = {}
-    stored_with_uproot = set()
-    with open_fn(outputFile, **open_args) as output_file:
-        for input in inputs:
-            copyInputTrees = input["copyTrees"]
-            copyInputHistograms = input["copyHistograms"]
-            with uproot.open(input["file"]) as input_file:
-                for input_object_name in input_file.keys():
-                    obj = input_file[input_object_name]
-                    obj_type = get_obj_type(obj.classname)
-                    if obj_type is None:
-                        raise RuntimeError(
-                            f"{input['file']}/{input_object_name}: unknown object type='{obj.classname}'"
-                        )
+        open_args = ("RECREATE",)
+    output_file = ROOT.TFile.Open(outputFile, *open_args)
+    if not output_file or output_file.IsZombie():
+        raise RuntimeError(f"Cannot open output file: {outputFile}")
+    try:
+        for out_path, sources in trees.items():
+            parts = out_path.split("/")
+            target_dir = get_or_create_dir(output_file, parts[:-1])
+            leaf = parts[-1]
+            chain = ROOT.TChain(sources[0][1])
+            for file_path, _ in sources:
+                chain.Add(file_path)
+            target_dir.cd()
+            existing = target_dir.Get(leaf)
+            if existing:
+                existing.CopyEntries(chain)
+                existing.Write("", ROOT.TObject.kOverwrite)
+            else:
+                new_tree = chain.CloneTree(-1, "fast")
+                new_tree.SetName(leaf)
+                new_tree.Write("", ROOT.TObject.kOverwrite)
 
-                    is_tree = obj_type == "tree"
-                    is_hist = obj_type == "histogram"
-                    if not (
-                        (copyInputTrees and is_tree)
-                        or (copyInputHistograms and is_hist)
-                    ):
-                        if verbose > 1:
-                            print(
-                                f'Skipping object "{input_object_name}" of type "{obj.classname}"'
-                            )
-                        continue
-
-                    out_name = f"{input['name_prefix']}{obj.name}{input['name_suffix']}"
-                    if verbose > 0:
-                        print(
-                            f"{input['file']}/{input_object_name} -> {out_name} (type='{obj.classname}')"
-                        )
-                    if is_hist:
-                        if out_name in histograms:
-                            hist, is_converted = histograms[out_name]
-                            if not is_converted:
-                                hist = hist.to_hist()
-                            new_hist = hist + obj.to_hist()
-                            histograms[out_name] = (new_hist, True)
-                        else:
-                            histograms[out_name] = (obj, False)
-                    else:
-                        if obj.num_entries > 0:
-                            for arrays in obj.iterate(step_size=step_size):
-                                groupped_arrays = defineColumnGrouping(
-                                    arrays, obj.keys(), verbose=min(0, verbose - 1)
-                                )
-                                if out_name in output_file:
-                                    output_file[out_name].extend(groupped_arrays)
-                                else:
-                                    output_file[out_name] = groupped_arrays
-                            stored_with_uproot.add(out_name)
-                        else:
-                            to_store_with_rdf[out_name] = (
-                                input["file"],
-                                input_object_name,
-                            )
-
-        for hist_name, (hist, _) in histograms.items():
-            output_file[hist_name] = hist
-
-    # If the file doesn't exist yet, change snapshot to RECREATE
-    if not os.path.exists(outputFile):
-        snapshotOptions.fMode = "RECREATE"
-    for out_name, (input_file_name, input_name) in to_store_with_rdf.items():
-        if out_name in stored_with_uproot:
-            # Check if the empty tree was already handled by another file
-            continue
-        df = ROOT.RDataFrame(input_name, input_file_name)
-        df.Snapshot(out_name, outputFile, ".*", snapshotOptions)
+        for out_path, hist in histograms.items():
+            parts = out_path.split("/")
+            target_dir = get_or_create_dir(output_file, parts[:-1])
+            leaf = parts[-1]
+            target_dir.cd()
+            existing = target_dir.Get(leaf)
+            if existing:
+                existing.Add(hist)
+                existing.Write(leaf, ROOT.TObject.kOverwrite)
+            else:
+                hist.Write(leaf, ROOT.TObject.kOverwrite)
+    finally:
+        output_file.Close()
+        if saved_dir:
+            saved_dir.cd()
 
 
 if __name__ == "__main__":
@@ -266,9 +299,6 @@ if __name__ == "__main__":
     parser.add_argument(
         "--compression-level", type=int, default=9, help="Compression level"
     )
-    parser.add_argument(
-        "--step-size", type=str, default="100MB", help="Step size for reading TTrees"
-    )
     parser.add_argument("--verbose", type=int, default=1, help="Verbosity level")
     parser.add_argument("inFile", nargs="+", type=str, help="Input ROOT files")
     args = parser.parse_args()
@@ -280,7 +310,6 @@ if __name__ == "__main__":
         copyHistograms=not args.no_copyHistograms,
         appendIfExists=args.appendIfExists,
         verbose=args.verbose,
-        step_size=args.step_size,
         compression_algorithm=args.compression_algorithm,
         compression_level=args.compression_level,
     )

--- a/Common/TupleHelpers.py
+++ b/Common/TupleHelpers.py
@@ -229,17 +229,14 @@ def copyFileContent(
             current = d
         return current
 
-    if appendIfExists and os.path.exists(outputFile):
-        comp_settings = ROOT.ROOT.CompressionSettings(
-            getattr(
-                ROOT.ROOT.RCompressionSetting.EAlgorithm, "k" + compression_algorithm
-            ),
-            compression_level,
-        )
-        open_args = ("UPDATE", "", comp_settings)
-    else:
-        open_args = ("RECREATE",)
-    output_file = ROOT.TFile.Open(outputFile, *open_args)
+    comp_settings = ROOT.ROOT.CompressionSettings(
+        getattr(ROOT.ROOT.RCompressionSetting.EAlgorithm, "k" + compression_algorithm),
+        compression_level,
+    )
+    open_mode = (
+        "UPDATE" if appendIfExists and os.path.exists(outputFile) else "RECREATE"
+    )
+    output_file = ROOT.TFile.Open(outputFile, open_mode, "", comp_settings)
     if not output_file or output_file.IsZombie():
         raise RuntimeError(f"Cannot open output file: {outputFile}")
     try:

--- a/Common/TupleHelpers.py
+++ b/Common/TupleHelpers.py
@@ -238,6 +238,9 @@ def copyFileContent(
     )
 
     try:
+        if not appendIfExists and os.path.exists(outputFile):
+            os.remove(outputFile)
+
         # Phase 1: trees → uproot.
         # Each source is read by its own internal_path and the result is grouped
         # with defineColumnGrouping before writing, preserving the zipped layout.
@@ -270,10 +273,7 @@ def copyFileContent(
         # Phase 2: empty trees + histograms → ROOT.
         if empty_tree_sources or histograms:
             root_open_mode = "UPDATE" if os.path.exists(outputFile) else "RECREATE"
-            if root_open_mode == "RECREATE":
-                root_out = ROOT.TFile.Open(outputFile, "RECREATE", "", root_comp)
-            else:
-                root_out = ROOT.TFile.Open(outputFile, "UPDATE")
+            root_out = ROOT.TFile.Open(outputFile, root_open_mode, "", root_comp)
             if not root_out or root_out.IsZombie():
                 raise RuntimeError(f"Cannot open output file: {outputFile}")
             try:

--- a/Common/TupleHelpers.py
+++ b/Common/TupleHelpers.py
@@ -1,6 +1,7 @@
 import awkward as ak
 import os
 import re
+import uproot
 import ROOT
 
 
@@ -97,6 +98,7 @@ def copyFileContent(
     copyHistograms=True,
     appendIfExists=False,
     verbose=1,
+    step_size="100MB",
     compression_algorithm="LZMA",
     compression_level=9,
 ):
@@ -105,7 +107,7 @@ def copyFileContent(
         print(
             f"copyFileContent: copyTrees={copyTrees}, copyHistograms={copyHistograms}, "
             f"appendIfExists={appendIfExists}, "
-            f"compression={compression_algorithm}({compression_level})"
+            f"compression={compression_algorithm}({compression_level}), step_size={step_size}"
         )
 
     def processInputs(original_inputs):
@@ -229,47 +231,80 @@ def copyFileContent(
             current = d
         return current
 
-    comp_settings = ROOT.ROOT.CompressionSettings(
+    uproot_comp = getattr(uproot, compression_algorithm)(compression_level)
+    root_comp = ROOT.ROOT.CompressionSettings(
         getattr(ROOT.ROOT.RCompressionSetting.EAlgorithm, "k" + compression_algorithm),
         compression_level,
     )
-    open_mode = (
-        "UPDATE" if appendIfExists and os.path.exists(outputFile) else "RECREATE"
-    )
-    output_file = ROOT.TFile.Open(outputFile, open_mode, "", comp_settings)
-    if not output_file or output_file.IsZombie():
-        raise RuntimeError(f"Cannot open output file: {outputFile}")
-    try:
-        for out_path, sources in trees.items():
-            parts = out_path.split("/")
-            target_dir = get_or_create_dir(output_file, parts[:-1])
-            leaf = parts[-1]
-            chain = ROOT.TChain(sources[0][1])
-            for file_path, _ in sources:
-                chain.Add(file_path)
-            target_dir.cd()
-            existing = target_dir.Get(leaf)
-            if existing:
-                existing.CopyEntries(chain)
-                existing.Write("", ROOT.TObject.kOverwrite)
-            else:
-                new_tree = chain.CloneTree(-1, "fast")
-                new_tree.SetName(leaf)
-                new_tree.Write("", ROOT.TObject.kOverwrite)
 
-        for out_path, hist in histograms.items():
-            parts = out_path.split("/")
-            target_dir = get_or_create_dir(output_file, parts[:-1])
-            leaf = parts[-1]
-            target_dir.cd()
-            existing = target_dir.Get(leaf)
-            if existing:
-                existing.Add(hist)
-                existing.Write(leaf, ROOT.TObject.kOverwrite)
+    try:
+        # Phase 1: trees → uproot.
+        # Each source is read by its own internal_path and the result is grouped
+        # with defineColumnGrouping before writing, preserving the zipped layout.
+        written_with_uproot = set()
+        empty_tree_sources = {}  # out_path -> (file_path, internal_path) for schema
+
+        if trees:
+            append_exists = appendIfExists and os.path.exists(outputFile)
+            uproot_open_fn = uproot.update if append_exists else uproot.recreate
+            uproot_open_kwargs = {} if append_exists else {"compression": uproot_comp}
+            with uproot_open_fn(outputFile, **uproot_open_kwargs) as uproot_out:
+                for out_path, sources in trees.items():
+                    for file_path, internal_path in sources:
+                        with uproot.open(f"{file_path}:{internal_path}") as src_tree:
+                            if src_tree.num_entries == 0:
+                                if out_path not in written_with_uproot:
+                                    empty_tree_sources.setdefault(out_path, (file_path, internal_path))
+                                continue
+                            written_with_uproot.add(out_path)
+                            empty_tree_sources.pop(out_path, None)
+                            for arrays in src_tree.iterate(step_size=step_size):
+                                grouped = defineColumnGrouping(arrays, src_tree.keys())
+                                if out_path in uproot_out:
+                                    uproot_out[out_path].extend(grouped)
+                                else:
+                                    uproot_out[out_path] = grouped
+
+        # Phase 2: empty trees + histograms → ROOT.
+        if empty_tree_sources or histograms:
+            root_open_mode = "UPDATE" if os.path.exists(outputFile) else "RECREATE"
+            if root_open_mode == "RECREATE":
+                root_out = ROOT.TFile.Open(outputFile, "RECREATE", "", root_comp)
             else:
-                hist.Write(leaf, ROOT.TObject.kOverwrite)
+                root_out = ROOT.TFile.Open(outputFile, "UPDATE")
+            if not root_out or root_out.IsZombie():
+                raise RuntimeError(f"Cannot open output file: {outputFile}")
+            try:
+                for out_path, (fp, ip) in empty_tree_sources.items():
+                    parts = out_path.split("/")
+                    target_dir = get_or_create_dir(root_out, parts[:-1])
+                    leaf = parts[-1]
+                    target_dir.cd()
+                    if not target_dir.Get(leaf):
+                        src_file = ROOT.TFile.Open(fp, "READ")
+                        if not src_file or src_file.IsZombie():
+                            raise RuntimeError(f"Cannot open source file: {fp}")
+                        try:
+                            cloned = src_file.Get(ip).CloneTree(0)
+                            cloned.SetName(leaf)
+                            cloned.Write("", ROOT.TObject.kOverwrite)
+                        finally:
+                            src_file.Close()
+
+                for out_path, hist in histograms.items():
+                    parts = out_path.split("/")
+                    target_dir = get_or_create_dir(root_out, parts[:-1])
+                    leaf = parts[-1]
+                    target_dir.cd()
+                    existing = target_dir.Get(leaf)
+                    if existing:
+                        existing.Add(hist)
+                        existing.Write(leaf, ROOT.TObject.kOverwrite)
+                    else:
+                        hist.Write(leaf, ROOT.TObject.kOverwrite)
+            finally:
+                root_out.Close()
     finally:
-        output_file.Close()
         if saved_dir:
             saved_dir.cd()
 
@@ -303,6 +338,9 @@ if __name__ == "__main__":
     parser.add_argument(
         "--compression-level", type=int, default=9, help="Compression level"
     )
+    parser.add_argument(
+        "--step-size", type=str, default="100MB", help="Step size for reading TTrees"
+    )
     parser.add_argument("--verbose", type=int, default=1, help="Verbosity level")
     parser.add_argument("inFile", nargs="+", type=str, help="Input ROOT files")
     args = parser.parse_args()
@@ -314,6 +352,7 @@ if __name__ == "__main__":
         copyHistograms=not args.no_copyHistograms,
         appendIfExists=args.appendIfExists,
         verbose=args.verbose,
+        step_size=args.step_size,
         compression_algorithm=args.compression_algorithm,
         compression_level=args.compression_level,
     )

--- a/Common/TupleHelpers.py
+++ b/Common/TupleHelpers.py
@@ -254,7 +254,9 @@ def copyFileContent(
                         with uproot.open(f"{file_path}:{internal_path}") as src_tree:
                             if src_tree.num_entries == 0:
                                 if out_path not in written_with_uproot:
-                                    empty_tree_sources.setdefault(out_path, (file_path, internal_path))
+                                    empty_tree_sources.setdefault(
+                                        out_path, (file_path, internal_path)
+                                    )
                                 continue
                             written_with_uproot.add(out_path)
                             empty_tree_sources.pop(out_path, None)

--- a/Common/TupleHelpers.py
+++ b/Common/TupleHelpers.py
@@ -281,12 +281,12 @@ def copyFileContent(
                     parts = out_path.split("/")
                     target_dir = get_or_create_dir(root_out, parts[:-1])
                     leaf = parts[-1]
-                    target_dir.cd()
                     if not target_dir.Get(leaf):
                         src_file = ROOT.TFile.Open(fp, "READ")
                         if not src_file or src_file.IsZombie():
                             raise RuntimeError(f"Cannot open source file: {fp}")
                         try:
+                            target_dir.cd()
                             cloned = src_file.Get(ip).CloneTree(0)
                             cloned.SetName(leaf)
                             cloned.Write("", ROOT.TObject.kOverwrite)


### PR DESCRIPTION
- Remove MC files that have overlapping lumi-sections. With the current logic, the whole file should be removed to obtain the correct denominator. 
- copyFileContent: moving to the ROOT backend to copy histograms and empty TTrees. The uproot backend has exhibited instability when writing histograms in .root files in some edge cases. The ROOT implementation seems much more robust.