### PR TITLE
[AnalysisCacheProducer] producar initialization

### DIFF
--- a/Analysis/AnalysisCacheProducer.py
+++ b/Analysis/AnalysisCacheProducer.py
@@ -9,6 +9,7 @@ import awkward as ak
 import numpy as np
 import sys
 import json
+import inspect
 
 ROOT.EnableThreadSafety()
 
@@ -144,7 +145,13 @@ def createAnalysisCache(
     producer_name = producer_config["producer_name"]
     producers_module = importlib.import_module(producers_module_name)
     producer_class = getattr(producers_module, producer_name)
-    producer = producer_class(producer_config, producer_to_run, period, setup.global_params)
+    producer_params = inspect.signature(producer_class).parameters
+    if "global_params" in producer_params:
+        producer = producer_class(
+            producer_config, producer_to_run, period, setup.global_params
+        )
+    else:
+        producer = producer_class(producer_config, producer_to_run, period)
     saveAs = producer_config.get("save_as", "root")
 
     tmp_fileNames = []
@@ -196,6 +203,7 @@ def createAnalysisCache(
                 )
             else:
                 raise NotImplementedError(f"Unsupported output format `{saveAs}`.")
+
             run_producer(
                 producer,
                 dfw,

--- a/Analysis/AnalysisCacheProducer.py
+++ b/Analysis/AnalysisCacheProducer.py
@@ -144,7 +144,7 @@ def createAnalysisCache(
     producer_name = producer_config["producer_name"]
     producers_module = importlib.import_module(producers_module_name)
     producer_class = getattr(producers_module, producer_name)
-    producer = producer_class(producer_config, producer_to_run, period)
+    producer = producer_class(producer_config, producer_to_run, period, setup.global_params)
     saveAs = producer_config.get("save_as", "root")
 
     tmp_fileNames = []
@@ -196,7 +196,6 @@ def createAnalysisCache(
                 )
             else:
                 raise NotImplementedError(f"Unsupported output format `{saveAs}`.")
-
             run_producer(
                 producer,
                 dfw,


### PR DESCRIPTION
For bbtautau DNN prediction, we need to import the global config in the producer class.
- Now the code looks for input needed for initialization. If "global_params" is an argument the initialization includes also global config file.
- No changes required from bbWW side