### PR TITLE
Fix crashes on HTCondor due to dependency printouts

### DIFF
--- a/AnaProd/tasks.py
+++ b/AnaProd/tasks.py
@@ -352,6 +352,8 @@ class AnaTupleFileListBuilderTask(Task, HTCondorWorkflow, law.LocalWorkflow):
 
     def requires(self):
         dataset_name, process_group = self.branch_data
+        if not InputFileTask.WF_complete(self):
+            return []
         AnaTuple_map = AnaTupleFileTask.req(
             self, branch=-1, branches=()
         ).create_branch_map()
@@ -509,6 +511,8 @@ class AnaTupleMergeTask(Task, HTCondorWorkflow, law.LocalWorkflow):
             _,
             skip_future_tasks,
         ) = self.branch_data
+        if not InputFileTask.WF_complete(self):
+            return {"root": {}, "json": {}}
         anaTuple_branch_map = AnaTupleFileTask.req(
             self, branch=-1, branches=()
         ).create_branch_map()

--- a/run_tools/law_customizations.py
+++ b/run_tools/law_customizations.py
@@ -294,9 +294,14 @@ class HTCondorWorkflow(law.htcondor.HTCondorWorkflow):
 
     def htcondor_job_file(self):
         from law.job.base import JobInputFile
+
         original = law.util.law_src_path("job", "law_job.sh")
-        custom = os.path.join(os.getenv("ANALYSIS_DATA_PATH"), "law_job_no_print_deps.sh")
-        if not os.path.exists(custom) or os.path.getmtime(original) > os.path.getmtime(custom):
+        custom = os.path.join(
+            os.getenv("ANALYSIS_DATA_PATH"), "law_job_no_print_deps.sh"
+        )
+        if not os.path.exists(custom) or os.path.getmtime(original) > os.path.getmtime(
+            custom
+        ):
             with open(original) as f:
                 content = f.read()
             content = re.sub(r'\bdeps_depth="[0-9]+"', 'deps_depth="0"', content)

--- a/run_tools/law_customizations.py
+++ b/run_tools/law_customizations.py
@@ -3,6 +3,7 @@ import law
 import luigi
 import math
 import os
+import re
 import tempfile
 
 from FLAF.RunKit.run_tools import natural_sort
@@ -274,3 +275,16 @@ class HTCondorWorkflow(law.htcondor.HTCondorWorkflow):
         )
         config.custom_content.append(("RequestCpus", self.n_cpus))
         return config
+
+    def htcondor_job_file(self):
+        from law.job.base import JobInputFile
+        original = law.util.law_src_path("job", "law_job.sh")
+        custom = os.path.join(os.getenv("ANALYSIS_DATA_PATH"), "law_job_no_print_deps.sh")
+        if not os.path.exists(custom) or os.path.getmtime(original) > os.path.getmtime(custom):
+            with open(original) as f:
+                content = f.read()
+            content = re.sub(r'\bdeps_depth="[0-9]+"', 'deps_depth="0"', content)
+            with open(custom, "w") as f:
+                f.write(content)
+            os.chmod(custom, 0o755)
+        return JobInputFile(path=custom, copy=True, share=True, render_job=True)


### PR DESCRIPTION
- Set deps_depth to 0 for remote job printout to reduce I/O
- Add protection in requires if InputFileTask is not ready