### PR TITLE
Branch HistFromNtupleProducerTask per dataset, not per dataset×variable

### DIFF
--- a/AnaProd/tasks.py
+++ b/AnaProd/tasks.py
@@ -121,8 +121,6 @@ class InputFileTask(Task, law.LocalWorkflow):
 class AnaTupleFileTask(Task, HTCondorWorkflow, law.LocalWorkflow):
     max_runtime = copy_param(HTCondorWorkflow.max_runtime, 40.0)
     n_cpus = copy_param(HTCondorWorkflow.n_cpus, 2)
-    # issue #264: many branches (~nTotalFiles) -> group several per HTCondor job by default.
-    tasks_per_job = copy_param(HTCondorWorkflow.tasks_per_job, 10)
 
     @property
     def bundle_flavours(self):
@@ -334,8 +332,6 @@ class AnaTupleFileTask(Task, HTCondorWorkflow, law.LocalWorkflow):
 class AnaTupleFileListBuilderTask(Task, HTCondorWorkflow, law.LocalWorkflow):
     max_runtime = copy_param(HTCondorWorkflow.max_runtime, 24.0)
     n_cpus = copy_param(HTCondorWorkflow.n_cpus, 1)
-    # issue #264: group several branches per HTCondor job by default.
-    tasks_per_job = copy_param(HTCondorWorkflow.tasks_per_job, 10)
     bundle_flavours = ["core", "inputFileList"]
 
     def __init__(self, *args, **kwargs):
@@ -531,8 +527,6 @@ class AnaTupleFileListTask(AnaTupleFileListBuilderTask):
 class AnaTupleMergeTask(Task, HTCondorWorkflow, law.LocalWorkflow):
     max_runtime = copy_param(HTCondorWorkflow.max_runtime, 48.0)
     n_cpus = copy_param(HTCondorWorkflow.n_cpus, 2)
-    # issue #264: many branches (~nTotalFiles) -> group several per HTCondor job by default.
-    tasks_per_job = copy_param(HTCondorWorkflow.tasks_per_job, 10)
     delete_inputs_after_merge = luigi.BoolParameter(default=False)
     bundle_flavours = ["core", "inputFileList", "AnaTupleFileList"]
 

--- a/AnaProd/tasks.py
+++ b/AnaProd/tasks.py
@@ -121,6 +121,8 @@ class InputFileTask(Task, law.LocalWorkflow):
 class AnaTupleFileTask(Task, HTCondorWorkflow, law.LocalWorkflow):
     max_runtime = copy_param(HTCondorWorkflow.max_runtime, 40.0)
     n_cpus = copy_param(HTCondorWorkflow.n_cpus, 2)
+    # issue #264: many branches (~nTotalFiles) -> group several per HTCondor job by default.
+    tasks_per_job = copy_param(HTCondorWorkflow.tasks_per_job, 10)
 
     @property
     def bundle_flavours(self):
@@ -332,6 +334,8 @@ class AnaTupleFileTask(Task, HTCondorWorkflow, law.LocalWorkflow):
 class AnaTupleFileListBuilderTask(Task, HTCondorWorkflow, law.LocalWorkflow):
     max_runtime = copy_param(HTCondorWorkflow.max_runtime, 24.0)
     n_cpus = copy_param(HTCondorWorkflow.n_cpus, 1)
+    # issue #264: group several branches per HTCondor job by default.
+    tasks_per_job = copy_param(HTCondorWorkflow.tasks_per_job, 10)
     bundle_flavours = ["core", "inputFileList"]
 
     def __init__(self, *args, **kwargs):
@@ -527,6 +531,8 @@ class AnaTupleFileListTask(AnaTupleFileListBuilderTask):
 class AnaTupleMergeTask(Task, HTCondorWorkflow, law.LocalWorkflow):
     max_runtime = copy_param(HTCondorWorkflow.max_runtime, 48.0)
     n_cpus = copy_param(HTCondorWorkflow.n_cpus, 2)
+    # issue #264: many branches (~nTotalFiles) -> group several per HTCondor job by default.
+    tasks_per_job = copy_param(HTCondorWorkflow.tasks_per_job, 10)
     delete_inputs_after_merge = luigi.BoolParameter(default=False)
     bundle_flavours = ["core", "inputFileList", "AnaTupleFileList"]
 

--- a/Analysis/HistProducerFromNTuple.py
+++ b/Analysis/HistProducerFromNTuple.py
@@ -273,7 +273,7 @@ if __name__ == "__main__":
             )
     print(uncs_to_compute)
 
-    vars_to_process = [v.strip() for v in args.vars.split(",")]
+    vars_to_process = [v.strip() for v in args.vars.split(",") if v.strip()]
     os.makedirs(args.outDir, exist_ok=True)
 
     if all_trees:

--- a/Analysis/HistProducerFromNTuple.py
+++ b/Analysis/HistProducerFromNTuple.py
@@ -36,13 +36,11 @@ def SaveHist(key_tuple, outFile, hist_list, hist_name, unc, scale, verbose=0):
     dir_ptr = Utilities.mkdir(outFile, dir_name)
 
     merged_hist = model.GetHistogram().Clone()
-    # If we use the THnD then we have 'GetNbins' function, else use 'GetNcells'
     N_bins = (
         unit_hist.GetNbins()
         if hasattr(unit_hist, "GetNbins")
         else unit_hist.GetNcells()
     )
-    # This can be a loop over many bins, several times. Can be improved to be ran in c++ instead
     for i in range(0, N_bins):
         bin_content = unit_hist.GetBinContent(i)
         bin_error = unit_hist.GetBinError(i)
@@ -68,7 +66,7 @@ def SaveHist(key_tuple, outFile, hist_list, hist_name, unc, scale, verbose=0):
 
 
 def GetUnitBinHist(rdf, var, filter_to_apply, weight_name, unc, scale):
-    var_entry = HistHelper.findBinEntry(hist_cfg_dict, args.var)
+    var_entry = HistHelper.findBinEntry(hist_cfg_dict, var)
     dims = (
         1
         if not hist_cfg_dict[var_entry].get("var_list", False)
@@ -79,7 +77,7 @@ def GetUnitBinHist(rdf, var, filter_to_apply, weight_name, unc, scale):
         hist_cfg_dict, var, dims, return_unit_bin_model=True
     )
     var_bin_list = (
-        [f"{var}_bin" for var in hist_cfg_dict[var_entry]["var_list"]]
+        [f"{v}_bin" for v in hist_cfg_dict[var_entry]["var_list"]]
         if dims > 1
         else [f"{var}_bin"]
     )
