### PR TITLE
Introducing bundles

### DIFF
--- a/AnaProd/tasks.py
+++ b/AnaProd/tasks.py
@@ -385,16 +385,12 @@ class AnaTupleFileListBuilderTask(Task, HTCondorWorkflow, law.LocalWorkflow):
             if match:
                 branch_set.add(br_idx)
 
-        reqs = [
-            AnaTupleFileTask.req(
-                self,
-                max_runtime=AnaTupleFileTask.max_runtime._default,
-                branch=prod_br,
-                branches=(prod_br,),
-            )
-            for prod_br in tuple(branch_set)
-        ]
-        return reqs
+        return AnaTupleFileTask.req(
+            self,
+            max_runtime=AnaTupleFileTask.max_runtime._default,
+            n_cpus=AnaTupleFileTask.n_cpus._default,
+            branches=tuple(branch_set),
+        )
 
     def create_branch_map(self):
         branches = {}

--- a/AnaProd/tasks.py
+++ b/AnaProd/tasks.py
@@ -353,7 +353,7 @@ class AnaTupleFileListBuilderTask(Task, HTCondorWorkflow, law.LocalWorkflow):
             return reqs
 
         if not isinstance(self._get_anaTuple_map(self), dict):
-            return []
+            return reqs
         branch_set = set()
         for idx, (dataset_name, process_group) in self.branch_map.items():
             branch_set |= self._get_branch_set_for_dataset(dataset_name, process_group)

--- a/AnaProd/tasks.py
+++ b/AnaProd/tasks.py
@@ -353,7 +353,7 @@ class AnaTupleFileListBuilderTask(Task, HTCondorWorkflow, law.LocalWorkflow):
             return reqs
 
         if not isinstance(self._get_anaTuple_map(self), dict):
-            return reqs
+            return []
         branch_set = set()
         for idx, (dataset_name, process_group) in self.branch_map.items():
             branch_set |= self._get_branch_set_for_dataset(dataset_name, process_group)
@@ -380,9 +380,19 @@ class AnaTupleFileListBuilderTask(Task, HTCondorWorkflow, law.LocalWorkflow):
         return branch_set
 
     def requires(self):
-        # workflow_requires() ensures all AnaTupleFileTask outputs are complete
-        # before any branch runs, so no per-branch scheduling overhead is needed.
-        return []
+        dataset_name, process_group = self.branch_data
+        if not InputFileTask.WF_complete(self):
+            return []
+        branch_set = self._get_branch_set_for_dataset(dataset_name, process_group)
+        return [
+            AnaTupleFileTask.req(
+                self,
+                max_runtime=AnaTupleFileTask.max_runtime._default,
+                branch=prod_br,
+                branches=(prod_br,),
+            )
+            for prod_br in tuple(branch_set)
+        ]
 
     def create_branch_map(self):
         branches = {}
@@ -420,19 +430,9 @@ class AnaTupleFileListBuilderTask(Task, HTCondorWorkflow, law.LocalWorkflow):
         with contextlib.ExitStack() as stack:
 
             print("Localizing inputs")
-            branch_set = self._get_branch_set_for_dataset(dataset_name, process_group)
             local_inputs = [
-                stack.enter_context(
-                    AnaTupleFileTask.req(
-                        self,
-                        max_runtime=AnaTupleFileTask.max_runtime._default,
-                        branch=prod_br,
-                        branches=(prod_br,),
-                    )
-                    .output()["report"]
-                    .localize("r")
-                ).abspath
-                for prod_br in sorted(branch_set)
+                stack.enter_context(inp["report"].localize("r")).abspath
+                for inp in self.input()
             ]
             print(f"Localized {len(local_inputs)} inputs")
 

--- a/AnaProd/tasks.py
+++ b/AnaProd/tasks.py
@@ -328,6 +328,16 @@ class AnaTupleFileListBuilderTask(Task, HTCondorWorkflow, law.LocalWorkflow):
     n_cpus = copy_param(HTCondorWorkflow.n_cpus, 1)
     bundle_flavours = ["core", "inputFileList"]
 
+    _anaTuple_map_cache = None
+
+    @classmethod
+    def _get_anaTuple_map(cls, ref_task):
+        if cls._anaTuple_map_cache is None:
+            cls._anaTuple_map_cache = AnaTupleFileTask.req(
+                ref_task, branch=-1, branches=()
+            ).create_branch_map()
+        return cls._anaTuple_map_cache
+
     def task_workflow_requires(self):
         input_file_task_complete = InputFileTask.WF_complete(self)
         if not input_file_task_complete:
@@ -336,9 +346,7 @@ class AnaTupleFileListBuilderTask(Task, HTCondorWorkflow, law.LocalWorkflow):
                 "inputFile": InputFileTask.req(self, branches=()),
             }
 
-        AnaTuple_map = AnaTupleFileTask.req(
-            self, branch=-1, branches=()
-        ).create_branch_map()
+        AnaTuple_map = self._get_anaTuple_map(self)
         if not isinstance(AnaTuple_map, dict):
             return []
         branch_set = set()
@@ -366,9 +374,7 @@ class AnaTupleFileListBuilderTask(Task, HTCondorWorkflow, law.LocalWorkflow):
         dataset_name, process_group = self.branch_data
         if not InputFileTask.WF_complete(self):
             return []
-        AnaTuple_map = AnaTupleFileTask.req(
-            self, branch=-1, branches=()
-        ).create_branch_map()
+        AnaTuple_map = self._get_anaTuple_map(self)
         branch_set = set()
         for br_idx, (anaTuple_dataset_name, _, _) in AnaTuple_map.items():
             match = dataset_name == anaTuple_dataset_name

--- a/AnaProd/tasks.py
+++ b/AnaProd/tasks.py
@@ -121,8 +121,9 @@ class InputFileTask(Task, law.LocalWorkflow):
 class AnaTupleFileTask(Task, HTCondorWorkflow, law.LocalWorkflow):
     max_runtime = copy_param(HTCondorWorkflow.max_runtime, 40.0)
     n_cpus = copy_param(HTCondorWorkflow.n_cpus, 2)
+    bundle_flavours = ["core", "inputFileList", "cmssw"]
 
-    def workflow_requires(self):
+    def task_workflow_requires(self):
         return {
             "inputFile": InputFileTask.req(self, branches=()),
         }
@@ -325,8 +326,9 @@ class AnaTupleFileTask(Task, HTCondorWorkflow, law.LocalWorkflow):
 class AnaTupleFileListBuilderTask(Task, HTCondorWorkflow, law.LocalWorkflow):
     max_runtime = copy_param(HTCondorWorkflow.max_runtime, 24.0)
     n_cpus = copy_param(HTCondorWorkflow.n_cpus, 1)
+    bundle_flavours = ["core", "inputFileList"]
 
-    def workflow_requires(self):
+    def task_workflow_requires(self):
         input_file_task_complete = InputFileTask.WF_complete(self)
         if not input_file_task_complete:
             return {
@@ -337,6 +339,8 @@ class AnaTupleFileListBuilderTask(Task, HTCondorWorkflow, law.LocalWorkflow):
         AnaTuple_map = AnaTupleFileTask.req(
             self, branch=-1, branches=()
         ).create_branch_map()
+        if not isinstance(AnaTuple_map, dict):
+            return []
         branch_set = set()
         for idx, (dataset_name, process_group) in self.branch_map.items():
             for br_idx, (anaTuple_dataset_name, _, _) in AnaTuple_map.items():
@@ -466,7 +470,13 @@ class AnaTupleFileListBuilderTask(Task, HTCondorWorkflow, law.LocalWorkflow):
 
 
 class AnaTupleFileListTask(AnaTupleFileListBuilderTask):
-    def workflow_requires(self):
+    bundle_flavours = []
+
+    def __init__(self, *args, **kwargs):
+        kwargs["workflow"] = "local"
+        super(AnaTupleFileListTask, self).__init__(*args, **kwargs)
+
+    def task_workflow_requires(self):
         return {"AnaTupleFileListBuilderTask": AnaTupleFileListBuilderTask.req(self)}
 
     def requires(self):
@@ -486,8 +496,9 @@ class AnaTupleMergeTask(Task, HTCondorWorkflow, law.LocalWorkflow):
     max_runtime = copy_param(HTCondorWorkflow.max_runtime, 48.0)
     n_cpus = copy_param(HTCondorWorkflow.n_cpus, 2)
     delete_inputs_after_merge = luigi.BoolParameter(default=False)
+    bundle_flavours = ["core", "inputFileList", "AnaTupleFileList"]
 
-    def workflow_requires(self):
+    def task_workflow_requires(self):
         merge_organization_complete = AnaTupleFileListTask.req(
             self, branches=()
         ).complete()
@@ -542,6 +553,8 @@ class AnaTupleMergeTask(Task, HTCondorWorkflow, law.LocalWorkflow):
             self, branch=-1, branches=()
         ).create_branch_map()
         required_branches = {"root": {}}
