### PR TITLE
Fix empty json implementation, add a data check to BtagShape, add MultiThread to Histogramming

### DIFF
--- a/Analysis/AnalysisCacheProducer.py
+++ b/Analysis/AnalysisCacheProducer.py
@@ -69,21 +69,21 @@ def run_producer(
         n_orig = n_orig.GetValue()
         if n_orig == 0:
             print(f"No events to process. Create a fake tree with correct columns.")
-            # Make fake tree with just the right columns but no events to avoid crashing later on
-            with uproot.recreate(outFileName, compression=uprootCompression) as outfile:
-                empty_array = np.array([], dtype=np.float32)
-                empty_full_event_id = np.array([], dtype=np.int64)
-                data_dict = {"FullEventId": empty_full_event_id}
-                for col in expected_columns:
-                    if col != "FullEventId":
-                        data_dict[col] = empty_array
-
-                if save_as == "root":
+            if save_as == "root":
+                # Make fake tree with just the right columns but no events to avoid crashing later on
+                with uproot.recreate(
+                    outFileName, compression=uprootCompression
+                ) as outfile:
+                    empty_array = np.array([], dtype=np.float32)
+                    empty_full_event_id = np.array([], dtype=np.int64)
+                    data_dict = {"FullEventId": empty_full_event_id}
+                    for col in expected_columns:
+                        if col != "FullEventId":
+                            data_dict[col] = empty_array
                     outfile[treeName] = data_dict
-                elif save_as == "json":
-                    final_dict = {}
-                    with open(outFileName, "w") as f:
-                        json.dump(final_dict, f, indent=4)
+            elif save_as == "json":
+                with open(outFileName, "w") as f:
+                    json.dump({}, f, indent=4)
             return
         final_array = None
         final_dict = None

--- a/Analysis/BtagShapeProducer.py
+++ b/Analysis/BtagShapeProducer.py
@@ -11,6 +11,7 @@ class BtagShapeProducer:
         self.payload_name = payload_name
         self.cfg = cfg
         self.weight_module = importlib.import_module(cfg["weight_module"])
+        self.isData = False
 
     def prepare_dfw(self, dfw, dataset):
         self.vars_to_save = [
@@ -18,7 +19,9 @@ class BtagShapeProducer:
         ]
         self.vars_to_save.extend(self.cfg["bins"].keys())
 
-        total_weight = self.weight_module.GetWeight(None, None, None)
+        total_weight = (
+            self.weight_module.GetWeight(None, None, None) if not self.isData else "1"
+        )
         dfw.df = dfw.df.Define("weight_total", f"return {total_weight}")
 
         cols = dfw.df.GetColumnNames()
@@ -80,6 +83,7 @@ class BtagShapeProducer:
         df_is_central,
         isData,
     ):
+        self.isData = isData
         histTupleDef.Initialize()
         histTupleDef.analysis_setup(setup)
 

--- a/Analysis/BtagShapeProducer.py
+++ b/Analysis/BtagShapeProducer.py
@@ -11,7 +11,6 @@ class BtagShapeProducer:
         self.payload_name = payload_name
         self.cfg = cfg
         self.weight_module = importlib.import_module(cfg["weight_module"])
-        self.isData = False
 
     def prepare_dfw(self, dfw, dataset):
         self.vars_to_save = [
@@ -19,9 +18,6 @@ class BtagShapeProducer:
         ]
         self.vars_to_save.extend(self.cfg["bins"].keys())
 
-        # total_weight = (
-        #     self.weight_module.GetWeight(None, None, None) if not self.isData else "1"
-        # )
         total_weight = "final_weight"
         dfw.df = dfw.df.Define("weight_total", f"return {total_weight}")
 
@@ -84,7 +80,6 @@ class BtagShapeProducer:
         df_is_central,
         isData,
     ):
-        self.isData = isData
         histTupleDef.Initialize()
         histTupleDef.analysis_setup(setup)
 

--- a/Analysis/BtagShapeProducer.py
+++ b/Analysis/BtagShapeProducer.py
@@ -19,9 +19,10 @@ class BtagShapeProducer:
         ]
         self.vars_to_save.extend(self.cfg["bins"].keys())
 
-        total_weight = (
-            self.weight_module.GetWeight(None, None, None) if not self.isData else "1"
-        )
+        # total_weight = (
+        #     self.weight_module.GetWeight(None, None, None) if not self.isData else "1"
+        # )
+        total_weight = "final_weight"
         dfw.df = dfw.df.Define("weight_total", f"return {total_weight}")
 
         cols = dfw.df.GetColumnNames()

--- a/Analysis/HistProducerFromNTuple.py
+++ b/Analysis/HistProducerFromNTuple.py
@@ -200,7 +200,10 @@ if __name__ == "__main__":
     parser.add_argument("--compute_rel_weights", type=bool, default=False)
     parser.add_argument("--furtherCut", type=str, default=None)
     parser.add_argument("--LAWrunVersion", required=True, type=str)
+    parser.add_argument("--nMT", type=int, default=8)
     args = parser.parse_args()
+
+    ROOT.EnableImplicitMT(args.nMT)
 
     start = time.time()
 

--- a/Analysis/tasks.py
+++ b/Analysis/tasks.py
@@ -523,6 +523,8 @@ class HistFromNtupleProducerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
             self.ana_path(), "FLAF", "Analysis", "HistProducerFromNTuple.py"
         )
         input_list_remote_target = [inp for inp in self.input()[0]]