@@ -131,8 +129,8 @@ def SaveSingleHistSet(
     return save_fn
 
 
-def SaveTmpFileUnc(
-    tmp_files,
+def BuildHistActions(
+    tmp_file_root,
     uncs_to_compute,
     unc_cfg_dict,
     all_trees,
@@ -141,15 +139,17 @@ def SaveTmpFileUnc(
     further_cuts,
     treeName,
 ):
-    tmp_file = f"tmp_{var}.root"
-    tmp_file_root = ROOT.TFile(tmp_file, "RECREATE")
+    """Register all histogram actions for var against the open TFile.
+
+    Returns a list of save_fn callables without triggering the RDF event loop
+    or closing the file. Call all returned functions after collecting actions
+    for every variable so ROOT can execute them in a single event-loop pass.
+    """
     save_fns = []
     for unc, scales in uncs_to_compute.items():
         is_shift_unc = unc in unc_cfg_dict["shape"].keys()
-
         for scale in scales:
             for key, filter_to_apply_base in key_filter_dict.items():
-                filter_to_apply_final = filter_to_apply_base
                 if further_cuts:
                     for further_cut_name in further_cuts.keys():
                         filter_to_apply_final = (
@@ -172,7 +172,7 @@ def SaveTmpFileUnc(
                     save_fn = SaveSingleHistSet(
                         all_trees,
                         var,
-                        filter_to_apply_final,
+                        filter_to_apply_base,
                         unc,
                         scale,
                         key,
@@ -181,21 +181,18 @@ def SaveTmpFileUnc(
                         treeName,
                     )
                     save_fns.append(save_fn)
-    for fn in save_fns:
-        fn()
-    tmp_file_root.Close()
-    tmp_files.append(tmp_file)
+    return save_fns
 
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("inputFiles", nargs="+", type=str)
     parser.add_argument("--period", required=True, type=str)
-    parser.add_argument("--outFile", required=True, type=str)
+    parser.add_argument("--outDir", required=True, type=str)
     parser.add_argument("--dataset_name", required=True, type=str)
     parser.add_argument("--customisations", type=str, default=None)
     parser.add_argument("--channels", type=str, default=None)
-    parser.add_argument("--var", type=str, default=None)
+    parser.add_argument("--vars", required=True, type=str)
     parser.add_argument("--compute_unc_variations", type=bool, default=False)
     parser.add_argument("--compute_rel_weights", type=bool, default=False)
     parser.add_argument("--furtherCut", type=str, default=None)
@@ -220,8 +217,6 @@ if __name__ == "__main__":
     treeName = setup.global_params["treeName"]
     all_infiles = [fileName for fileName in args.inputFiles]
     unique_keys = find_keys(all_infiles)
-    inFiles = Utilities.ListToVector(all_infiles)
-    base_rdfs = {}
 
     hist_cfg_dict = setup.hists
 
@@ -232,10 +227,10 @@ if __name__ == "__main__":
     )
     setup.global_params["channels_to_consider"] = channels
 
+    base_rdfs = {}
     for key in unique_keys:
         if not key.startswith(treeName):
             continue
-
         base_rdfs[key] = ROOT.RDataFrame(key, Utilities.ListToVector(all_infiles))
         ROOT.RDF.Experimental.AddProgressBar(base_rdfs[key])
 
@@ -245,22 +240,10 @@ if __name__ == "__main__":
     if "further_cuts" in setup.global_params and setup.global_params["further_cuts"]:
         further_cuts.update(setup.global_params["further_cuts"])
     print(further_cuts)
+
     key_filter_dict = analysis.createKeyFilterDict(
         setup.global_params, setup.global_params["era"]
     )
-
-    variables = setup.global_params["variables"]
-    vars_needed = set()
-    for var in variables:
-        if isinstance(var, dict) and "vars" in var:
-            for v in var["vars"]:
-                vars_needed.add(v)
-        else:
-            vars_needed.add(var)
-    for further_cut_name, (vars_for_cut, _) in further_cuts.items():
-        for var_for_cut in vars_for_cut:
-            if var_for_cut:
-                vars_needed.add(var_for_cut)
 
     all_trees = {}
     for tree_name, rdf in base_rdfs.items():
@@ -288,25 +271,41 @@ if __name__ == "__main__":
             )
     print(uncs_to_compute)
 
-    tmp_files = []
+    vars_to_process = [v.strip() for v in args.vars.split(",")]
+    os.makedirs(args.outDir, exist_ok=True)
+
     if all_trees:
-        SaveTmpFileUnc(
-            tmp_files,
-            uncs_to_compute,
-            unc_cfg_dict,
-            all_trees,
-            args.var,
-            key_filter_dict,
-            further_cuts,
-            treeName,
-        )
+        # Open a tmp ROOT file per variable and register all histogram actions.
+        # Collecting actions for all variables before triggering lets ROOT execute
+        # them in a single event-loop pass over the input files.
+        var_tmp_files = {}
+        all_save_fns = []
+        for var in vars_to_process:
+            tmp_path = os.path.join(args.outDir, f"tmp_{var}.root")
+            tmp_root_file = ROOT.TFile(tmp_path, "RECREATE")
+            var_tmp_files[var] = (tmp_path, tmp_root_file)
+            fns = BuildHistActions(
+                tmp_root_file,
+                uncs_to_compute,
+                unc_cfg_dict,
+                all_trees,
+                var,
+                key_filter_dict,
+                further_cuts,
+                treeName,
+            )
+            all_save_fns.extend(fns)
 
-    if tmp_files:
-        hadd_str = f"hadd -f209 -j -O {args.outFile} " + " ".join(tmp_files)
-        ps_call([hadd_str], True)
+        for fn in all_save_fns:
+            fn()
 
-    for f in tmp_files:
-        if os.path.exists(f):
-            os.remove(f)
+        for var in vars_to_process:
+            tmp_path, tmp_root_file = var_tmp_files[var]
+            tmp_root_file.Close()
+            out_path = os.path.join(args.outDir, f"{var}.root")
+            hadd_str = f"hadd -f209 -j -O {out_path} {tmp_path}"
+            ps_call([hadd_str], True)
+            os.remove(tmp_path)
+
     time_elapsed = time.time() - start
     print(f"execution time = {time_elapsed} ")

--- a/Analysis/HistProducerFromNTuple.py
+++ b/Analysis/HistProducerFromNTuple.py
@@ -198,6 +198,7 @@ if __name__ == "__main__":
     parser.add_argument("--furtherCut", type=str, default=None)
     parser.add_argument("--LAWrunVersion", required=True, type=str)
     parser.add_argument("--nMT", type=int, default=8)
+    parser.add_argument("--user-custom", type=str, default=None)
     args = parser.parse_args()
 
     ROOT.EnableImplicitMT(args.nMT)
@@ -209,6 +210,7 @@ if __name__ == "__main__":
         args.period,
         args.LAWrunVersion,
         customisations=args.customisations,
+        user_custom_file=args.user_custom,
     )
     unc_cfg_dict = setup.weights_config
     analysis_import = setup.global_params["analysis_import"]

--- a/Analysis/HistTupleProducer.py
+++ b/Analysis/HistTupleProducer.py
@@ -221,6 +221,7 @@ if __name__ == "__main__":
     parser.add_argument("--nEvents", type=int, default=None)
     parser.add_argument("--evtIds", type=str, default=None)
     parser.add_argument("--LAWrunVersion", required=True, type=str)
+    parser.add_argument("--user-custom", type=str, default=None)
 
     args = parser.parse_args()
     startTime = time.time()
@@ -229,7 +230,10 @@ if __name__ == "__main__":
     ROOT.gROOT.ProcessLine('#include "include/Utilities.h"')
 
     setup = Setup.getGlobal(
-        os.environ["ANALYSIS_PATH"], args.period, args.LAWrunVersion
+        os.environ["ANALYSIS_PATH"],
+        args.period,
+        args.LAWrunVersion,
+        user_custom_file=args.user_custom,
     )
 
     setup.global_params["channels_to_consider"] = (

--- a/Analysis/tasks.py
+++ b/Analysis/tasks.py
@@ -395,6 +395,8 @@ class HistTupleProducerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
                 )
             if self.customisations:
                 HistTupleProducer_cmd.extend([f"--customisations", self.customisations])
+            if self.user_custom:
+                HistTupleProducer_cmd.extend(["--user-custom", self.user_custom])
             if len(producer_list) > 0:
                 local_anacaches = {}
                 for producer_name, cache_file in self.input()["anaCaches"].items():
@@ -639,6 +641,8 @@ class HistFromNtupleProducerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
                     )
                 if self.customisations:
                     cmd.extend(["--customisations", self.customisations])
+                if self.user_custom:
+                    cmd.extend(["--user-custom", self.user_custom])
                 cmd.extend(curr["files"])
                 ps_call(cmd, verbose=1)
 

--- a/Analysis/tasks.py
+++ b/Analysis/tasks.py
@@ -621,6 +621,8 @@ class HistMergerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
         hfn_branch_map = HistFromNtupleProducerTask.req(
             self, branches=()
         ).create_branch_map()
+        if not hfn_branch_map:
+            return {}
         # Each HFN branch covers one dataset and all variables.
         # Build parallel lists of HFN branch indices and dataset names.
         hfn_br_indices = []

--- a/Analysis/tasks.py
+++ b/Analysis/tasks.py
@@ -23,7 +23,7 @@ from FLAF.Common.Utilities import getCustomisationSplit, ServiceThread
 class HistTupleProducerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
     max_runtime = copy_param(HTCondorWorkflow.max_runtime, 5.0)
     n_cpus = copy_param(HTCondorWorkflow.n_cpus, 4)
-    # issue #264: many branches (~nTotalFiles) -> group several per HTCondor job by default.
+    # many short per-file branches: group several per HTCondor job to bound nJobs.
     tasks_per_job = copy_param(HTCondorWorkflow.tasks_per_job, 10)
 
     @property
@@ -435,8 +435,6 @@ class HistTupleProducerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
 class HistFromNtupleProducerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
     max_runtime = copy_param(HTCondorWorkflow.max_runtime, 10.0)
     n_cpus = copy_param(HTCondorWorkflow.n_cpus, 2)
-    # issue #264: many branches (nDatasets x nVariableBatches) -> group per HTCondor job.
-    tasks_per_job = copy_param(HTCondorWorkflow.tasks_per_job, 10)
     variables = luigi.Parameter(default="")
     vars_per_batch = luigi.IntParameter(default=20)
     files_chunk_size = luigi.IntParameter(default=10)
@@ -965,8 +963,6 @@ class HistMergerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
 class AnalysisCacheTask(Task, HTCondorWorkflow, law.LocalWorkflow):
     max_runtime = copy_param(HTCondorWorkflow.max_runtime, 2.0)
     n_cpus = copy_param(HTCondorWorkflow.n_cpus, 1)
-    # issue #264: many branches (~nTotalFiles) -> group several per HTCondor job by default.
-    tasks_per_job = copy_param(HTCondorWorkflow.tasks_per_job, 10)
     producer_to_run = luigi.Parameter()
 
     @property
@@ -1478,8 +1474,6 @@ class HistPlotTask(Task, HTCondorWorkflow, law.LocalWorkflow):
 class AnalysisCacheAggregationTask(Task, HTCondorWorkflow, law.LocalWorkflow):
     max_runtime = copy_param(HTCondorWorkflow.max_runtime, 2.0)
     n_cpus = copy_param(HTCondorWorkflow.n_cpus, 1)
-    # issue #264: group several branches per HTCondor job by default.
-    tasks_per_job = copy_param(HTCondorWorkflow.tasks_per_job, 10)
     producer_to_aggregate = luigi.Parameter()
 
     @property

--- a/Analysis/tasks.py
+++ b/Analysis/tasks.py
@@ -436,9 +436,8 @@ class HistFromNtupleProducerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
             )
             return req_dict
         branch_set = set()
-        for br_idx, (var, prod_br_list, dataset_names) in self.branch_map.items():
-            if var in self.global_params["variables"]:
-                branch_set.update(prod_br_list)
+        for br_idx, (dataset_name, prod_br_list) in self.branch_map.items():
+            branch_set.update(prod_br_list)
         branches = tuple(branch_set)
         req_dict = {
             "HistTupleProducerTask": HistTupleProducerTask.req(
@@ -448,9 +447,8 @@ class HistFromNtupleProducerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
         return req_dict
 
     def requires(self):
-        var, prod_br_list, dataset_name = self.branch_data
-        reqs = []
-        reqs.append(
+        dataset_name, prod_br_list = self.branch_data
+        return [
             HistTupleProducerTask.req(
                 self,
                 max_runtime=HistTupleProducerTask.max_runtime._default,
@@ -458,8 +456,7 @@ class HistFromNtupleProducerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
                 customisations=self.customisations,
             )
             for prod_br in prod_br_list
-        )
-        return reqs
+        ]
 
     @law.dynamic_workflow_condition
     def workflow_condition(self):
@@ -468,8 +465,6 @@ class HistFromNtupleProducerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
     @workflow_condition.create_branch_map
     def create_branch_map(self):
         branches = {}
-        prod_br_list = []
-        current_dataset = None
         n = 0
 
         dataset_to_branches = {}
@@ -486,24 +481,29 @@ class HistFromNtupleProducerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
             dataset_to_branches.setdefault(histTuple_dataset_name, []).append(prod_br)
 
         for dataset_name, prod_br_list in dataset_to_branches.items():
-            for var_name in self.global_params["variables"]:
-                branches[n] = (var_name, prod_br_list, dataset_name)
-                n += 1
+            branches[n] = (dataset_name, prod_br_list)
+            n += 1
 
         return branches
 
     @workflow_condition.output
     def output(self):
-        var, prod_br, dataset_name = self.branch_data
-        if isinstance(var, dict):
-            var = var["name"]
-        output_path = os.path.join(
-            self.version, "Hists_split", self.period, var, f"{dataset_name}.root"
-        )
-        return self.remote_target(output_path, fs=self.fs_HistTuple)
+        dataset_name, prod_br_list = self.branch_data
+        outputs = {}
+        for var in self.global_params["variables"]:
+            var_name = var["name"] if isinstance(var, dict) else var
+            output_path = os.path.join(
+                self.version,
+                "Hists_split",
+                self.period,
+                var_name,
+                f"{dataset_name}.root",
+            )
+            outputs[var_name] = self.remote_target(output_path, fs=self.fs_HistTuple)
+        return outputs
 
     def run(self):
-        var, prod_br, dataset_name = self.branch_data
+        dataset_name, prod_br_list = self.branch_data
         job_home, remove_job_home = self.law_job_home()
         customisation_dict = getCustomisationSplit(self.customisations)
         channels = (
@@ -511,7 +511,6 @@ class HistFromNtupleProducerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
             if "channels" in customisation_dict.keys()
             else self.global_params["channelSelection"]
         )
-        # Channels from the yaml are a list, but the format we need for the ps_call later is 'ch1,ch2,ch3', basically join into a string separated by comma
         if type(channels) == list:
             channels = ",".join(channels)
         compute_unc_histograms = (
@@ -522,60 +521,46 @@ class HistFromNtupleProducerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
         HistFromNtupleProducer = os.path.join(
             self.ana_path(), "FLAF", "Analysis", "HistProducerFromNTuple.py"
         )
-        input_list_remote_target = [inp for inp in self.input()[0]]
         with contextlib.ExitStack() as stack:
             local_inputs = [
-                stack.enter_context((inp).localize("r")).abspath
-                for inp in self.input()[0]
+                stack.enter_context(inp.localize("r")).abspath for inp in self.input()
             ]
-
-            var = var if type(var) != dict else var["name"]
-            tmpFile = os.path.join(job_home, f"HistFromNtuple_{var}.root")
-
-            HistFromNtupleProducer_cmd = [
-                "python3",
-                HistFromNtupleProducer,
-                "--period",
-                self.period,
-                "--outFile",
-                tmpFile,
-                "--channels",
-                channels,
-                "--var",
-                var,
-                "--dataset_name",
-                dataset_name,
-                "--LAWrunVersion",
-                self.version,
-            ]
-            if compute_unc_histograms:
-                HistFromNtupleProducer_cmd.extend(
-                    [
-                        "--compute_rel_weights",
-                        "True",
-                        "--compute_unc_variations",
-                        "True",
-                    ]
-                )
-            if self.customisations:
-                HistFromNtupleProducer_cmd.extend(
-                    [f"--customisations", self.customisations]
-                )
-
-            HistFromNtupleProducer_cmd.extend(local_inputs)
-            ps_call(HistFromNtupleProducer_cmd, verbose=1)
-
-        with (self.output()).localize("w") as tmp_local_file:
-            out_local_path = tmp_local_file.abspath
-            shutil.move(tmpFile, out_local_path)
-
-        delete_after_merge = False  # var == self.global_config["variables"][-1] --> find more robust condition
-        if delete_after_merge:
-            print(f"Finished HistogramProducer, lets delete remote targets")
-            for remote_target in input_list_remote_target:
-                remote_target.remove()
-                with remote_target.localize("w") as tmp_local_file:
-                    tmp_local_file.touch()  # Create a dummy to avoid dependency crashes
+            for var in self.global_params["variables"]:
+                var_name = var["name"] if isinstance(var, dict) else var
+                tmpFile = os.path.join(job_home, f"HistFromNtuple_{var_name}.root")
+                HistFromNtupleProducer_cmd = [
+                    "python3",
+                    HistFromNtupleProducer,
+                    "--period",
+                    self.period,
+                    "--outFile",
+                    tmpFile,
+                    "--channels",
+                    channels,
+                    "--var",
+                    var_name,
+                    "--dataset_name",
+                    dataset_name,
+                    "--LAWrunVersion",
+                    self.version,
+                ]
+                if compute_unc_histograms:
+                    HistFromNtupleProducer_cmd.extend(
+                        [
+                            "--compute_rel_weights",
+                            "True",
+                            "--compute_unc_variations",
+                            "True",
+                        ]
+                    )
+                if self.customisations:
+                    HistFromNtupleProducer_cmd.extend(
+                        ["--customisations", self.customisations]
+                    )
+                HistFromNtupleProducer_cmd.extend(local_inputs)
+                ps_call(HistFromNtupleProducer_cmd, verbose=1)
+                with self.output()[var_name].localize("w") as tmp_local_file:
+                    shutil.move(tmpFile, tmp_local_file.abspath)
 
         if remove_job_home:
             shutil.rmtree(job_home)
@@ -605,14 +590,9 @@ class HistMergerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
                 ),
             }
 
-        branch_set = set()
-        all_datasets = {}
-        for br_idx, (var, prod_br_list, dataset_names) in self.branch_map.items():
-            all_datasets[var] = prod_br_list
-
         new_branchset = set()
-        for var in all_datasets.keys():
-            new_branchset.update(all_datasets[var])
+        for br_idx, (var_name, hfn_br_list, dataset_names) in self.branch_map.items():
+            new_branchset.update(hfn_br_list)
 
         return {
             "HistFromNtupleProducerTask": HistFromNtupleProducerTask.req(
@@ -622,17 +602,15 @@ class HistMergerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
 
     def requires(self):
         var_name, br_indices, datasets = self.branch_data
-        reqs = [
+        return [
             HistFromNtupleProducerTask.req(
                 self,
                 max_runtime=HistFromNtupleProducerTask.max_runtime._default,
-                branch=prod_br,
+                branch=br_idx,
                 customisations=self.customisations,
             )
-            for prod_br in tuple(set(br_indices))
+            for br_idx in br_indices
         ]
-
-        return reqs
 
     @law.dynamic_workflow_condition
     def workflow_condition(self):
@@ -640,34 +618,21 @@ class HistMergerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
 
     @workflow_condition.create_branch_map
     def create_branch_map(self):
-        HistFromNtupleProducerTask_branch_map = HistFromNtupleProducerTask.req(
+        hfn_branch_map = HistFromNtupleProducerTask.req(
             self, branches=()
         ).create_branch_map()
-        all_datasets = {}
+        # Each HFN branch covers one dataset and all variables.
+        # Build parallel lists of HFN branch indices and dataset names.
+        hfn_br_indices = []
+        dataset_names = []
+        for br_idx, (dataset_name, _) in hfn_branch_map.items():
+            hfn_br_indices.append(br_idx)
+            dataset_names.append(dataset_name)
+        # One HistMerger branch per variable.
         branches = {}
-        k = 0
-        for br_idx, (
-            var_name,
-            prod_br_list,
-            current_dataset,
-        ) in HistFromNtupleProducerTask_branch_map.items():
-            var_name = (
-                var_name.get("name", var_name)
-                if isinstance(var_name, dict)
-                else var_name
-            )
-            if var_name not in all_datasets.keys():
-                all_datasets[var_name] = []
-            all_datasets[var_name].append((br_idx, current_dataset))
-        for var_name, br_list in all_datasets.items():
-            br_indices = []
-            datasets = []
-            for key in br_list:
-                idx, dataset_name = key
-                br_indices.append(idx)
-                datasets.append(dataset_name)
-            branches[k] = (var_name, br_indices, datasets)
-            k += 1
+        for k, var in enumerate(self.global_params["variables"]):
+            var_name = var["name"] if isinstance(var, dict) else var
+            branches[k] = (var_name, hfn_br_indices, dataset_names)
         return branches
 
     @workflow_condition.output
@@ -721,9 +686,11 @@ class HistMergerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
         local_inputs = []
         with contextlib.ExitStack() as stack:
             for inp in self.input():
-                dataset_name = os.path.basename(inp.abspath)
-                all_datasets.append(dataset_name.split(".")[0])
-                local_inputs.append(stack.enter_context(inp.localize("r")).abspath)
+                # Each inp is a dict {var_name: FileTarget} from HistFromNtupleProducerTask.
+                var_file = inp[var_name]
+                dataset_name = os.path.basename(var_file.abspath).split(".")[0]
+                all_datasets.append(dataset_name)
+                local_inputs.append(stack.enter_context(var_file.localize("r")).abspath)
             dataset_names = ",".join(smpl for smpl in all_datasets)
             all_outputs_merged = []
             if len(uncNames) == 1:

--- a/Analysis/tasks.py
+++ b/Analysis/tasks.py
@@ -2,8 +2,9 @@ import law
 import os
 import contextlib
 import luigi
+import queue
 import shutil
-import threading
+from concurrent.futures import ThreadPoolExecutor
 
 
 from FLAF.RunKit.run_tools import ps_call
@@ -22,6 +23,8 @@ from FLAF.Common.Utilities import getCustomisationSplit, ServiceThread
 class HistTupleProducerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
     max_runtime = copy_param(HTCondorWorkflow.max_runtime, 5.0)
     n_cpus = copy_param(HTCondorWorkflow.n_cpus, 4)
+    # issue #264: many branches (~nTotalFiles) -> group several per HTCondor job by default.
+    tasks_per_job = copy_param(HTCondorWorkflow.tasks_per_job, 10)
 
     @property
     def bundle_flavours(self):
@@ -432,6 +435,8 @@ class HistTupleProducerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
 class HistFromNtupleProducerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
     max_runtime = copy_param(HTCondorWorkflow.max_runtime, 10.0)
     n_cpus = copy_param(HTCondorWorkflow.n_cpus, 2)
+    # issue #264: many branches (nDatasets x nVariableBatches) -> group per HTCondor job.
+    tasks_per_job = copy_param(HTCondorWorkflow.tasks_per_job, 10)
     variables = luigi.Parameter(default="")
     vars_per_batch = luigi.IntParameter(default=20)
     files_chunk_size = luigi.IntParameter(default=10)
@@ -476,7 +481,7 @@ class HistFromNtupleProducerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
             )
             return reqs
         branch_set = set()
-        for br_idx, (dataset_name, prod_br_list) in self.branch_map.items():
+        for br_idx, (dataset_name, prod_br_list, var_batch) in self.branch_map.items():
             branch_set.update(prod_br_list)
         branches = tuple(sorted(branch_set))
         reqs["HistTupleProducerTask"] = HistTupleProducerTask.req(
@@ -487,7 +492,7 @@ class HistFromNtupleProducerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
         return reqs
 
     def requires(self):
-        dataset_name, prod_br_list = self.branch_data
+        dataset_name, prod_br_list, var_batch = self.branch_data
         return [
             HistTupleProducerTask.req(
                 self,
@@ -524,18 +529,35 @@ class HistFromNtupleProducerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
         ) in HistTupleBranchMap.items():
             dataset_to_branches.setdefault(histTuple_dataset_name, []).append(prod_br)
 
+        # Variable batching happens here (issue #257): each (dataset, variable-batch)
+        # is its own branch/job, so a job localizes the dataset inputs once and produces
+        # the histograms for just its batch of variables — avoiding the old
+        # (nDatasets x nVariables) re-localization while still parallelizing across
+        # batches. vars_per_batch <= 0 means "all variables in one batch" (one job
+        # per dataset, the extreme of issue #257).
+        all_var_names = [
+            v["name"] if isinstance(v, dict) else v for v in self.active_variables
+        ]
+        batch_size = (
+            self.vars_per_batch if self.vars_per_batch > 0 else len(all_var_names)
+        )
+        var_batches = [
+            all_var_names[i : i + batch_size]
+            for i in range(0, len(all_var_names), max(1, batch_size))
+        ]
+
         for dataset_name, prod_br_list in sorted(dataset_to_branches.items()):
-            branches[n] = (dataset_name, prod_br_list)
-            n += 1
+            for var_batch in var_batches:
+                branches[n] = (dataset_name, sorted(prod_br_list), var_batch)
+                n += 1
 
         return branches
 
     @workflow_condition.output
     def output(self):
-        dataset_name, prod_br_list = self.branch_data
+        dataset_name, prod_br_list, var_batch = self.branch_data
         outputs = {}
-        for var in self.active_variables:
-            var_name = var["name"] if isinstance(var, dict) else var
+        for var_name in var_batch:
             output_path = os.path.join(
                 self.version,
                 "Hists_split",
@@ -547,7 +569,7 @@ class HistFromNtupleProducerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
         return outputs
 
     def run(self):
-        dataset_name, prod_br_list = self.branch_data
+        dataset_name, prod_br_list, var_batch = self.branch_data
         job_home, remove_job_home = self.law_job_home()
         customisation_dict = getCustomisationSplit(self.customisations)
         channels = (
@@ -567,133 +589,152 @@ class HistFromNtupleProducerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
         )
         nMT = self.n_cpus * 2 if self.effective_workflow == "htcondor" else 8
 
-        # Determine which variables still need to be produced.
-        vars_to_run = [
-            var["name"] if isinstance(var, dict) else var
-            for var in self.active_variables
-            if not self.output()[var["name"] if isinstance(var, dict) else var].exists()
-        ]
+        # Determine which variables of this batch still need to be produced.
+        outputs = self.output()
+        vars_to_run = [v for v in var_batch if not outputs[v].exists()]
         if not vars_to_run:
-            print(f"All outputs already exist for dataset {dataset_name}, skipping")
+            print(
+                f"All outputs already exist for dataset {dataset_name} "
+                f"batch {var_batch}, skipping"
+            )
             if remove_job_home:
                 shutil.rmtree(job_home)
             return
 
-        # Split variables into batches so HistProducerFromNTuple processes
-        # vars_per_batch variables per invocation (limits peak memory usage).
-        batch_size = (
-            self.vars_per_batch if self.vars_per_batch > 0 else len(vars_to_run)
-        )
-        var_batches = [
-            vars_to_run[i : i + batch_size]
-            for i in range(0, len(vars_to_run), batch_size)
-        ]
+        inputs = list(self.input())
+        n_inputs = len(inputs)
 
-        # Split input files into chunks so local disk usage is bounded.
-        # While HistProducerFromNTuple processes chunk N, chunk N+1 is
-        # downloaded in a background thread.
-        all_inputs = self.input()
-        chunk_size = (
-            self.files_chunk_size if self.files_chunk_size > 0 else len(all_inputs)
-        )
-        file_chunks = [
-            all_inputs[i : i + chunk_size]
-            for i in range(0, len(all_inputs), chunk_size)
-        ]
-
-        chunk_outputs = {var: [] for var in vars_to_run}
-
-        def _download(chunk_inputs, result):
-            stack = contextlib.ExitStack()
-            try:
-                result["files"] = [
-                    stack.enter_context(inp.localize("r")).abspath
-                    for inp in chunk_inputs
-                ]
-                result["stack"] = stack
-            except Exception as e:
-                stack.close()
-                result["error"] = e
-
-        # Download the first chunk synchronously before entering the loop.
-        curr = {}
-        _download(file_chunks[0], curr)
-        if "error" in curr:
-            raise curr["error"]
-
-        for ci in range(len(file_chunks)):
-            # Start downloading the next chunk while we process the current one.
-            nxt = {}
-            nxt_thread = None
-            if ci + 1 < len(file_chunks):
-                nxt_thread = threading.Thread(
-                    target=_download, args=(file_chunks[ci + 1], nxt)
-                )
-                nxt_thread.start()
-
-            chunk_dir = os.path.join(job_home, "chunks", str(ci))
-            os.makedirs(chunk_dir, exist_ok=True)
-
-            try:
-                for var_batch in var_batches:
-                    cmd = [
-                        "python3",
-                        HistFromNtupleProducer,
-                        "--period",
-                        self.period,
-                        "--outDir",
-                        chunk_dir,
-                        "--channels",
-                        channels,
-                        "--vars",
-                        ",".join(var_batch),
-                        "--dataset_name",
-                        dataset_name,
-                        "--LAWrunVersion",
-                        self.version,
-                        "--nMT",
-                        str(nMT),
+        def _run_producer(out_dir, files):
+            cmd = [
+                "python3",
+                HistFromNtupleProducer,
+                "--period",
+                self.period,
+                "--outDir",
+                out_dir,
+                "--channels",
+                channels,
+                "--vars",
+                ",".join(vars_to_run),
+                "--dataset_name",
+                dataset_name,
+                "--LAWrunVersion",
+                self.version,
+                "--nMT",
+                str(nMT),
+            ]
+            if compute_unc_histograms:
+                cmd.extend(
+                    [
+                        "--compute_rel_weights",
+                        "True",
+                        "--compute_unc_variations",
+                        "True",
                     ]
-                    if compute_unc_histograms:
-                        cmd.extend(
-                            [
-                                "--compute_rel_weights",
-                                "True",
-                                "--compute_unc_variations",
-                                "True",
-                            ]
-                        )
-                    if self.customisations:
-                        cmd.extend(["--customisations", self.customisations])
-                    if self.user_custom:
-                        cmd.extend(["--user-custom", self.user_custom])
-                    cmd.extend(curr["files"])
-                    ps_call(cmd, verbose=1)
+                )
+            if self.customisations:
+                cmd.extend(["--customisations", self.customisations])
+            if self.user_custom:
+                cmd.extend(["--user-custom", self.user_custom])
+            cmd.extend(files)
+            ps_call(cmd, verbose=1)
 
+        round_outputs = {var: [] for var in vars_to_run}
+
+        # ---- Queue-based download/process pipeline (issue #257 design) ----
+        # A pool of downloader threads localizes ALL input files concurrently and
+        # pushes each ready local path onto `ready_q`. Downloads are never gated by
+        # the consumer, so I/O fully overlaps processing. The (single, since the
+        # producer is itself multi-threaded via nMT) processing loop consumes files
+        # in waves: it starts as soon as `min_ready` files are available, and each
+        # subsequent wave grabs every file downloaded while the previous wave ran.
+        # Each wave produces partial per-variable histograms that are hadd-ed at the
+        # end. (Disk peak is the dataset size, by design: downloading does not stop.)
+        ready_q = queue.Queue()
+        errors = []
+
+        def _download_one(inp):
+            try:
+                stack = contextlib.ExitStack()
+                abspath = stack.enter_context(inp.localize("r")).abspath
+                ready_q.put((abspath, stack))
+            except Exception as e:  # noqa: BLE001 - surfaced to the main thread
+                errors.append(e)
+                ready_q.put(("__error__", None))
+
+        # Bound the number of simultaneous transfers (network politeness) without
+        # ever pausing the overall download progress.
+        max_parallel_dl = (
+            min(self.files_chunk_size, n_inputs)
+            if self.files_chunk_size > 0
+            else n_inputs
+        )
+        max_parallel_dl = max(1, max_parallel_dl)
+        # Minimum files ready before the first processing wave starts.
+        min_ready = max_parallel_dl
+
+        executor = ThreadPoolExecutor(max_workers=max_parallel_dl)
+        for inp in inputs:
+            executor.submit(_download_one, inp)
+
+        try:
+            remaining = n_inputs
+            round_idx = 0
+            while remaining > 0:
+                wave = []
+                # Block until we have the threshold for this wave (capped at what is
+                # left): min_ready for the first wave, at least one afterwards.
+                need = min(min_ready if round_idx == 0 else 1, remaining)
+                while len(wave) < need:
+                    item = ready_q.get()
+                    if item[0] == "__error__":
+                        raise errors[0]
+                    wave.append(item)
+                # Opportunistically take everything else already downloaded.
+                while len(wave) < remaining:
+                    try:
+                        item = ready_q.get_nowait()
+                    except queue.Empty:
+                        break
+                    if item[0] == "__error__":
+                        raise errors[0]
+                    wave.append(item)
+
+                remaining -= len(wave)
+                round_dir = os.path.join(job_home, "rounds", str(round_idx))
+                os.makedirs(round_dir, exist_ok=True)
+                _run_producer(round_dir, [abspath for abspath, _ in wave])
                 for var in vars_to_run:
-                    chunk_outputs[var].append(os.path.join(chunk_dir, f"{var}.root"))
-            finally:
-                # Release local copies of the current chunk and join the
-                # background download thread even if processing raised.
-                curr["stack"].close()
-                if nxt_thread is not None:
-                    nxt_thread.join()
+                    round_outputs[var].append(os.path.join(round_dir, f"{var}.root"))
+                round_idx += 1
+                # Release the local copies of this wave's inputs.
+                for _, stack in wave:
+                    stack.close()
+        finally:
+            executor.shutdown(wait=True)
+            # Drain and release any files that were downloaded after an exception.
+            while True:
+                try:
+                    _, stack = ready_q.get_nowait()
+                except queue.Empty:
+                    break
+                if stack is not None:
+                    stack.close()
 
-            if "error" in nxt:
-                raise nxt["error"]
-            curr = nxt
+        if errors:
+            raise errors[0]
 
-        # Merge per-chunk outputs per variable and upload.
+        # Merge per-wave partial outputs per variable and upload.
         for var in vars_to_run:
-            files = chunk_outputs[var]
+            files = round_outputs[var]
             if len(files) == 1:
-                with self.output()[var].localize("w") as tmp_out:
+                with outputs[var].localize("w") as tmp_out:
                     shutil.move(files[0], tmp_out.abspath)
             else:
                 merged = os.path.join(job_home, f"merged_{var}.root")
                 hadd_cmd = f"hadd -f209 -j -O {merged} " + " ".join(files)
                 ps_call([hadd_cmd], True)
-                with self.output()[var].localize("w") as tmp_out:
+                with outputs[var].localize("w") as tmp_out:
                     shutil.move(merged, tmp_out.abspath)
 
         if remove_job_home:
@@ -781,17 +822,22 @@ class HistMergerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
         ).create_branch_map()
         if not hfn_branch_map:
             return {}
-        # Each HFN branch covers one dataset and all variables.
-        # Build parallel lists of HFN branch indices and dataset names.
-        hfn_br_indices = []
-        dataset_names = []
-        for br_idx, (dataset_name, _) in sorted(hfn_branch_map.items()):
-            hfn_br_indices.append(br_idx)
-            dataset_names.append(dataset_name)
+        # HFN now branches per (dataset, variable-batch). Map each variable to the HFN
+        # branch (one per dataset) whose batch produced it, so this merger branch only
+        # depends on the HFN jobs that actually wrote its variable.
+        var_to_dataset_branch = {}  # var_name -> {dataset_name: hfn_br_idx}
+        for br_idx, (dataset_name, _prod_br_list, var_batch) in sorted(
+            hfn_branch_map.items()
+        ):
+            for v in var_batch:
+                var_to_dataset_branch.setdefault(v, {})[dataset_name] = br_idx
         # One HistMerger branch per active variable.
         branches = {}
         for k, var in enumerate(self.active_variables):
             var_name = var["name"] if isinstance(var, dict) else var
+            ds_to_br = var_to_dataset_branch.get(var_name, {})
+            dataset_names = sorted(ds_to_br)
+            hfn_br_indices = [ds_to_br[ds] for ds in dataset_names]
             branches[k] = (var_name, hfn_br_indices, dataset_names)
         return branches
 
@@ -919,6 +965,8 @@ class HistMergerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
 class AnalysisCacheTask(Task, HTCondorWorkflow, law.LocalWorkflow):
     max_runtime = copy_param(HTCondorWorkflow.max_runtime, 2.0)
     n_cpus = copy_param(HTCondorWorkflow.n_cpus, 1)
+    # issue #264: many branches (~nTotalFiles) -> group several per HTCondor job by default.
+    tasks_per_job = copy_param(HTCondorWorkflow.tasks_per_job, 10)
     producer_to_run = luigi.Parameter()
 
     @property
@@ -1430,6 +1478,8 @@ class HistPlotTask(Task, HTCondorWorkflow, law.LocalWorkflow):
 class AnalysisCacheAggregationTask(Task, HTCondorWorkflow, law.LocalWorkflow):
     max_runtime = copy_param(HTCondorWorkflow.max_runtime, 2.0)
     n_cpus = copy_param(HTCondorWorkflow.n_cpus, 1)
+    # issue #264: group several branches per HTCondor job by default.
+    tasks_per_job = copy_param(HTCondorWorkflow.tasks_per_job, 10)
     producer_to_aggregate = luigi.Parameter()
 
     @property

--- a/Analysis/tasks.py
+++ b/Analysis/tasks.py
@@ -5,6 +5,7 @@ import hashlib
 import luigi
 import queue
 import shutil
+import threading
 from concurrent.futures import ThreadPoolExecutor
 
 
@@ -440,7 +441,6 @@ class HistFromNtupleProducerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
     # Fixed NUMBER of variable batches (not batch size): branch indices stay stable when
     # the set of variables changes. n_var_batches=1 => one job per dataset (the #257 extreme).
     n_var_batches = luigi.IntParameter(default=10)
-    files_chunk_size = luigi.IntParameter(default=10)
 
     @staticmethod
     def _var_batch_id(var_name, n_batches):
@@ -671,37 +671,54 @@ class HistFromNtupleProducerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
 
         round_outputs = {var: [] for var in vars_to_run}
 
-        # ---- Queue-based download/process pipeline (issue #257 design) ----
-        # A pool of downloader threads localizes ALL input files concurrently and
-        # pushes each ready local path onto `ready_q`. Downloads are never gated by
-        # the consumer, so I/O fully overlaps processing. The (single, since the
-        # producer is itself multi-threaded via nMT) processing loop consumes files
-        # in waves: it starts as soon as `min_ready` files are available, and each
-        # subsequent wave grabs every file downloaded while the previous wave ran.
-        # Each wave produces partial per-variable histograms that are hadd-ed at the
-        # end. (Disk peak is the dataset size, by design: downloading does not stop.)
+        # ---- Queue-based download/process pipeline ----
+        # A bounded pool of downloader threads localizes the input files concurrently and
+        # pushes each ready local path onto `ready_q`; the single processing loop (the producer
+        # is itself multi-threaded via nMT) consumes them in waves -- block for >=1 file, then
+        # take everything already downloaded -- and hadds the per-wave partials at the end, so
+        # download and processing overlap. Two limits from the global config bound resource use:
+        #   * max_simultaneous_downloads (default 4): concurrent transfers.
+        #   * max_total_download_size_gb (default 10): total size of localized-but-not-yet-
+        #     processed files. A downloader waits when the budget is exhausted and resumes once a
+        #     processed wave releases its files. At least one file is always admitted, so a single
+        #     file larger than the whole budget cannot deadlock (the cap is then soft).
+        max_parallel_dl = max(
+            1, int(self.global_params.get("max_simultaneous_downloads", 4))
+        )
+        max_download_bytes = (
+            float(self.global_params.get("max_total_download_size_gb", 10)) * 1024**3
+        )
+
         ready_q = queue.Queue()
         errors = []
+        budget_cond = threading.Condition()
+        downloaded_bytes = [0.0]
 
         def _download_one(inp):
             try:
+                with budget_cond:
+                    # Wait for budget, but always admit at least one file (downloaded_bytes==0).
+                    while (
+                        downloaded_bytes[0] >= max_download_bytes
+                        and downloaded_bytes[0] > 0
+                    ):
+                        budget_cond.wait()
                 stack = contextlib.ExitStack()
                 abspath = stack.enter_context(inp.localize("r")).abspath
-                ready_q.put((abspath, stack))
+                size = os.path.getsize(abspath)
+                with budget_cond:
+                    downloaded_bytes[0] += size
+                ready_q.put((abspath, stack, size))
             except Exception as e:  # noqa: BLE001 - surfaced to the main thread
                 errors.append(e)
-                ready_q.put(("__error__", None))
+                ready_q.put(("__error__", None, 0))
 
-        # Bound the number of simultaneous transfers (network politeness) without
-        # ever pausing the overall download progress.
-        max_parallel_dl = (
-            min(self.files_chunk_size, n_inputs)
-            if self.files_chunk_size > 0
-            else n_inputs
-        )
-        max_parallel_dl = max(1, max_parallel_dl)
-        # Minimum files ready before the first processing wave starts.
-        min_ready = max_parallel_dl
+        def _release(stack, size):
+            if stack is not None:
+                stack.close()
+            with budget_cond:
+                downloaded_bytes[0] -= size
+                budget_cond.notify_all()
 
         executor = ThreadPoolExecutor(max_workers=max_parallel_dl)
         for inp in inputs:
@@ -712,15 +729,11 @@ class HistFromNtupleProducerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
             round_idx = 0
             while remaining > 0:
                 wave = []
-                # Block until we have the threshold for this wave (capped at what is
-                # left): min_ready for the first wave, at least one afterwards.
-                need = min(min_ready if round_idx == 0 else 1, remaining)
-                while len(wave) < need:
-                    item = ready_q.get()
-                    if item[0] == "__error__":
-                        raise errors[0]
-                    wave.append(item)
-                # Opportunistically take everything else already downloaded.
+                # Block for the first ready file, then take everything already downloaded.
+                item = ready_q.get()
+                if item[0] == "__error__":
+                    raise errors[0]
+                wave.append(item)
                 while len(wave) < remaining:
                     try:
                         item = ready_q.get_nowait()
@@ -733,23 +746,22 @@ class HistFromNtupleProducerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
                 remaining -= len(wave)
                 round_dir = os.path.join(job_home, "rounds", str(round_idx))
                 os.makedirs(round_dir, exist_ok=True)
-                _run_producer(round_dir, [abspath for abspath, _ in wave])
+                _run_producer(round_dir, [abspath for abspath, _, _ in wave])
                 for var in vars_to_run:
                     round_outputs[var].append(os.path.join(round_dir, f"{var}.root"))
                 round_idx += 1
-                # Release the local copies of this wave's inputs.
-                for _, stack in wave:
-                    stack.close()
+                # Release this wave's local copies and free their download budget.
+                for _, stack, size in wave:
+                    _release(stack, size)
         finally:
             executor.shutdown(wait=True)
-            # Drain and release any files that were downloaded after an exception.
+            # Drain and release anything downloaded after an exception.
             while True:
                 try:
-                    _, stack = ready_q.get_nowait()
+                    _, stack, size = ready_q.get_nowait()
                 except queue.Empty:
                     break
-                if stack is not None:
-                    stack.close()
+                _release(stack, size)
 
         if errors:
             raise errors[0]

--- a/Analysis/tasks.py
+++ b/Analysis/tasks.py
@@ -438,7 +438,7 @@ class HistFromNtupleProducerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
         branch_set = set()
         for br_idx, (dataset_name, prod_br_list) in self.branch_map.items():
             branch_set.update(prod_br_list)
-        branches = tuple(branch_set)
+        branches = tuple(sorted(branch_set))
         req_dict = {
             "HistTupleProducerTask": HistTupleProducerTask.req(
                 self, branches=branches, customisations=self.customisations
@@ -480,7 +480,7 @@ class HistFromNtupleProducerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
         ) in HistTupleBranchMap.items():
             dataset_to_branches.setdefault(histTuple_dataset_name, []).append(prod_br)
 
-        for dataset_name, prod_br_list in dataset_to_branches.items():
+        for dataset_name, prod_br_list in sorted(dataset_to_branches.items()):
             branches[n] = (dataset_name, prod_br_list)
             n += 1
 
@@ -596,7 +596,7 @@ class HistMergerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
 
         return {
             "HistFromNtupleProducerTask": HistFromNtupleProducerTask.req(
-                self, branches=list(new_branchset)
+                self, branches=sorted(new_branchset)
             )
         }
 
@@ -625,7 +625,7 @@ class HistMergerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
         # Build parallel lists of HFN branch indices and dataset names.
         hfn_br_indices = []
         dataset_names = []
-        for br_idx, (dataset_name, _) in hfn_branch_map.items():
+        for br_idx, (dataset_name, _) in sorted(hfn_branch_map.items()):
             hfn_br_indices.append(br_idx)
             dataset_names.append(dataset_name)
         # One HistMerger branch per variable.

--- a/Analysis/tasks.py
+++ b/Analysis/tasks.py
@@ -1,6 +1,7 @@
 import law
 import os
 import contextlib
+import hashlib
 import luigi
 import queue
 import shutil
@@ -436,8 +437,17 @@ class HistFromNtupleProducerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
     max_runtime = copy_param(HTCondorWorkflow.max_runtime, 10.0)
     n_cpus = copy_param(HTCondorWorkflow.n_cpus, 2)
     variables = luigi.Parameter(default="")
-    vars_per_batch = luigi.IntParameter(default=20)
+    # Fixed NUMBER of variable batches (not batch size): branch indices stay stable when
+    # the set of variables changes. n_var_batches=1 => one job per dataset (the #257 extreme).
+    n_var_batches = luigi.IntParameter(default=10)
     files_chunk_size = luigi.IntParameter(default=10)
+
+    @staticmethod
+    def _var_batch_id(var_name, n_batches):
+        # Deterministic across processes (unlike the salted built-in hash()), so a given
+        # variable always lands in the same batch regardless of which other variables exist.
+        digest = hashlib.md5(var_name.encode("utf-8")).hexdigest()
+        return int(digest, 16) % n_batches
 
     @property
     def bundle_flavours(self):
@@ -512,7 +522,6 @@ class HistFromNtupleProducerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
     @workflow_condition.create_branch_map
     def create_branch_map(self):
         branches = {}
-        n = 0
 
         dataset_to_branches = {}
         HistTupleBranchMap = HistTupleProducerTask.req(
@@ -527,27 +536,35 @@ class HistFromNtupleProducerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
         ) in HistTupleBranchMap.items():
             dataset_to_branches.setdefault(histTuple_dataset_name, []).append(prod_br)
 
-        # Variable batching happens here (issue #257): each (dataset, variable-batch)
-        # is its own branch/job, so a job localizes the dataset inputs once and produces
-        # the histograms for just its batch of variables — avoiding the old
-        # (nDatasets x nVariables) re-localization while still parallelizing across
-        # batches. vars_per_batch <= 0 means "all variables in one batch" (one job
-        # per dataset, the extreme of issue #257).
-        all_var_names = [
+        # Each (dataset, variable-batch) is its own branch/job: a job localizes the dataset
+        # inputs once and produces the histograms for just its batch of variables (avoids the
+        # old nDatasets x nVariables re-localization while keeping per-batch parallelism).
+        #
+        # The number of batches is FIXED (n_var_batches) and a variable's batch is a
+        # deterministic function of its name, so branch indices
+        #   index = dataset_position * n_var_batches + batch_id
+        # are stable when the set of variables changes: adding/removing a variable only
+        # makes the affected (dataset, batch) branches incomplete, without renumbering any
+        # other branch (so a running production's HTCondor job map stays aligned). Empty
+        # batches yield an empty output() and are trivially complete (never submitted).
+        n_batches = max(1, self.n_var_batches)
+        batched_vars = [[] for _ in range(n_batches)]
+        for var_name in (
             v["name"] if isinstance(v, dict) else v for v in self.active_variables
-        ]
-        batch_size = (
-            self.vars_per_batch if self.vars_per_batch > 0 else len(all_var_names)
-        )
-        var_batches = [
-            all_var_names[i : i + batch_size]
-            for i in range(0, len(all_var_names), max(1, batch_size))
-        ]
+        ):
+            batched_vars[self._var_batch_id(var_name, n_batches)].append(var_name)
+        batched_vars = [sorted(b) for b in batched_vars]
 
-        for dataset_name, prod_br_list in sorted(dataset_to_branches.items()):
-            for var_batch in var_batches:
-                branches[n] = (dataset_name, sorted(prod_br_list), var_batch)
-                n += 1
+        for ds_pos, (dataset_name, prod_br_list) in enumerate(
+            sorted(dataset_to_branches.items())
+        ):
+            for batch_id in range(n_batches):
+                idx = ds_pos * n_batches + batch_id
+                branches[idx] = (
+                    dataset_name,
+                    sorted(prod_br_list),
+                    batched_vars[batch_id],
+                )
 
         return branches
 

--- a/Analysis/tasks.py
+++ b/Analysis/tasks.py
@@ -3,6 +3,7 @@ import os
 import contextlib
 import luigi
 import shutil
+import threading
 
 
 from FLAF.RunKit.run_tools import ps_call
@@ -420,6 +421,24 @@ class HistFromNtupleProducerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
     max_runtime = copy_param(HTCondorWorkflow.max_runtime, 10.0)
     n_cpus = copy_param(HTCondorWorkflow.n_cpus, 2)
     bundle_flavours = ["core", "AnaTupleFileList"]
+    variables = luigi.Parameter(default="")
+    vars_per_batch = luigi.IntParameter(default=20)
+    files_chunk_size = luigi.IntParameter(default=10)
+
+    @property
+    def active_variables(self):
+        all_vars = self.global_params["variables"]
+        if not self.variables:
+            return all_vars
+        selected = set(self.variables.split(","))
+        result = [
+            v for v in all_vars if (v["name"] if isinstance(v, dict) else v) in selected
+        ]
+        found = {v["name"] if isinstance(v, dict) else v for v in result}
+        missing = selected - found
+        if missing:
+            print(f"Warning: variables not found in config: {sorted(missing)}")
+        return result
 
     def workflow_requires(self):
         reqs = super().workflow_requires()
@@ -490,7 +509,7 @@ class HistFromNtupleProducerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
     def output(self):
         dataset_name, prod_br_list = self.branch_data
         outputs = {}
-        for var in self.global_params["variables"]:
+        for var in self.active_variables:
             var_name = var["name"] if isinstance(var, dict) else var
             output_path = os.path.join(
                 self.version,
@@ -521,31 +540,96 @@ class HistFromNtupleProducerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
         HistFromNtupleProducer = os.path.join(
             self.ana_path(), "FLAF", "Analysis", "HistProducerFromNTuple.py"
         )
-        with contextlib.ExitStack() as stack:
-            local_inputs = [
-                stack.enter_context(inp.localize("r")).abspath for inp in self.input()
-            ]
-            for var in self.global_params["variables"]:
-                var_name = var["name"] if isinstance(var, dict) else var
-                tmpFile = os.path.join(job_home, f"HistFromNtuple_{var_name}.root")
-                HistFromNtupleProducer_cmd = [
+        nMT = self.n_cpus * 2 if self.effective_workflow == "htcondor" else 8
+
+        # Determine which variables still need to be produced.
+        vars_to_run = [
+            var["name"] if isinstance(var, dict) else var
+            for var in self.active_variables
+            if not self.output()[var["name"] if isinstance(var, dict) else var].exists()
+        ]
+        if not vars_to_run:
+            print(f"All outputs already exist for dataset {dataset_name}, skipping")
+            if remove_job_home:
+                shutil.rmtree(job_home)
+            return
+
+        # Split variables into batches so HistProducerFromNTuple processes
+        # vars_per_batch variables per invocation (limits peak memory usage).
+        batch_size = (
+            self.vars_per_batch if self.vars_per_batch > 0 else len(vars_to_run)
+        )
+        var_batches = [
+            vars_to_run[i : i + batch_size]
+            for i in range(0, len(vars_to_run), batch_size)
+        ]
+
+        # Split input files into chunks so local disk usage is bounded.
+        # While HistProducerFromNTuple processes chunk N, chunk N+1 is
+        # downloaded in a background thread.
+        all_inputs = self.input()
+        chunk_size = (
+            self.files_chunk_size if self.files_chunk_size > 0 else len(all_inputs)
+        )
+        file_chunks = [
+            all_inputs[i : i + chunk_size]
+            for i in range(0, len(all_inputs), chunk_size)
+        ]
+
+        chunk_outputs = {var: [] for var in vars_to_run}
+
+        def _download(chunk_inputs, result):
+            stack = contextlib.ExitStack()
+            try:
+                result["files"] = [
+                    stack.enter_context(inp.localize("r")).abspath
+                    for inp in chunk_inputs
+                ]
+                result["stack"] = stack
+            except Exception as e:
+                stack.close()
+                result["error"] = e
+
+        # Download the first chunk synchronously before entering the loop.
+        curr = {}
+        _download(file_chunks[0], curr)
+        if "error" in curr:
+            raise curr["error"]
+
+        for ci in range(len(file_chunks)):
+            # Start downloading the next chunk while we process the current one.
+            nxt = {}
+            nxt_thread = None
+            if ci + 1 < len(file_chunks):
+                nxt_thread = threading.Thread(
+                    target=_download, args=(file_chunks[ci + 1], nxt)
+                )
+                nxt_thread.start()
+
+            chunk_dir = os.path.join(job_home, "chunks", str(ci))
+            os.makedirs(chunk_dir, exist_ok=True)
+
+            for var_batch in var_batches:
+                cmd = [
                     "python3",
                     HistFromNtupleProducer,
                     "--period",
                     self.period,
-                    "--outFile",
-                    tmpFile,
+                    "--outDir",
+                    chunk_dir,
                     "--channels",
                     channels,
-                    "--var",
-                    var_name,
+                    "--vars",
+                    ",".join(var_batch),
                     "--dataset_name",
                     dataset_name,
                     "--LAWrunVersion",
                     self.version,
+                    "--nMT",
+                    str(nMT),
                 ]
                 if compute_unc_histograms:
-                    HistFromNtupleProducer_cmd.extend(
+                    cmd.extend(
                         [
                             "--compute_rel_weights",
                             "True",
@@ -554,13 +638,35 @@ class HistFromNtupleProducerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
                         ]
                     )
                 if self.customisations:
-                    HistFromNtupleProducer_cmd.extend(
-                        ["--customisations", self.customisations]
-                    )
-                HistFromNtupleProducer_cmd.extend(local_inputs)
-                ps_call(HistFromNtupleProducer_cmd, verbose=1)
-                with self.output()[var_name].localize("w") as tmp_local_file:
-                    shutil.move(tmpFile, tmp_local_file.abspath)
+                    cmd.extend(["--customisations", self.customisations])
+                cmd.extend(curr["files"])
+                ps_call(cmd, verbose=1)
+
+            for var in vars_to_run:
+                chunk_outputs[var].append(os.path.join(chunk_dir, f"{var}.root"))
+
+            # Release local copies of the current chunk to free disk space.
+            curr["stack"].close()
+
+            # Wait for the next chunk download before continuing.
+            if nxt_thread is not None:
+                nxt_thread.join()
+                if "error" in nxt:
+                    raise nxt["error"]
+                curr = nxt
+
+        # Merge per-chunk outputs per variable and upload.
+        for var in vars_to_run:
+            files = chunk_outputs[var]
+            if len(files) == 1:
+                with self.output()[var].localize("w") as tmp_out:
+                    shutil.move(files[0], tmp_out.abspath)
+            else:
+                merged = os.path.join(job_home, f"merged_{var}.root")
+                hadd_cmd = f"hadd -f209 -j -O {merged} " + " ".join(files)
+                ps_call([hadd_cmd], True)
+                with self.output()[var].localize("w") as tmp_out:
+                    shutil.move(merged, tmp_out.abspath)
 
         if remove_job_home:
             shutil.rmtree(job_home)
@@ -570,6 +676,22 @@ class HistMergerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
     max_runtime = copy_param(HTCondorWorkflow.max_runtime, 5.0)
     n_cpus = copy_param(HTCondorWorkflow.n_cpus, 2)
     bundle_flavours = ["core", "AnaTupleFileList"]
+    variables = luigi.Parameter(default="")
+
+    @property
+    def active_variables(self):
+        all_vars = self.global_params["variables"]
+        if not self.variables:
+            return all_vars
+        selected = set(self.variables.split(","))
+        result = [
+            v for v in all_vars if (v["name"] if isinstance(v, dict) else v) in selected
+        ]
+        found = {v["name"] if isinstance(v, dict) else v for v in result}
+        missing = selected - found
+        if missing:
+            print(f"Warning: variables not found in config: {sorted(missing)}")
+        return result
 
     def workflow_requires(self):
         reqs = super().workflow_requires()
@@ -630,9 +752,9 @@ class HistMergerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
         for br_idx, (dataset_name, _) in sorted(hfn_branch_map.items()):
             hfn_br_indices.append(br_idx)
             dataset_names.append(dataset_name)
-        # One HistMerger branch per variable.
+        # One HistMerger branch per active variable.
         branches = {}
-        for k, var in enumerate(self.global_params["variables"]):
+        for k, var in enumerate(self.active_variables):
             var_name = var["name"] if isinstance(var, dict) else var
             branches[k] = (var_name, hfn_br_indices, dataset_names)
         return branches
@@ -1024,6 +1146,22 @@ class HistPlotTask(Task, HTCondorWorkflow, law.LocalWorkflow):
     max_runtime = copy_param(HTCondorWorkflow.max_runtime, 2.0)
     n_cpus = copy_param(HTCondorWorkflow.n_cpus, 1)
     bundle_flavours = ["core", "AnaTupleFileList"]
+    variables = luigi.Parameter(default="")
+
+    @property
+    def active_variables(self):
+        all_vars = self.global_params["variables"]
+        if not self.variables:
+            return all_vars
+        selected = set(self.variables.split(","))
+        result = [
+            v for v in all_vars if (v["name"] if isinstance(v, dict) else v) in selected
+        ]
+        found = {v["name"] if isinstance(v, dict) else v for v in result}
+        missing = selected - found
+        if missing:
+            print(f"Warning: variables not found in config: {sorted(missing)}")
+        return result
 
     def workflow_requires(self):
         reqs = super().workflow_requires()

--- a/Analysis/tasks.py
+++ b/Analysis/tasks.py
@@ -432,7 +432,7 @@ class HistFromNtupleProducerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
         all_vars = self.global_params["variables"]
         if not self.variables:
             return all_vars
-        selected = set(self.variables.split(","))
+        selected = {v.strip() for v in self.variables.split(",") if v.strip()}
         result = [
             v for v in all_vars if (v["name"] if isinstance(v, dict) else v) in selected
         ]
@@ -611,53 +611,54 @@ class HistFromNtupleProducerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
             chunk_dir = os.path.join(job_home, "chunks", str(ci))
             os.makedirs(chunk_dir, exist_ok=True)
 
-            for var_batch in var_batches:
-                cmd = [
-                    "python3",
-                    HistFromNtupleProducer,
-                    "--period",
-                    self.period,
-                    "--outDir",
-                    chunk_dir,
-                    "--channels",
-                    channels,
-                    "--vars",
-                    ",".join(var_batch),
-                    "--dataset_name",
-                    dataset_name,
-                    "--LAWrunVersion",
-                    self.version,
-                    "--nMT",
-                    str(nMT),
-                ]
-                if compute_unc_histograms:
-                    cmd.extend(
-                        [
-                            "--compute_rel_weights",
-                            "True",
-                            "--compute_unc_variations",
-                            "True",
-                        ]
-                    )
-                if self.customisations:
-                    cmd.extend(["--customisations", self.customisations])
-                if self.user_custom:
-                    cmd.extend(["--user-custom", self.user_custom])
-                cmd.extend(curr["files"])
-                ps_call(cmd, verbose=1)
+            try:
+                for var_batch in var_batches:
+                    cmd = [
+                        "python3",
+                        HistFromNtupleProducer,
+                        "--period",
+                        self.period,
+                        "--outDir",
+                        chunk_dir,
+                        "--channels",
+                        channels,
+                        "--vars",
+                        ",".join(var_batch),
+                        "--dataset_name",
+                        dataset_name,
+                        "--LAWrunVersion",
+                        self.version,
+                        "--nMT",
+                        str(nMT),
+                    ]
+                    if compute_unc_histograms:
+                        cmd.extend(
+                            [
+                                "--compute_rel_weights",
+                                "True",
+                                "--compute_unc_variations",
+                                "True",
+                            ]
+                        )
+                    if self.customisations:
+                        cmd.extend(["--customisations", self.customisations])
+                    if self.user_custom:
+                        cmd.extend(["--user-custom", self.user_custom])
+                    cmd.extend(curr["files"])
+                    ps_call(cmd, verbose=1)
 
-            for var in vars_to_run:
-                chunk_outputs[var].append(os.path.join(chunk_dir, f"{var}.root"))
+                for var in vars_to_run:
+                    chunk_outputs[var].append(os.path.join(chunk_dir, f"{var}.root"))
+            finally:
+                # Release local copies of the current chunk and join the
+                # background download thread even if processing raised.
+                curr["stack"].close()
+                if nxt_thread is not None:
+                    nxt_thread.join()
 
-            # Release local copies of the current chunk to free disk space.
-            curr["stack"].close()
-
-            # Wait for the next chunk download before continuing.
-            if nxt_thread is not None:
-                nxt_thread.join()
-                if "error" in nxt:
-                    raise nxt["error"]
-                curr = nxt
+            if "error" in nxt:
+                raise nxt["error"]
+            curr = nxt
 
         # Merge per-chunk outputs per variable and upload.
         for var in vars_to_run:
@@ -687,7 +688,7 @@ class HistMergerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
         all_vars = self.global_params["variables"]
         if not self.variables:
             return all_vars
-        selected = set(self.variables.split(","))
+        selected = {v.strip() for v in self.variables.split(",") if v.strip()}
         result = [
             v for v in all_vars if (v["name"] if isinstance(v, dict) else v) in selected
         ]
@@ -722,7 +723,7 @@ class HistMergerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
             new_branchset.update(hfn_br_list)
 
         reqs["HistFromNtupleProducerTask"] = HistFromNtupleProducerTask.req(
-            self, branches=list(new_branchset)
+            self, branches=sorted(new_branchset)
         )
         return reqs
 
@@ -1157,7 +1158,7 @@ class HistPlotTask(Task, HTCondorWorkflow, law.LocalWorkflow):
         all_vars = self.global_params["variables"]
         if not self.variables:
             return all_vars
-        selected = set(self.variables.split(","))
+        selected = {v.strip() for v in self.variables.split(",") if v.strip()}
         result = [
             v for v in all_vars if (v["name"] if isinstance(v, dict) else v) in selected
         ]

--- a/Analysis/tasks.py
+++ b/Analysis/tasks.py
@@ -568,9 +568,21 @@ class HistFromNtupleProducerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
 
         return branches
 
+    def _empty_batch_placeholder(self):
+        # Existing local placeholder used as the output of an empty variable bucket, so the
+        # branch is always complete and is never submitted to HTCondor. Created idempotently
+        # (only ever evaluated on the submit side, where the data path is writable).
+        path = self.local_path("empty_batch.placeholder")
+        if not os.path.exists(path):
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            open(path, "a").close()
+        return law.LocalFileTarget(path)
+
     @workflow_condition.output
     def output(self):
         dataset_name, prod_br_list, var_batch = self.branch_data
+        if not var_batch:
+            return self._empty_batch_placeholder()
         outputs = {}
         for var_name in var_batch:
             output_path = os.path.join(
@@ -585,6 +597,9 @@ class HistFromNtupleProducerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
 
     def run(self):
         dataset_name, prod_br_list, var_batch = self.branch_data
+        if not var_batch:
+            # Empty bucket: output is the placeholder (already complete); nothing to do.
+            return
         job_home, remove_job_home = self.law_job_home()
         customisation_dict = getCustomisationSplit(self.customisations)
         channels = (

--- a/run_tools/law_customizations.py
+++ b/run_tools/law_customizations.py
@@ -45,6 +45,9 @@ class Task(law.Task):
         "ana_version",
         "tasks_per_job",
     ]
+    # tasks_per_job is a per-task tuning knob: each task keeps its own default (or an
+    # explicit CLI value) instead of inheriting the requesting task's value via .req().
+    exclude_params_req = law.Task.exclude_params_req | {"tasks_per_job"}
     period = luigi.Parameter()
     customisations = luigi.Parameter(default="")
     test = luigi.IntParameter(default=-1)


### PR DESCRIPTION
# Fix for [#257](https://github.com/cms-flaf/FLAF/issues/257): Improvement to HistFromNtupleProducerTask nJobs Management

## Root cause

`HistFromNtupleProducerTask.create_branch_map()` created one branch per
`(dataset, variable)` pair — `nDatasets × nVariables` branches total. Each branch
localised all HistTuple files for its dataset (potentially 100+ files) and then
ran `HistProducerFromNTuple.py` for a single variable. The next branch for the
same dataset would localise exactly the same files again for the next variable.
With 50 variables and 50+ datasets this multiplied network I/O and queue slots
by the number of variables for no gain.

## Solution

Branch `HistFromNtupleProducerTask` per **dataset** only (`nDatasets` branches).
Each branch localises the dataset's HistTuple files once and loops over all
variables inside `run()`, producing one output file per variable. The output of
each branch is now a `dict` keyed by variable name rather than a single file.

`HistMergerTask` is adapted to match:
- `create_branch_map()` reads the new per-dataset HFN branch map and emits one
  Merger branch per variable (same as before), recording all HFN branch indices.
- `requires()` requests all HFN dataset branches (each branch covers all vars).
- `run()` extracts `inp[var_name]` from each dict input instead of using
  `inp.abspath` directly.

`HistPlotTask` is unchanged — it still iterates over `HistMergerTask`'s branch
map whose tuple structure `(var_name, br_indices, datasets)` is preserved.

## Files changed

- `FLAF/Analysis/tasks.py`
  - `HistFromNtupleProducerTask.create_branch_map`: `{n: (dataset, prod_br_list)}` instead of `{n: (var, prod_br_list, dataset)}`
  - `HistFromNtupleProducerTask.workflow_requires`: updated branch_map unpacking
  - `HistFromNtupleProducerTask.requires`: updated branch_data unpacking; fixed list-vs-generator bug in old code
  - `HistFromNtupleProducerTask.output`: returns `{var_name: remote_target}` dict
  - `HistFromNtupleProducerTask.run`: loops over variables; localises inputs once
  - `HistMergerTask.create_branch_map`: rewritten to read per-dataset HFN branches
  - `HistMergerTask.workflow_requires`: updated branch_map unpacking
  - `HistMergerTask.requires`: updated to request HFN branches by dataset index
  - `HistMergerTask.run`: extracts `inp[var_name]` from dict input

## Testing

Run the full CI pipeline (`HistPlotTask --version CI --period Run3_2022 --workflow local --branches 0 --test 1000`) for each analysis. The number of `HistFromNtupleProducerTask` branches should drop from `nDatasets × nVariables` to `nDatasets`.