+        if not isinstance(anaTuple_branch_map, dict):
+            return required_branches
         for prod_br, (
             anaTuple_dataset_name,
             anaTuple_input_file,

--- a/AnaProd/tasks.py
+++ b/AnaProd/tasks.py
@@ -346,19 +346,11 @@ class AnaTupleFileListBuilderTask(Task, HTCondorWorkflow, law.LocalWorkflow):
                 "inputFile": InputFileTask.req(self, branches=()),
             }
 
-        AnaTuple_map = self._get_anaTuple_map(self)
-        if not isinstance(AnaTuple_map, dict):
+        if not isinstance(self._get_anaTuple_map(self), dict):
             return []
         branch_set = set()
         for idx, (dataset_name, process_group) in self.branch_map.items():
-            for br_idx, (anaTuple_dataset_name, _, _) in AnaTuple_map.items():
-                match = dataset_name == anaTuple_dataset_name
-                if not match and process_group == "data":
-                    anaTuple_dataset = self.datasets[anaTuple_dataset_name]
-                    anaTuple_process_group = anaTuple_dataset["process_group"]
-                    match = anaTuple_process_group == "data"
-                if match:
-                    branch_set.add(br_idx)
+            branch_set |= self._get_branch_set_for_dataset(dataset_name, process_group)
 
         deps = {
             "AnaTupleFileTask": AnaTupleFileTask.req(
@@ -370,10 +362,7 @@ class AnaTupleFileListBuilderTask(Task, HTCondorWorkflow, law.LocalWorkflow):
         }
         return deps
 
-    def requires(self):
-        dataset_name, process_group = self.branch_data
-        if not InputFileTask.WF_complete(self):
-            return []
+    def _get_branch_set_for_dataset(self, dataset_name, process_group):
         AnaTuple_map = self._get_anaTuple_map(self)
         branch_set = set()
         for br_idx, (anaTuple_dataset_name, _, _) in AnaTuple_map.items():
@@ -384,13 +373,12 @@ class AnaTupleFileListBuilderTask(Task, HTCondorWorkflow, law.LocalWorkflow):
                 match = anaTuple_process_group == "data"
             if match:
                 branch_set.add(br_idx)
+        return branch_set
 
-        return AnaTupleFileTask.req(
-            self,
-            max_runtime=AnaTupleFileTask.max_runtime._default,
-            n_cpus=AnaTupleFileTask.n_cpus._default,
-            branches=tuple(branch_set),
-        )
+    def requires(self):
+        # task_workflow_requires() ensures all AnaTupleFileTask outputs are complete
+        # before any branch runs, so no per-branch scheduling overhead is needed.
+        return []
 
     def create_branch_map(self):
         branches = {}
@@ -428,9 +416,19 @@ class AnaTupleFileListBuilderTask(Task, HTCondorWorkflow, law.LocalWorkflow):
         with contextlib.ExitStack() as stack:
 
             print("Localizing inputs")
+            branch_set = self._get_branch_set_for_dataset(dataset_name, process_group)
             local_inputs = [
-                stack.enter_context(inp["report"].localize("r")).abspath
-                for inp in self.input()
+                stack.enter_context(
+                    AnaTupleFileTask.req(
+                        self,
+                        max_runtime=AnaTupleFileTask.max_runtime._default,
+                        branch=prod_br,
+                        branches=(prod_br,),
+                    )
+                    .output()["report"]
+                    .localize("r")
+                ).abspath
+                for prod_br in sorted(branch_set)
             ]
             print(f"Localized {len(local_inputs)} inputs")
 

--- a/AnaProd/tasks.py
+++ b/AnaProd/tasks.py
@@ -129,10 +129,10 @@ class AnaTupleFileTask(Task, HTCondorWorkflow, law.LocalWorkflow):
             flavours.append("cmssw")
         return flavours
 
-    def task_workflow_requires(self):
-        return {
-            "inputFile": InputFileTask.req(self, branches=()),
-        }
+    def workflow_requires(self):
+        reqs = super().workflow_requires()
+        reqs["inputFile"] = InputFileTask.req(self, branches=())
+        return reqs
 
     def requires(self):
         return []
@@ -344,29 +344,27 @@ class AnaTupleFileListBuilderTask(Task, HTCondorWorkflow, law.LocalWorkflow):
             ).create_branch_map()
         return cls._anaTuple_map_cache
 
-    def task_workflow_requires(self):
+    def workflow_requires(self):
+        reqs = super().workflow_requires()
         input_file_task_complete = InputFileTask.WF_complete(self)
         if not input_file_task_complete:
-            return {
-                "anaTuple": AnaTupleFileTask.req(self, branches=()),
-                "inputFile": InputFileTask.req(self, branches=()),
-            }
+            reqs["anaTuple"] = AnaTupleFileTask.req(self, branches=())
+            reqs["inputFile"] = InputFileTask.req(self, branches=())
+            return reqs
 
         if not isinstance(self._get_anaTuple_map(self), dict):
-            return []
+            return reqs
         branch_set = set()
         for idx, (dataset_name, process_group) in self.branch_map.items():
             branch_set |= self._get_branch_set_for_dataset(dataset_name, process_group)
 
-        deps = {
-            "AnaTupleFileTask": AnaTupleFileTask.req(
-                self,
-                branches=tuple(branch_set),
-                max_runtime=AnaTupleFileTask.max_runtime._default,
-                n_cpus=AnaTupleFileTask.n_cpus._default,
-            )
-        }
-        return deps
+        reqs["AnaTupleFileTask"] = AnaTupleFileTask.req(
+            self,
+            branches=tuple(branch_set),
+            max_runtime=AnaTupleFileTask.max_runtime._default,
+            n_cpus=AnaTupleFileTask.n_cpus._default,
+        )
+        return reqs
 
     def _get_branch_set_for_dataset(self, dataset_name, process_group):
         AnaTuple_map = self._get_anaTuple_map(self)
@@ -382,7 +380,7 @@ class AnaTupleFileListBuilderTask(Task, HTCondorWorkflow, law.LocalWorkflow):
         return branch_set
 
     def requires(self):
-        # task_workflow_requires() ensures all AnaTupleFileTask outputs are complete
+        # workflow_requires() ensures all AnaTupleFileTask outputs are complete
         # before any branch runs, so no per-branch scheduling overhead is needed.
         return []
 
@@ -482,8 +480,10 @@ class AnaTupleFileListTask(AnaTupleFileListBuilderTask):
         kwargs["workflow"] = "local"
         super(AnaTupleFileListTask, self).__init__(*args, **kwargs)
 
-    def task_workflow_requires(self):
-        return {"AnaTupleFileListBuilderTask": AnaTupleFileListBuilderTask.req(self)}
+    def workflow_requires(self):
+        reqs = super().workflow_requires()
+        reqs["AnaTupleFileListBuilderTask"] = AnaTupleFileListBuilderTask.req(self)
+        return reqs
 
     def requires(self):
         return AnaTupleFileListBuilderTask.req(self)
@@ -504,19 +504,19 @@ class AnaTupleMergeTask(Task, HTCondorWorkflow, law.LocalWorkflow):
     delete_inputs_after_merge = luigi.BoolParameter(default=False)
     bundle_flavours = ["core", "inputFileList", "AnaTupleFileList"]
 
