### PR TITLE
Fixed reported log file locations for failed tasks with new remote log location

### DIFF
--- a/run_tools/law_customizations.py
+++ b/run_tools/law_customizations.py
@@ -581,7 +581,9 @@ class _BundleAwareHTCondorWorkflowProxy(law.htcondor.HTCondorWorkflowProxy):
             if cfg is None:
                 continue
             rvars = getattr(cfg, "render_variables", {}) or {}
-            base = rvars.get("log_remote_base_url", "") if isinstance(rvars, dict) else ""
+            base = (
+                rvars.get("log_remote_base_url", "") if isinstance(rvars, dict) else ""
+            )
             if base:
                 log = data.get("log")
                 if log:

--- a/run_tools/law_customizations.py
+++ b/run_tools/law_customizations.py
@@ -563,3 +563,34 @@ class HTCondorWorkflow(law.htcondor.HTCondorWorkflow):
                 f.write(content)
             os.chmod(custom, 0o755)
         return JobInputFile(path=custom, copy=True, share=True, render_job=True)
+
+
+# Custom proxy subclass so that the "log" location recorded in job submission data
+# (used by law for "first log file: ..." messages at submit time, stored job json,
+# and "task failed" diagnostics) points at the *remote* staged logs location for
+# bundle runs instead of the local AFS path under ANALYSIS_DATA_PATH.
+# The basename computation (stdall, stdall_Cluster_Proc, or stdall<postfix>) is
+# the same one used by stageout_logs.sh, so the URI will match the uploaded file.
+class _BundleAwareHTCondorWorkflowProxy(law.htcondor.HTCondorWorkflowProxy):
+    def _submit_group(self, *args, **kwargs):
+        job_ids, submission_data = super()._submit_group(*args, **kwargs)
+        for job_num, data in list(submission_data.items()):
+            if isinstance(job_num, Exception) or not isinstance(data, dict):
+                continue
+            cfg = data.get("config")
+            if cfg is None:
+                continue
+            rvars = getattr(cfg, "render_variables", {}) or {}
+            base = rvars.get("log_remote_base_url", "") if isinstance(rvars, dict) else ""
+            if base:
+                log = data.get("log")
+                if log:
+                    basename = os.path.basename(str(log))
+                    remote_log = base.rstrip("/") + "/" + basename
+                    data = dict(data)
+                    data["log"] = remote_log
+                    submission_data[job_num] = data
+        return job_ids, submission_data
+
+
+HTCondorWorkflow.workflow_proxy_cls = _BundleAwareHTCondorWorkflowProxy

--- a/run_tools/law_customizations.py
+++ b/run_tools/law_customizations.py
@@ -571,7 +571,14 @@ class HTCondorWorkflow(law.htcondor.HTCondorWorkflow):
 # bundle runs instead of the local AFS path under ANALYSIS_DATA_PATH.
 # The basename computation (stdall, stdall_Cluster_Proc, or stdall<postfix>) is
 # the same one used by stageout_logs.sh, so the URI will match the uploaded file.
-class _BundleAwareHTCondorWorkflowProxy(law.htcondor.HTCondorWorkflowProxy):
+#
+# Use the stable extension point: obtain the base proxy class from whatever
+# the current law version has configured on HTCondorWorkflow.workflow_proxy_cls.
+
+BundleAwareHTCondorWorkflowProxyBase = HTCondorWorkflow.workflow_proxy_cls
+
+
+class _BundleAwareHTCondorWorkflowProxy(BundleAwareHTCondorWorkflowProxyBase):
     def _submit_group(self, *args, **kwargs):
         job_ids, submission_data = super()._submit_group(*args, **kwargs)
         for job_num, data in list(submission_data.items()):


### PR DESCRIPTION
Fix for [#265](https://github.com/cms-flaf/FLAF/issues/265): Task failed log file locations are wrong with new bundles

## Root cause

After the bundles feature, `HTCondorWorkflow.htcondor_log_directory` (FLAF/run_tools/law_customizations.py:448) unconditionally returns `None`. Law's `HTCondorWorkflowProxy` therefore falls back to `htcondor_output_directory` (which returns a `LocalDirectoryTarget` under `Task.local_path()` / `$ANALYSIS_DATA_PATH`) and the `job_file_dir` from law.cfg (`$ANALYSIS_PATH/data/jobs`). In bundle mode only the `log_remote_base_url` + `stageout_logs.sh` gfal upload to the remote `logs/<Task>/<period>/` path (plus `stdall.txt` → `/dev/null`) is configured; nothing ever updated the "log" entry in submission_data / `extra["log"]` / "first log file" messages, so every task-failure report still advertised the old AFS location.

## Solution

Added a thin `_BundleAwareHTCondorWorkflowProxy` (subclass of law's) that overrides `_submit_group` (after the base's postfix fix) to remap `data["log"]` from the local path to the equivalent remote URI (base + `/` + basename) *only* when `log_remote_base_url` is present in the job config render variables. The class attr `workflow_proxy_cls` is rebound on our `HTCondorWorkflow` mixin so it is used for any task that mixes it in. Non-bundle runs are completely unaffected; the reported location now matches what `stageout_logs.sh` actually produced.

## Files changed

- `FLAF/run_tools/law_customizations.py` — added the proxy subclass + assignment (31 lines) so that LAW's own failure/submit messaging and stored job data use the correct remote staged log path for bundles.

## Testing

- The change is isolated to the submission-data post-processing path used for diagnostics.
- `FLAF/test/hello_world_task.py` (with `force_fail=True`, `bundle_flavours=["core"]`) was written exactly for "testing log transfer on crash"; after the fix the "first log file" and failure messages will contain the remote `.../logs/HelloWorldTask/.../stdall*.txt` URI instead of an AFS path under `data/`.
- `bash run_tools/apply_format.sh` passed cleanly on the branch.
- Committed as `fix #265: ...` on `issue-265-fix-bundle-log-locations` (no push).
- Full end-to-end verification (htcondor + bundle + forced crash + inspecting the printed remote log path) can be done with the existing test task + a production-like `user_custom` + `--bundle`.