+        nMT = f"{self.n_cpus * 2}" if self.effective_workflow == "htcondor" else "8"
+        print(f"Running HistFromNtupleProducer for dataset {dataset_name} on workflow {self.effective_workflow} with nMT={nMT}")
         with contextlib.ExitStack() as stack:
             local_inputs = [
                 stack.enter_context((inp).localize("r")).abspath
@@ -547,6 +549,8 @@ class HistFromNtupleProducerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
                 dataset_name,
                 "--LAWrunVersion",
                 self.version,
+                "--nMT",
+                nMT,
             ]
             if compute_unc_histograms:
                 HistFromNtupleProducer_cmd.extend(

--- a/Analysis/tasks.py
+++ b/Analysis/tasks.py
@@ -524,7 +524,9 @@ class HistFromNtupleProducerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
         )
         input_list_remote_target = [inp for inp in self.input()[0]]
         nMT = f"{self.n_cpus * 2}" if self.effective_workflow == "htcondor" else "8"
-        print(f"Running HistFromNtupleProducer for dataset {dataset_name} on workflow {self.effective_workflow} with nMT={nMT}")
+        print(
+            f"Running HistFromNtupleProducer for dataset {dataset_name} on workflow {self.effective_workflow} with nMT={nMT}"
+        )
         with contextlib.ExitStack() as stack:
             local_inputs = [
                 stack.enter_context((inp).localize("r")).abspath

--- a/include/MT2.h
+++ b/include/MT2.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "Lester_mt2_bisect.h"
+#include <cmath>
 
 // implementation as LLR and as article
 namespace analysis {
@@ -49,5 +50,25 @@ namespace analysis {
         double MT2 = asymm_mt2_lester_bisect::get_mT2(mVisA, pxA, pyA, mVisB, pxB, pyB, pxMiss, pyMiss, chiA, chiB, 0);
         return MT2;
     }
+
+        // Safe wrapper that validates inputs before calling the MT2 routine.
+        // Returns the sentinel value -100.0 when inputs are not finite.
+        template <typename LVector1, typename LVector2, typename LVector3>
+        double Calculate_MT2_safe(const LVector1 &visible1,
+                                  const LVector2 &visible2,
+                                  const LVector3 &invisible,
+                                  const double massHypo1,
+                                  const double massHypo2) {
+            auto finite = [](double x) { return std::isfinite(x); };
+            if (!finite(visible1.mass()) || !finite(visible1.px()) || !finite(visible1.py()))
+                return -100.;
+            if (!finite(visible2.mass()) || !finite(visible2.px()) || !finite(visible2.py()))
+                return -100.;
+            if (!finite(invisible.px()) || !finite(invisible.py()))
+                return -100.;
+            if (!finite(massHypo1) || !finite(massHypo2))
+                return -100.;
+            return Calculate_MT2_func(visible1, visible2, invisible, massHypo1, massHypo2);
+        }
 
 }  // namespace analysis

--- a/include/MT2.h
+++ b/include/MT2.h
@@ -3,7 +3,6 @@
 #pragma once
 
 #include "Lester_mt2_bisect.h"
-#include <cmath>
 
 // implementation as LLR and as article
 namespace analysis {

--- a/include/MT2.h
+++ b/include/MT2.h
@@ -51,24 +51,4 @@ namespace analysis {
         return MT2;
     }
 
-        // Safe wrapper that validates inputs before calling the MT2 routine.
-        // Returns the sentinel value -100.0 when inputs are not finite.
-        template <typename LVector1, typename LVector2, typename LVector3>
-        double Calculate_MT2_safe(const LVector1 &visible1,
-                                  const LVector2 &visible2,
-                                  const LVector3 &invisible,
-                                  const double massHypo1,
-                                  const double massHypo2) {
-            auto finite = [](double x) { return std::isfinite(x); };
-            if (!finite(visible1.mass()) || !finite(visible1.px()) || !finite(visible1.py()))
-                return -100.;
-            if (!finite(visible2.mass()) || !finite(visible2.px()) || !finite(visible2.py()))
-                return -100.;
-            if (!finite(invisible.px()) || !finite(invisible.py()))
-                return -100.;
-            if (!finite(massHypo1) || !finite(massHypo2))
-                return -100.;
-            return Calculate_MT2_func(visible1, visible2, invisible, massHypo1, massHypo2);
-        }
-
 }  // namespace analysis


### PR DESCRIPTION
When the original tree is empty, the uproot array does not loop correctly, so empty structures are required.
Changes are to make the empty json version outside of an uproot recreate to avoid some corruption when creating the json with an open outFile from uproot.

BTag shape was previously not possible for data as the payload tries to get ```HistTupleDef.GetWeight("", "", "")```. This function returns uncs that do not exist for data. Inside HistTupleDef this is only called when not data. I added a ```self.isData``` that is filled when the BTagShape is called, allowing data to pass a BTag weight value of "1.".

This bug was invisible as data does not normally have BTagShape run. When called through ```HistTupleProducerTask``` the dependencies know data should not depend on BTagShape, and therefore this never runs. But the law implementation of AnalysisCache will create a branch for all datasets including data. This means if you run ```AnalysisCacheTask --producer-to-run BtagShape``` then the jobs would crash as data fails.

This fix now makes it safe for data to run, and will create some data BTagShape files. Even though these files will never be used, it adds some computer waste for the sake of simplicity in the law formatting.