-    def task_workflow_requires(self):
+    def workflow_requires(self):
+        reqs = super().workflow_requires()
         merge_organization_complete = AnaTupleFileListTask.req(
             self, branches=()
         ).complete()
         if not merge_organization_complete:
-            return {
-                "AnaTupleFileListTask": AnaTupleFileListTask.req(
-                    self,
-                    branches=(),
-                    max_runtime=AnaTupleFileListTask.max_runtime._default,
-                    n_cpus=AnaTupleFileListTask.n_cpus._default,
-                ),
-            }
+            reqs["AnaTupleFileListTask"] = AnaTupleFileListTask.req(
+                self,
+                branches=(),
+                max_runtime=AnaTupleFileListTask.max_runtime._default,
+                n_cpus=AnaTupleFileListTask.n_cpus._default,
+            )
+            return reqs
 
         branch_set = set()
         for _, (
@@ -532,14 +532,13 @@ class AnaTupleMergeTask(Task, HTCondorWorkflow, law.LocalWorkflow):
             branch_set.add(ds_branch)
             branch_set.update(dataset_dependencies.values())
 
-        return {
-            "AnaTupleFileListTask": AnaTupleFileListTask.req(
-                self,
-                branches=tuple(branch_set),
-                max_runtime=AnaTupleFileListTask.max_runtime._default,
-                n_cpus=AnaTupleFileListTask.n_cpus._default,
-            )
-        }
+        reqs["AnaTupleFileListTask"] = AnaTupleFileListTask.req(
+            self,
+            branches=tuple(branch_set),
+            max_runtime=AnaTupleFileListTask.max_runtime._default,
+            n_cpus=AnaTupleFileListTask.n_cpus._default,
+        )
+        return reqs
 
     def requires(self):
         # Need both the AnaTupleFileTask for the input ROOT file, and the AnaTupleFileListTask for the json structure

--- a/AnaProd/tasks.py
+++ b/AnaProd/tasks.py
@@ -121,7 +121,13 @@ class InputFileTask(Task, law.LocalWorkflow):
 class AnaTupleFileTask(Task, HTCondorWorkflow, law.LocalWorkflow):
     max_runtime = copy_param(HTCondorWorkflow.max_runtime, 40.0)
     n_cpus = copy_param(HTCondorWorkflow.n_cpus, 2)
-    bundle_flavours = ["core", "inputFileList", "cmssw"]
+
+    @property
+    def bundle_flavours(self):
+        flavours = ["core", "inputFileList"]
+        if self.global_params.get("use_cmssw_env_AnaTupleProduction", False):
+            flavours.append("cmssw")
+        return flavours
 
     def task_workflow_requires(self):
         return {

--- a/Analysis/tasks.py
+++ b/Analysis/tasks.py
@@ -796,7 +796,17 @@ class AnalysisCacheTask(Task, HTCondorWorkflow, law.LocalWorkflow):
     max_runtime = copy_param(HTCondorWorkflow.max_runtime, 2.0)
     n_cpus = copy_param(HTCondorWorkflow.n_cpus, 1)
     producer_to_run = luigi.Parameter()
-    bundle_flavours = ["core", "AnaTupleFileList"]
+
+    @property
+    def bundle_flavours(self):
+        flavours = ["core", "AnaTupleFileList"]
+        if (
+            self.global_params.get("payload_producers", {})
+            .get(self.producer_to_run, {})
+            .get("cmssw_env", False)
+        ):
+            flavours.append("cmssw")
+        return flavours
 
     # Need to override this from HTCondorWorkflow to have separate data pathways for different cache tasks
     def htcondor_output_directory(self):

--- a/Analysis/tasks.py
+++ b/Analysis/tasks.py
@@ -23,7 +23,8 @@ class HistTupleProducerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
     n_cpus = copy_param(HTCondorWorkflow.n_cpus, 4)
     bundle_flavours = ["core", "AnaTupleFileList"]
 
-    def task_workflow_requires(self):
+    def workflow_requires(self):
+        reqs = super().workflow_requires()
         merge_organization_complete = AnaTupleFileListTask.req(
             self, branches=()
         ).complete()
@@ -65,7 +66,8 @@ class HistTupleProducerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
                         )
                     )
 
-            return req_dict
+            reqs.update(req_dict)
+            return reqs
 
         branch_set = set()
         branch_set_cache = set()
@@ -100,8 +102,6 @@ class HistTupleProducerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
                     ) in aggr_task_branch_map.items():
                         if aggr_dataset_name == dataset:
                             agg_dict[agg_name].add(aggr_br_idx)
-
-        reqs = {}
 
         if len(branch_set) > 0:
             reqs["anaTuple"] = AnaTupleMergeTask.req(
@@ -421,33 +421,31 @@ class HistFromNtupleProducerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
     n_cpus = copy_param(HTCondorWorkflow.n_cpus, 2)
     bundle_flavours = ["core", "AnaTupleFileList"]
 
-    def task_workflow_requires(self):
+    def workflow_requires(self):
+        reqs = super().workflow_requires()
         merge_organization_complete = AnaTupleFileListTask.req(
             self, branches=()
         ).complete()
         if not merge_organization_complete:
-            req_dict = {}
-            req_dict["AnaTupleFileListTask"] = AnaTupleFileListTask.req(
+            reqs["AnaTupleFileListTask"] = AnaTupleFileListTask.req(
                 self,
                 branches=(),
                 max_runtime=AnaTupleFileListTask.max_runtime._default,
                 n_cpus=AnaTupleFileListTask.n_cpus._default,
             )
-            req_dict["HistTupleProducerTask"] = HistTupleProducerTask.req(
+            reqs["HistTupleProducerTask"] = HistTupleProducerTask.req(
                 self, branches=(), customisations=self.customisations
             )
-            return req_dict
+            return reqs
         branch_set = set()
         for br_idx, (var, prod_br_list, dataset_names) in self.branch_map.items():
             if var in self.global_params["variables"]:
                 branch_set.update(prod_br_list)
         branches = tuple(branch_set)
-        req_dict = {
-            "HistTupleProducerTask": HistTupleProducerTask.req(
-                self, branches=branches, customisations=self.customisations
-            )
-        }
-        return req_dict
+        reqs["HistTupleProducerTask"] = HistTupleProducerTask.req(
+            self, branches=branches, customisations=self.customisations
+        )
+        return reqs
 
     def requires(self):
         var, prod_br_list, dataset_name = self.branch_data
@@ -588,25 +586,25 @@ class HistMergerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
     n_cpus = copy_param(HTCondorWorkflow.n_cpus, 2)
     bundle_flavours = ["core", "AnaTupleFileList"]
 
-    def task_workflow_requires(self):
+    def workflow_requires(self):
+        reqs = super().workflow_requires()
         branch_map = self.create_branch_map()
 
         merge_organization_complete = AnaTupleFileListTask.req(
             self, branches=()
         ).complete()
         if not merge_organization_complete:
-            return {
-                "AnaTupleFileListTask": AnaTupleFileListTask.req(
-                    self,
-                    branches=(),
-                    max_runtime=AnaTupleFileListTask.max_runtime._default,
-                    n_cpus=AnaTupleFileListTask.n_cpus._default,
-                ),
-                "HistFromNtupleProducerTask": HistFromNtupleProducerTask.req(
-                    self,
-                    branches=(),
-                ),
-            }
+            reqs["AnaTupleFileListTask"] = AnaTupleFileListTask.req(
+                self,
+                branches=(),
+                max_runtime=AnaTupleFileListTask.max_runtime._default,
+                n_cpus=AnaTupleFileListTask.n_cpus._default,
+            )
+            reqs["HistFromNtupleProducerTask"] = HistFromNtupleProducerTask.req(
+                self,
+                branches=(),
+            )
+            return reqs
 
         branch_set = set()
         all_datasets = {}
@@ -617,11 +615,10 @@ class HistMergerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
         for var in all_datasets.keys():
             new_branchset.update(all_datasets[var])
 
-        return {
-            "HistFromNtupleProducerTask": HistFromNtupleProducerTask.req(
-                self, branches=list(new_branchset)
-            )
-        }
+        reqs["HistFromNtupleProducerTask"] = HistFromNtupleProducerTask.req(
+            self, branches=list(new_branchset)
+        )
+        return reqs
 
     def requires(self):
         var_name, br_indices, datasets = self.branch_data
@@ -825,7 +822,8 @@ class AnalysisCacheTask(Task, HTCondorWorkflow, law.LocalWorkflow):
             self.producer_to_run
         ].get("save_as", "root")
 
-    def task_workflow_requires(self):
+    def workflow_requires(self):
+        reqs = super().workflow_requires()
         merge_organization_complete = AnaTupleFileListTask.req(
             self, branches=()
         ).complete()
@@ -862,7 +860,8 @@ class AnalysisCacheTask(Task, HTCondorWorkflow, law.LocalWorkflow):
                 for producer_name in list(producer_requires_set)
                 if producer_name is not None
             ]
-            return req_dict
+            reqs.update(req_dict)
+            return reqs
 
         workflow_dict = {}
         workflow_dict["anaTuple"] = {
@@ -896,7 +895,8 @@ class AnalysisCacheTask(Task, HTCondorWorkflow, law.LocalWorkflow):
                     )
                     for br_idx, _ in self.branch_map.items()
                 }
-        return workflow_dict
+        reqs.update(workflow_dict)
+        return reqs
 
     def requires(self):
         dataset_name, prod_br, producer_list, aggregate_list, input_index = (
@@ -1056,22 +1056,22 @@ class HistPlotTask(Task, HTCondorWorkflow, law.LocalWorkflow):
     n_cpus = copy_param(HTCondorWorkflow.n_cpus, 1)
     bundle_flavours = ["core", "AnaTupleFileList"]
 
-    def task_workflow_requires(self):
+    def workflow_requires(self):
+        reqs = super().workflow_requires()
         merge_organization_complete = AnaTupleFileListTask.req(
             self, branches=()
         ).complete()
         if not merge_organization_complete:
-            req_dict = {}
-            req_dict["HistMergerTask"] = HistMergerTask.req(
+            reqs["HistMergerTask"] = HistMergerTask.req(
                 self, branches=(), customisations=self.customisations
             )
-            req_dict["AnaTupleFileListTask"] = AnaTupleFileListTask.req(
+            reqs["AnaTupleFileListTask"] = AnaTupleFileListTask.req(
                 self,
                 branches=(),
                 max_runtime=AnaTupleFileListTask.max_runtime._default,
                 n_cpus=AnaTupleFileListTask.n_cpus._default,
             )
-            return req_dict
+            return reqs
         merge_map = HistMergerTask.req(
             self, branch=-1, branches=(), customisations=self.customisations
         ).create_branch_map()
@@ -1082,13 +1082,12 @@ class HistPlotTask(Task, HTCondorWorkflow, law.LocalWorkflow):
                 if v == var:
                     branch_set.add(br)
 
-        return {
-            "merge": HistMergerTask.req(
-                self,
-                branches=tuple(branch_set),
-                customisations=self.customisations,
-            )
-        }
+        reqs["merge"] = HistMergerTask.req(
+            self,
+            branches=tuple(branch_set),
+            customisations=self.customisations,
+        )
+        return reqs
 
     def requires(self):
         var = self.branch_data
@@ -1266,22 +1265,20 @@ class AnalysisCacheAggregationTask(Task, HTCondorWorkflow, law.LocalWorkflow):
     def workflow_condition(self):
         return AnaTupleFileListTask.req(self, branch=-1, branches=()).complete()
 
-    def task_workflow_requires(self):
+    def workflow_requires(self):
+        reqs = super().workflow_requires()
         merge_organization_complete = AnaTupleFileListTask.req(
             self, branches=()
         ).complete()
         payload_producers = self.global_params["payload_producers"]
         if not merge_organization_complete:
-            deps = {
-                "AnaTupleFileListTask": AnaTupleFileListTask.req(
-                    self,
-                    branches=(),
-                    max_runtime=AnaTupleFileListTask.max_runtime._default,
-                    n_cpus=AnaTupleFileListTask.n_cpus._default,
-                ),
-            }
-
-            deps["AnalysisCacheTask"] = AnalysisCacheTask.req(
+            reqs["AnaTupleFileListTask"] = AnaTupleFileListTask.req(
+                self,
+                branches=(),
+                max_runtime=AnaTupleFileListTask.max_runtime._default,
+                n_cpus=AnaTupleFileListTask.n_cpus._default,
+            )
+            reqs["AnalysisCacheTask"] = AnalysisCacheTask.req(
                 self,
                 branches=(),
                 max_runtime=AnalysisCacheTask.max_runtime._default,
@@ -1289,9 +1286,8 @@ class AnalysisCacheAggregationTask(Task, HTCondorWorkflow, law.LocalWorkflow):
                 customisations=self.customisations,
                 producer_to_run=self.producer_to_aggregate,
             )
-            return deps
+            return reqs
 
-        deps = {}
         cache_branch_set = set()
         for idx, (
             sample_name,
@@ -1300,7 +1296,7 @@ class AnalysisCacheAggregationTask(Task, HTCondorWorkflow, law.LocalWorkflow):
             for br in list_of_producer_cache_keys:
                 cache_branch_set.add(br)
 
-        deps["AnalysisCacheTask"] = AnalysisCacheTask.req(
+        reqs["AnalysisCacheTask"] = AnalysisCacheTask.req(
             self,
             branches=tuple(cache_branch_set),
             max_runtime=AnalysisCacheTask.max_runtime._default,
@@ -1308,7 +1304,7 @@ class AnalysisCacheAggregationTask(Task, HTCondorWorkflow, law.LocalWorkflow):
             customisations=self.customisations,
             producer_to_run=self.producer_to_aggregate,
         )
-        return deps
+        return reqs
 
     def requires(self):
         # I don't need to check here that this producer applies to target group

--- a/Analysis/tasks.py
+++ b/Analysis/tasks.py
@@ -21,8 +21,9 @@ from FLAF.Common.Utilities import getCustomisationSplit, ServiceThread
 class HistTupleProducerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
     max_runtime = copy_param(HTCondorWorkflow.max_runtime, 5.0)
     n_cpus = copy_param(HTCondorWorkflow.n_cpus, 4)
+    bundle_flavours = ["core", "AnaTupleFileList"]
 
-    def workflow_requires(self):
+    def task_workflow_requires(self):
         merge_organization_complete = AnaTupleFileListTask.req(
             self, branches=()
         ).complete()
@@ -418,8 +419,9 @@ class HistTupleProducerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
 class HistFromNtupleProducerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
     max_runtime = copy_param(HTCondorWorkflow.max_runtime, 10.0)
     n_cpus = copy_param(HTCondorWorkflow.n_cpus, 2)
+    bundle_flavours = ["core", "AnaTupleFileList"]
 
-    def workflow_requires(self):
+    def task_workflow_requires(self):
         merge_organization_complete = AnaTupleFileListTask.req(
             self, branches=()
         ).complete()
@@ -584,8 +586,9 @@ class HistFromNtupleProducerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
 class HistMergerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
     max_runtime = copy_param(HTCondorWorkflow.max_runtime, 5.0)
     n_cpus = copy_param(HTCondorWorkflow.n_cpus, 2)
+    bundle_flavours = ["core", "AnaTupleFileList"]
 
-    def workflow_requires(self):
+    def task_workflow_requires(self):
         branch_map = self.create_branch_map()
 
         merge_organization_complete = AnaTupleFileListTask.req(
@@ -793,6 +796,7 @@ class AnalysisCacheTask(Task, HTCondorWorkflow, law.LocalWorkflow):
     max_runtime = copy_param(HTCondorWorkflow.max_runtime, 2.0)
     n_cpus = copy_param(HTCondorWorkflow.n_cpus, 1)
     producer_to_run = luigi.Parameter()
+    bundle_flavours = ["core", "AnaTupleFileList"]
 
     # Need to override this from HTCondorWorkflow to have separate data pathways for different cache tasks
     def htcondor_output_directory(self):
@@ -811,7 +815,7 @@ class AnalysisCacheTask(Task, HTCondorWorkflow, law.LocalWorkflow):
             self.producer_to_run
         ].get("save_as", "root")
 
-    def workflow_requires(self):
+    def task_workflow_requires(self):
         merge_organization_complete = AnaTupleFileListTask.req(
             self, branches=()
         ).complete()
@@ -1040,8 +1044,9 @@ class AnalysisCacheTask(Task, HTCondorWorkflow, law.LocalWorkflow):
 class HistPlotTask(Task, HTCondorWorkflow, law.LocalWorkflow):
     max_runtime = copy_param(HTCondorWorkflow.max_runtime, 2.0)
     n_cpus = copy_param(HTCondorWorkflow.n_cpus, 1)
+    bundle_flavours = ["core", "AnaTupleFileList"]
 
-    def workflow_requires(self):
+    def task_workflow_requires(self):
         merge_organization_complete = AnaTupleFileListTask.req(
             self, branches=()
         ).complete()
@@ -1242,6 +1247,7 @@ class AnalysisCacheAggregationTask(Task, HTCondorWorkflow, law.LocalWorkflow):
     max_runtime = copy_param(HTCondorWorkflow.max_runtime, 2.0)
     n_cpus = copy_param(HTCondorWorkflow.n_cpus, 1)
     producer_to_aggregate = luigi.Parameter()
+    bundle_flavours = ["core", "AnaTupleFileList"]
 
     def __init__(self, *args, **kwargs):
         super(AnalysisCacheAggregationTask, self).__init__(*args, **kwargs)
@@ -1250,7 +1256,7 @@ class AnalysisCacheAggregationTask(Task, HTCondorWorkflow, law.LocalWorkflow):
     def workflow_condition(self):
         return AnaTupleFileListTask.req(self, branch=-1, branches=()).complete()
 
-    def workflow_requires(self):
+    def task_workflow_requires(self):
         merge_organization_complete = AnaTupleFileListTask.req(
             self, branches=()
         ).complete()

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -4,6 +4,7 @@ action() {
     local run_token_server_host="{{run_token_server_host}}"
     local run_token_server_port="{{run_token_server_port}}"
     local analysis_path="{{analysis_path}}"
+    local bundle_list="{{bundle_list}}"
 
     if [ -n "${run_token_server_host}" ] && [ -n "${run_token_server_port}" ]; then
         local get_run_token_script
@@ -23,6 +24,88 @@ action() {
         fi
     fi
 
-    source "${analysis_path}/env.sh"
+    if [ -f "${LAW_JOB_INIT_DIR}/voms.proxy" ] && [ -z "${X509_USER_PROXY:-}" ]; then
+        chmod 600 "${LAW_JOB_INIT_DIR}/voms.proxy"
+        export X509_USER_PROXY="${LAW_JOB_INIT_DIR}/voms.proxy"
+    fi
+
+    if [ -n "${bundle_list}" ]; then
+        local lcg_setup="/cvmfs/sft.cern.ch/lcg/views/LCG_108a/x86_64-el9-gcc15-opt/setup.sh"
+        if [ -f "${lcg_setup}" ]; then
+            source "${lcg_setup}" 2>/dev/null
+        fi
+
+        local gfal_copy_bin
+        gfal_copy_bin=$(which gfal-copy 2>/dev/null)
+        if [ -z "${gfal_copy_bin}" ]; then
+            echo "ERROR: gfal-copy not found; cannot download bundles"
+            return 1
+        fi
+
+        local bundle_dir="${LAW_JOB_HOME}/bundle"
+        mkdir -p "${bundle_dir}"
+
+        local has_cmssw=0
+
+        for entry in ${bundle_list}; do
+            local flavour="${entry%%:*}"
+            local url="${entry#*:}"
+
+            echo "bootstrap: downloading ${flavour} bundle from ${url}"
+            local bundle_tar="${LAW_JOB_HOME}/${flavour}.tar.bz2"
+            env -i X509_USER_PROXY="${X509_USER_PROXY:-}" \
+                "${gfal_copy_bin}" -f "${url}" "file://${bundle_tar}"
+            local rc=$?
+            if [ ${rc} -ne 0 ]; then
+                echo "ERROR: ${flavour} bundle download failed (exit code ${rc})"
+                return ${rc}
+            fi
+
+            echo "bootstrap: unpacking ${flavour} bundle"
+            tar -xjf "${bundle_tar}" -C "${bundle_dir}"
+            rm -f "${bundle_tar}"
+
+            if [ "${flavour}" = "cmssw" ]; then
+                has_cmssw=1
+            fi
+        done
+
+        echo "bootstrap: patching bundle paths"
+        local real_analysis_path
+        real_analysis_path=$(head -1 "${bundle_dir}/soft/flaf_env/bin/pip" 2>/dev/null \
+            | sed 's|^#!||; s|/soft/flaf_env.*||')
+        if [ -n "${real_analysis_path}" ]; then
+            grep -rl "${real_analysis_path}" "${bundle_dir}/soft/flaf_env/bin/" 2>/dev/null \
+                | xargs -r sed -i "s|${real_analysis_path}|${bundle_dir}|g"
+        fi
+
+        if [ ${has_cmssw} -eq 1 ]; then
+            local flaf_cmssw_version
+            flaf_cmssw_version=$(sed -n 's/.*FLAF_CMSSW_VERSION="\([^"]*\)".*/\1/p' \
+                "${bundle_dir}/env.sh" 2>/dev/null | head -1)
+            if [ -n "${flaf_cmssw_version}" ]; then
+                local cmssw_dir="${bundle_dir}/soft/${flaf_cmssw_version}"
+                if [ -d "${cmssw_dir}/src" ]; then
+                    echo "bootstrap: relocating CMSSW ${flaf_cmssw_version}"
+                    source /cvmfs/cms.cern.ch/cmsset_default.sh 2>/dev/null || true
+                    local prev_dir="${PWD}"
+                    cd "${cmssw_dir}/src"
+                    eval "$(scramv1 runtime -sh 2>/dev/null)" || true
+                    scramv1 b ProjectRename "${cmssw_dir}" 2>/dev/null || true
+                    cd "${prev_dir}"
+                fi
+            fi
+        fi
+
+        echo "bootstrap: sourcing env.sh from bundle"
+        export FLAF_NO_INSTALL=1
+        source "${bundle_dir}/env.sh"
+    else
+        if [ "${analysis_path}" = "NONE" ]; then
+            echo "ERROR: analysis_path is NONE but no bundle_list was provided"
+            return 1
+        fi
+        source "${analysis_path}/env.sh"
+    fi
 }
 action

--- a/env.sh
+++ b/env.sh
@@ -122,6 +122,11 @@ install() {
     return 0
   fi
 
+  if [[ "${FLAF_NO_INSTALL:-0}" == "1" ]]; then
+    echo "ERROR: $installed_flag not found and FLAF_NO_INSTALL=1"
+    kill -INT $$
+  fi
+
   if [[ $node_os == $target_os ]]; then
     local env_cmd=""
     local env_cmd_args=""
@@ -178,6 +183,10 @@ load_flaf_env() {
   local FLAF_LCG_VERSION="LCG_108a"
   local FLAF_LCG_ARCH="x86_64-el9-gcc15-opt"
   if [[ ! -f "$FLAF_ENVIRONMENT_PATH/.${FLAF_LCG_VERSION}_${FLAF_LCG_ARCH}" ]]; then
+    if [[ "${FLAF_NO_INSTALL:-0}" == "1" ]]; then
+      echo "ERROR: FLAF environment not found at $FLAF_ENVIRONMENT_PATH and FLAF_NO_INSTALL=1"
+      kill -INT $$
+    fi
     if [[ -d "$FLAF_ENVIRONMENT_PATH" ]]; then
       echo "Removing old FLAF environment installation in $FLAF_ENVIRONMENT_PATH ..."
       run_cmd rm -rf "$FLAF_ENVIRONMENT_PATH"
@@ -200,23 +209,26 @@ load_flaf_env() {
   [ -z "$FLAF_COMBINE_VERSION" ] && export FLAF_COMBINE_VERSION="v10.4.2"
   export FLAF_CMSSW_BASE="$ANALYSIS_SOFT_PATH/$FLAF_CMSSW_VERSION"
   export FLAF_CMSSW_ARCH="${target_os_gt_prefix}${FLAF_CMSSW_OS_VERSION}_amd64_${FLAF_CMSSW_COMPILER}"
-  install_cmssw "$env_file" $node_os $target_os $FLAF_CMSSW_ARCH $FLAF_CMSSW_VERSION $FLAF_COMBINE_VERSION
-
   export PYTHONPATH="$ANALYSIS_PATH:$PYTHONPATH"
-  if [ "$FLAF_COMBINE_VERSION" != "none" ]; then
-    local cmb_os_version=9
-    local cmb_os_prefix=$(get_os_prefix $cmb_os_version)
-    local cmb_os=$cmb_os_prefix$cmb_os_version
-    export FLAF_COMBINE_PATH="$FLAF_CMSSW_BASE/src/HiggsAnalysis/CombinedLimit"
-    install_combine "$env_file" $node_os $cmb_os "$FLAF_COMBINE_PATH"
+  # When FLAF_NO_INSTALL=1 (bundle mode) skip CMSSW/combine/inference entirely if
+  # CMSSW is not present in the bundle; tasks that need it declare the cmssw bundle flavour.
+  if [[ "${FLAF_NO_INSTALL:-0}" == "0" ]] || [[ -d "$FLAF_CMSSW_BASE" ]]; then
+    install_cmssw "$env_file" $node_os $target_os $FLAF_CMSSW_ARCH $FLAF_CMSSW_VERSION $FLAF_COMBINE_VERSION
+    if [ "$FLAF_COMBINE_VERSION" != "none" ]; then
+      local cmb_os_version=9
+      local cmb_os_prefix=$(get_os_prefix $cmb_os_version)
+      local cmb_os=$cmb_os_prefix$cmb_os_version
+      export FLAF_COMBINE_PATH="$FLAF_CMSSW_BASE/src/HiggsAnalysis/CombinedLimit"
+      install_combine "$env_file" $node_os $cmb_os "$FLAF_COMBINE_PATH"
 
-    export PATH="$FLAF_COMBINE_PATH/build/bin:$PATH"
-    export LD_LIBRARY_PATH="$FLAF_COMBINE_PATH/build/lib:$LD_LIBRARY_PATH"
-    export PYTHONPATH="$FLAF_COMBINE_PATH/build/python:$PYTHONPATH"
-    if [ -d "$HH_INFERENCE_PATH" ]; then
-      install_inference "$env_file" $node_os $cmb_os $FLAF_COMBINE_VERSION
-      export PYTHONPATH="$HH_INFERENCE_PATH:$PYTHONPATH"
-      source $HH_INFERENCE_PATH/.setups/flaf.sh
+      export PATH="$FLAF_COMBINE_PATH/build/bin:$PATH"
+      export LD_LIBRARY_PATH="$FLAF_COMBINE_PATH/build/lib:$LD_LIBRARY_PATH"
+      export PYTHONPATH="$FLAF_COMBINE_PATH/build/python:$PYTHONPATH"
+      if [ -d "$HH_INFERENCE_PATH" ]; then
+        install_inference "$env_file" $node_os $cmb_os $FLAF_COMBINE_VERSION
+        export PYTHONPATH="$HH_INFERENCE_PATH:$PYTHONPATH"
+        source $HH_INFERENCE_PATH/.setups/flaf.sh
+      fi
     fi
   fi
 
@@ -225,7 +237,7 @@ load_flaf_env() {
     bashcompinit
   fi
 
-  source "$( law completion )"
+  source "$( law completion )" 2>/dev/null
   current_args=( "$@" )
   set --
   source /cvmfs/cms.cern.ch/rucio/setup-py3.sh &> /dev/null

--- a/run_tools/law_customizations.py
+++ b/run_tools/law_customizations.py
@@ -425,17 +425,14 @@ class HTCondorWorkflow(law.htcondor.HTCondorWorkflow):
     ]
     bundle_flavours = []
 
-    def task_workflow_requires(self):
-        return {}
-
     def workflow_requires(self):
-        reqs = self.task_workflow_requires()
         if self.bundle and self.bundle_flavours:
-            reqs = dict(reqs)
-            reqs["bundles"] = [
-                BundleTask.req(self, flavour=f) for f in self.bundle_flavours
-            ]
-        return reqs
+            return {
+                "bundles": [
+                    BundleTask.req(self, flavour=f) for f in self.bundle_flavours
+                ]
+            }
+        return {}
 
     def htcondor_check_job_completeness(self):
         return False

--- a/run_tools/law_customizations.py
+++ b/run_tools/law_customizations.py
@@ -1,14 +1,17 @@
 import copy
+import importlib
 import law
 import luigi
 import math
 import os
 import re
+import shutil
+import subprocess
 import tempfile
 
 from FLAF.RunKit.run_tools import natural_sort
 from FLAF.RunKit.crabLaw import update_kinit
-from FLAF.RunKit.law_wlcg import WLCGFileTarget, WLCGDirectoryTarget
+from FLAF.RunKit.law_wlcg import WLCGFileSystem, WLCGFileTarget, WLCGDirectoryTarget
 from FLAF.Common.Setup import Setup
 
 law.contrib.load("htcondor")
@@ -225,6 +228,143 @@ class Task(law.Task):
         )
 
 
+class BundleTask(Task):
+    flavour = luigi.Parameter(
+        description="bundle flavour (core, cmssw, inputFileList, AnaTupleFileList)"
+    )
+
+    def requires(self):
+        bundle_cfg = self.global_params.get("bundles", {}).get(self.flavour, {})
+        task_req_cfg = bundle_cfg.get("task_requires")
+        if task_req_cfg is None:
+            return {}
+        mod = importlib.import_module(task_req_cfg["module"])
+        task_cls = getattr(mod, task_req_cfg["class"])
+        return {"source": task_cls.req(self, branches=())}
+
+    def output(self):
+        return self.remote_target(
+            self.version, "bundles", self.period, f"{self.flavour}.tar.bz2"
+        )
+
+    def run(self):
+        bundle_cfg = self.global_params.get("bundles", {}).get(self.flavour)
+        if not bundle_cfg:
+            raise RuntimeError(
+                f"Bundle flavour '{self.flavour}' not configured in bundles section of global.yaml"
+            )
+
+        patterns = bundle_cfg.get("patterns", [])
+        ana_path = os.getenv("ANALYSIS_PATH")
+
+        formatted_patterns = [
+            p.format(version=self.version, period=self.period) for p in patterns
+        ]
+
+        include_args = []
+        for pattern in formatted_patterns:
+            full_path = os.path.join(ana_path, pattern)
+            if os.path.exists(full_path):
+                include_args.append(f"./{pattern}")
+            else:
+                print(
+                    f"bundle[{self.flavour}]: warning: '{pattern}' not found, skipping"
+                )
+
+        if not include_args:
+            raise RuntimeError(f"No files found for bundle flavour '{self.flavour}'")
+
+        os.makedirs(self.local_path(), exist_ok=True)
+
+        print(f"bundle[{self.flavour}]: creating archive from {ana_path}")
+        with self.output().localize("w") as tmp:
+            subprocess.run(
+                [
+                    "tar",
+                    "--exclude=*/__pycache__",
+                    "--exclude=*.pyc",
+                    "--exclude=*.pyo",
+                    "-cjf",
+                    tmp.abspath,
+                    "-C",
+                    ana_path,
+                ]
+                + include_args,
+                check=True,
+            )
+        print(f"bundle[{self.flavour}]: done")
+
+
+class CERNHTCondorJobFileFactory(law.htcondor.HTCondorJobFileFactory):
+    """HTCondor job file factory that stages transfer_input_files to EOS and uses protocol URLs.
+
+    When config._worker_files_remote_dir is set (a WLCGDirectoryTarget), every file listed in
+    transfer_input_files is uploaded to that remote directory and its path in the JDL is replaced
+    with the corresponding remote URL.  This lets CERN HTCondor fetch input files from EOS via the
+    protocol layer instead of trying to read /eos POSIX paths, which the batch system does not
+    support.
+    """
+
+    def create(self, **kwargs):
+        worker_files_dir = kwargs.get("_worker_files_remote_dir")
+        job_file, c = super().create(**kwargs)
+        self._stage_and_update_jdl(job_file, worker_files_dir)
+        return job_file, c
+
+    @staticmethod
+    def _stage_and_update_jdl(job_file, worker_files_dir=None):
+        with open(job_file) as f:
+            content = f.read()
+
+        lines = content.split("\n")
+        new_lines = []
+        updated = False
+
+        for line in lines:
+            line_key = line.lower().split("=")[0].strip() if "=" in line else ""
+
+            if line_key == "transfer_input_files" and worker_files_dir is not None:
+                key, _, value = line.partition(" = ")
+                value = value.strip()
+                quoted = value.startswith('"') and value.endswith('"')
+                if quoted:
+                    value = value[1:-1]
+                local_paths = [p.strip() for p in value.split(",") if p.strip()]
+                remote_urls = []
+                for local_path in local_paths:
+                    if "://" in local_path:
+                        remote_urls.append(local_path)
+                        continue
+                    basename = os.path.basename(local_path)
+                    remote_file = worker_files_dir.child(basename, type="f")
+                    if not remote_file.exists():
+                        print(f"worker_files: uploading {basename}")
+                        remote_file.copy_from_local(local_path)
+                    remote_urls.append(remote_file.uri())
+                line = f'{key} = {",".join(remote_urls)}'
+                updated = True
+
+            elif line_key == "initialdir":
+                updated = True
+                continue
+
+            elif line_key == "x509userproxy":
+                key, _, proxy_path = line.partition(" = ")
+                proxy_path = proxy_path.strip()
+                if "://" not in proxy_path and not proxy_path.startswith("/tmp/"):
+                    tmp_proxy = f"/tmp/{os.environ.get('USER', 'law')}_voms.proxy"
+                    shutil.copy2(proxy_path, tmp_proxy)
+                    os.chmod(tmp_proxy, 0o600)
+                    line = f"{key} = {tmp_proxy}"
+                    updated = True
+
+            new_lines.append(line)
+
+        if updated:
+            with open(job_file, "w") as f:
+                f.write("\n".join(new_lines))
+
+
 class HTCondorWorkflow(law.htcondor.HTCondorWorkflow):
     """
     Batch systems are typically very heterogeneous by design, and so is HTCondor. Law does not aim
@@ -251,6 +391,38 @@ class HTCondorWorkflow(law.htcondor.HTCondorWorkflow):
         default=0,
         description="job priority among your HTCondor jobs. Accepted values from -20 (lowest) to 20 (highest). Default 0.",
     )
+    bundle = luigi.BoolParameter(
+        default=False,
+        significant=False,
+        description="download pre-built bundle archives on workers instead of accessing AFS; "
+        "tasks declare which flavours they need via bundle_flavours",
+    )
+    htcondor_spool = luigi.BoolParameter(
+        default=True,
+        significant=False,
+        description="pass -spool to condor_submit so input files (including the x509 proxy) are "
+        "read locally on the submit host and transferred to the schedd, avoiding any "
+        "shared-filesystem dependency for the proxy path",
+    )
+
+    htcondor_job_kwargs_submit = [
+        "htcondor_pool",
+        "htcondor_scheduler",
+        "htcondor_spool",
+    ]
+    bundle_flavours = []
+
+    def task_workflow_requires(self):
+        return {}
+
+    def workflow_requires(self):
+        reqs = self.task_workflow_requires()
+        if self.bundle and self.bundle_flavours:
+            reqs = dict(reqs)
+            reqs["bundles"] = [
+                BundleTask.req(self, flavour=f) for f in self.bundle_flavours
+            ]
+        return reqs
 
     def htcondor_check_job_completeness(self):
         return False
@@ -263,24 +435,36 @@ class HTCondorWorkflow(law.htcondor.HTCondorWorkflow):
         # the directory where submission meta data should be stored
         return law.LocalDirectoryTarget(self.local_path())
 
-    # def htcondor_log_directory(self):
-    #     # the directory where HTCondor should store job logs, it can be the same as the output directory
-    #     path = ("logs",) + self.store_parts()
-    #     return self.remote_dir_target(*path)
+    def htcondor_log_directory(self):
+        return None
+
+    def htcondor_stageout_file(self):
+        return os.path.join(
+            os.getenv("ANALYSIS_PATH"), "FLAF", "run_tools", "stageout_logs.sh"
+        )
 
     def htcondor_bootstrap_file(self):
         # each job can define a bootstrap file that is executed prior to the actual job
         # in order to setup software and environment variables
         return os.path.join(os.getenv("ANALYSIS_PATH"), "FLAF", "bootstrap.sh")
 
+    def htcondor_job_file_factory_cls(self):
+        return CERNHTCondorJobFileFactory
+
     def htcondor_job_config(self, config, job_num, branches):
         ana_path = os.getenv("ANALYSIS_PATH")
-        # render_variables are rendered into all files sent with a job
-        config.render_variables["analysis_path"] = ana_path
+        # When using bundles, set analysis_path to NONE so the worker cannot
+        # accidentally fall back to the original AFS path.  The bootstrap will
+        # detect this and fail loudly if bundle_list is somehow empty.
+        if self.bundle and self.bundle_flavours:
+            config.render_variables["analysis_path"] = "NONE"
+        else:
+            config.render_variables["analysis_path"] = ana_path
 
-        # token server for rate-limiting job starts to avoid AFS overload
+        # token server for rate-limiting job starts to avoid AFS overload.
+        # Not needed in bundle mode: workers never touch AFS, so there is no load concern.
         runTokenServer = self.global_params.get("runTokenServer", None)
-        if runTokenServer:
+        if runTokenServer and not (self.bundle and self.bundle_flavours):
             config.render_variables["run_token_server_host"] = runTokenServer["host"]
             config.render_variables["run_token_server_port"] = str(
                 runTokenServer["port"]
@@ -304,6 +488,50 @@ class HTCondorWorkflow(law.htcondor.HTCondorWorkflow):
         )
         config.custom_content.append(("RequestCpus", self.n_cpus))
         config.custom_content.append(("priority", self.priority))
+
+        # Forward the x509 proxy so HTCondor can delegate credentials to the execution node.
+        proxy_path = os.environ.get("X509_USER_PROXY", "")
+        if proxy_path and os.path.isfile(proxy_path):
+            config.custom_content.append(("x509userproxy", proxy_path))
+
+        # Expose the per-job postfix so the stageout script can build the log filename dynamically.
+        config.custom_content.append(
+            ("environment", '"LAW_HTCONDOR_JOB_POSTFIX=$(law_job_postfix)"')
+        )
+
+        # Redirect the log file HTCondor transfer to /dev/null so the sandbox
+        # copy is discarded rather than written to AFS.
+        config.output_files["stdall.txt"] = "/dev/null"
+
+        # Compute the remote destination directory for the stageout script.
+        log_remote_base_url = ""
+        if isinstance(self.fs_default, WLCGFileSystem):
+            log_remote_base_url = self.remote_dir_target(
+                self.version, "logs", self.__class__.__name__, self.period
+            ).uri()
+        config.render_variables["log_remote_base_url"] = log_remote_base_url
+
+        # bundle: build a space-separated list of "flavour:url" pairs for bootstrap.sh.
+        if self.bundle and self.bundle_flavours:
+            if not isinstance(self.fs_default, WLCGFileSystem):
+                raise RuntimeError(
+                    "--bundle requires fs_default to be a remote filesystem (davs://, root://, …)"
+                )
+            bundle_parts = []
+            for flavour in self.bundle_flavours:
+                bundle_url = self.remote_target(
+                    self.version, "bundles", self.period, f"{flavour}.tar.bz2"
+                ).uri()
+                bundle_parts.append(f"{flavour}:{bundle_url}")
+            config.render_variables["bundle_list"] = " ".join(bundle_parts)
+
+            if not self.htcondor_spool:
+                config._worker_files_remote_dir = self.remote_dir_target(
+                    self.version, "worker_files", self.period
+                )
+        else:
+            config.render_variables["bundle_list"] = ""
+
         return config
 
     def htcondor_job_file(self):

--- a/run_tools/law_customizations.py
+++ b/run_tools/law_customizations.py
@@ -281,6 +281,7 @@ class BundleTask(Task):
             subprocess.run(
                 [
                     "tar",
+                    "--dereference",
                     "--exclude=*/__pycache__",
                     "--exclude=*.pyc",
                     "--exclude=*.pyo",

--- a/run_tools/law_customizations.py
+++ b/run_tools/law_customizations.py
@@ -261,38 +261,50 @@ class BundleTask(Task):
             p.format(version=self.version, period=self.period) for p in patterns
         ]
 
-        include_args = []
-        for pattern in formatted_patterns:
-            full_path = os.path.join(ana_path, pattern)
-            if os.path.exists(full_path):
-                include_args.append(f"./{pattern}")
-            else:
-                print(
-                    f"bundle[{self.flavour}]: warning: '{pattern}' not found, skipping"
-                )
-
-        if not include_args:
-            raise RuntimeError(f"No files found for bundle flavour '{self.flavour}'")
-
         os.makedirs(self.local_path(), exist_ok=True)
 
         print(f"bundle[{self.flavour}]: creating archive from {ana_path}")
         with self.output().localize("w") as tmp:
-            subprocess.run(
-                [
-                    "tar",
-                    "--dereference",
-                    "--exclude=*/__pycache__",
-                    "--exclude=*.pyc",
-                    "--exclude=*.pyo",
-                    "-cjf",
-                    tmp.abspath,
-                    "-C",
-                    ana_path,
-                ]
-                + include_args,
-                check=True,
-            )
+            with tempfile.TemporaryDirectory() as staging:
+                found_any = False
+                for pattern in formatted_patterns:
+                    full_path = os.path.join(ana_path, pattern)
+                    # Resolve top-level symlinks so the staging copy uses real content,
+                    # but symlinks *within* the directory are preserved as symlinks.
+                    # This prevents --dereference from following CVMFS symlinks inside flaf_env.
+                    real_path = os.path.realpath(full_path)
+                    if not os.path.exists(real_path):
+                        print(
+                            f"bundle[{self.flavour}]: warning: '{pattern}' not found, skipping"
+                        )
+                        continue
+                    found_any = True
+                    dest = os.path.join(staging, pattern)
+                    os.makedirs(os.path.dirname(dest), exist_ok=True)
+                    if os.path.isdir(real_path):
+                        shutil.copytree(real_path, dest, symlinks=True)
+                    else:
+                        shutil.copy2(real_path, dest)
+
+                if not found_any:
+                    raise RuntimeError(
+                        f"No files found for bundle flavour '{self.flavour}'"
+                    )
+
+                subprocess.run(
+                    [
+                        "tar",
+                        "--exclude=*/__pycache__",
+                        "--exclude=*.pyc",
+                        "--exclude=*.pyo",
+                        "-cjf",
+                        tmp.abspath,
+                        "-C",
+                        staging,
+                        ".",
+                    ],
+                    check=True,
+                )
         print(f"bundle[{self.flavour}]: done")
 
 

--- a/run_tools/law_customizations.py
+++ b/run_tools/law_customizations.py
@@ -509,10 +509,6 @@ class HTCondorWorkflow(law.htcondor.HTCondorWorkflow):
             ("environment", '"LAW_HTCONDOR_JOB_POSTFIX=$(law_job_postfix)"')
         )
 
-        # Redirect the log file HTCondor transfer to /dev/null so the sandbox
-        # copy is discarded rather than written to AFS.
-        config.output_files["stdall.txt"] = "/dev/null"
-
         # Compute the remote destination directory for the stageout script.
         log_remote_base_url = ""
         if isinstance(self.fs_default, WLCGFileSystem):
@@ -520,6 +516,12 @@ class HTCondorWorkflow(law.htcondor.HTCondorWorkflow):
                 self.version, "logs", self.__class__.__name__, self.period
             ).uri()
         config.render_variables["log_remote_base_url"] = log_remote_base_url
+
+        # Redirect the sandbox log copy to /dev/null only when stageout will
+        # actually upload it; otherwise keep the file so HTCondor transfers it
+        # back to the submit node for local debugging.
+        if log_remote_base_url:
+            config.output_files["stdall.txt"] = "/dev/null"
 
         # bundle: build a space-separated list of "flavour:url" pairs for bootstrap.sh.
         if self.bundle and self.bundle_flavours:

--- a/run_tools/stageout_logs.sh
+++ b/run_tools/stageout_logs.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+log_remote_base_url="{{log_remote_base_url}}"
+
+if [ -z "${log_remote_base_url}" ]; then
+    echo "stageout_logs: no remote log URL configured, skipping"
+    exit 0
+fi
+
+postfix="${LAW_HTCONDOR_JOB_POSTFIX}"
+if [ -n "${postfix}" ]; then
+    log_file="stdall${postfix}.txt"
+else
+    cluster="${LAW_HTCONDOR_JOB_CLUSTER}"
+    process="${LAW_HTCONDOR_JOB_PROCESS}"
+    if [ -n "${cluster}" ] && [ -n "${process}" ]; then
+        log_file="stdall_${cluster}_${process}.txt"
+    else
+        log_file="stdall.txt"
+    fi
+fi
+
+if [ -n "${LAW_JOB_INIT_DIR}" ]; then
+    log_path="${LAW_JOB_INIT_DIR}/${log_file}"
+else
+    log_path="${log_file}"
+fi
+
+if [ ! -f "${log_path}" ]; then
+    echo "stageout_logs: log file '${log_path}' not found, skipping"
+    exit 0
+fi
+
+log_remote_url="${log_remote_base_url%/}/${log_file}"
+
+GFAL_COPY=$(which gfal-copy 2>/dev/null)
+if [ -z "${GFAL_COPY}" ]; then
+    echo "stageout_logs: gfal-copy not found in PATH, skipping"
+    exit 0
+fi
+
+if [ -z "${X509_USER_PROXY:-}" ] && [ -f "${LAW_JOB_INIT_DIR}/voms.proxy" ]; then
+    chmod 600 "${LAW_JOB_INIT_DIR}/voms.proxy"
+    export X509_USER_PROXY="${LAW_JOB_INIT_DIR}/voms.proxy"
+fi
+
+local_url="file://$(realpath "${log_path}")"
+echo "stageout_logs: uploading '${log_path}' to '${log_remote_url}'"
+env -i X509_USER_PROXY="${X509_USER_PROXY}" "${GFAL_COPY}" -p -f "${local_url}" "${log_remote_url}"
+ret=$?
+if [ "${ret}" != "0" ]; then
+    echo "stageout_logs: upload failed with exit code ${ret}, continuing"
+fi
+exit 0

--- a/test/hello_world_task.py
+++ b/test/hello_world_task.py
@@ -1,19 +1,32 @@
 import law
+import luigi
 
 from FLAF.run_tools.law_customizations import Task, HTCondorWorkflow, copy_param
 
 
 class HelloWorldTask(Task, HTCondorWorkflow, law.LocalWorkflow):
-    max_runtime = copy_param(HTCondorWorkflow.max_runtime, 1.0)
+    max_runtime = copy_param(HTCondorWorkflow.max_runtime, 0.1)
     n_cpus = copy_param(HTCondorWorkflow.n_cpus, 1)
+    poll_interval = copy_param(HTCondorWorkflow.poll_interval, 1)
+    bundle_flavours = ["core"]
+    force_fail = luigi.BoolParameter(
+        default=False,
+        significant=False,
+        description="raise an exception in run() to test log transfer on crash",
+    )
 
     def create_branch_map(self):
         return {0: "hello"}
 
     def output(self):
-        return self.local_target("hello_world_done.txt")
+        return self.remote_target(
+            self.version, self.__class__.__name__, self.period, "hello_world_done.txt"
+        )
 
     def run(self):
+        if self.force_fail:
+            raise RuntimeError("Forced failure for testing log transfer on crash")
         print("hello world")
-        with open(self.output().path, "w") as f:
-            f.write("done\n")
+        with self.output().localize("w") as tmp:
+            with open(tmp.path, "w") as f:
+                f.write("done\n")


### PR DESCRIPTION
Allow creating a tarball of the repository to fully ship the code to the working node and eliminate dependence on the original FW installation area.
Also, storing logs in the remote storage to avoid AFS overloads.