### PR TITLE
Integrate RunKit tools into FLAF, drop RunKit submodule

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -7,7 +7,8 @@
 - **Repository size**: ~2 MB
 - **Languages**: Python (~13,000 lines), C++ headers, Bash scripts, YAML configs
 - **Target environment**: CERN lxplus (AlmaLinux 9), requires CVMFS and CMSSW
-- **Submodules**: `RunKit`, `PlotKit` (must be cloned with `--recursive`)
+- **Submodules**: `PlotKit` (must be cloned with `--recursive`)
+- **Vendored**: `RunKit` (subset of workflow utilities, integrated directly — no longer a submodule)
 
 ## Project Structure
 
@@ -24,7 +25,7 @@ FLAF/
 ├── include/                    # C++ headers for ROOT analysis
 ├── run_tools/                  # Helper scripts (mk_flaf_env.sh, law_customizations.py)
 ├── test/                       # Test scripts (checkDatasetConfigConsistency.py)
-├── RunKit/                     # Git submodule for workflow utilities
+├── RunKit/                     # Vendored subset of RunKit workflow utilities
 ├── PlotKit/                    # Git submodule for plotting
 ├── env.sh                      # Main environment setup script
 ├── bootstrap.sh                # HTCondor bootstrap script

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ __pycache__
 /.vscode
 /site
 /config/user_custom.yaml
+/RunKit/.dasmaps
+/RunKit/.gfal_copy_safe_tmp

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "RunKit"]
-	path = RunKit
-	url = git@github.com:kandrosov/RunKit.git
 [submodule "PlotKit"]
 	path = PlotKit
 	url = git@github.com:kandrosov/PlotKit.git

--- a/Common/Utilities.py
+++ b/Common/Utilities.py
@@ -464,7 +464,7 @@ def InitializeCorrections(setup, dataset_name, stage):
 class ServiceThread:
     def __init__(self):
         import threading
-        from FLAF.RunKit.crabLaw import cond, update_kinit_thread
+        from FLAF.RunKit.kinit import cond, update_kinit_thread
 
         self.cond = cond
         self.thread = threading.Thread(target=update_kinit_thread)

--- a/RunKit/envToJson.py
+++ b/RunKit/envToJson.py
@@ -1,0 +1,75 @@
+import json
+import os
+import sys
+
+if __name__ == "__main__":
+    file_dir = os.path.dirname(os.path.abspath(__file__))
+    sys.path.append(os.path.dirname(file_dir))
+    __package__ = "RunKit"
+
+from .run_tools import ps_call
+
+
+def get_env(script, python_cmd="python3", singularity_cmd=None):
+    magic_str = "---envToJson.py---"
+
+    cmd = f'{script}; echo {magic_str}; {python_cmd} -c "import json, os; print(json.dumps(dict(os.environ)))"'
+    if singularity_cmd:
+        cmd = f"{singularity_cmd} --command-to-run '{cmd}'"
+    returncode, output, err = ps_call(
+        [cmd],
+        shell=True,
+        env={},
+        catch_stdout=True,
+        catch_stderr=True,
+        split="\n",
+        verbose=0,
+    )
+    for n, line in enumerate(output):
+        if line == magic_str:
+            break
+    env = json.loads(output[n + 1])
+    to_del = ["_"]
+    if singularity_cmd:
+        to_del.extend(
+            [
+                "APPTAINER_COMMAND",
+                "APPTAINER_CONTAINER",
+                "SINGULARITY_CONTAINER",
+                "APPTAINER_BIND",
+                "APPTAINER_NAME",
+                "SINGULARITY_ENVIRONMENT",
+                "SINGULARITY_NAME",
+                "APPTAINER_APPNAME",
+                "APPTAINER_ENVIRONMENT",
+                "SINGULARITY_BIND",
+            ]
+        )
+    for key in to_del:
+        if key in env:
+            del env[key]
+    return env
+
+
+def get_cmsenv(
+    cmssw_path, python_cmd=None, crab_env=False, crab_type="", singularity_cmd=None
+):
+    script = f'source /cvmfs/cms.cern.ch/cmsset_default.sh; cd "{cmssw_path}"; eval `scramv1 runtime -sh`'
+    if not python_cmd:
+        python_cmd = "python3"
+        _, cmssw_release_str = os.path.split(os.path.abspath(cmssw_path))
+        cmssw_id_parts = cmssw_release_str.split("_")
+        if len(cmssw_id_parts) > 1 and int(cmssw_id_parts[1]) < 10:
+            python_cmd = "python"
+    if crab_env:
+        if python_cmd != "python":
+            script += "; alias python=$(which python3)"
+        script += f"; source /cvmfs/cms.cern.ch/common/crab-setup.sh {crab_type}"
+    return get_env(script, python_cmd=python_cmd, singularity_cmd=singularity_cmd)
+
+
+if __name__ == "__main__":
+    script = " ".join(sys.argv[1:])
+    # env = get_env(script)
+    env = get_cmsenv(sys.argv[1])
+    print(json.dumps(env, indent=2))

--- a/RunKit/grid_helper_tasks.py
+++ b/RunKit/grid_helper_tasks.py
@@ -1,0 +1,48 @@
+import law
+import luigi
+import os
+import re
+
+from .run_tools import ps_call
+from .grid_tools import get_voms_proxy_info
+
+
+class CreateVomsProxy(law.Task):
+    time_limit = luigi.Parameter(default="24")
+
+    def __init__(self, *args, **kwargs):
+        super(CreateVomsProxy, self).__init__(*args, **kwargs)
+        self.proxy_path = os.getenv("X509_USER_PROXY")
+        if os.path.exists(self.proxy_path):
+            proxy_info = get_voms_proxy_info()
+            timeleft = proxy_info.get("timeleft", 0.0)
+            if timeleft < float(self.time_limit):
+                self.publish_message(
+                    f"Removing old proxy which expires in a less than {timeleft:.1f} hours."
+                )
+                self.output().remove()
+
+    def output(self):
+        return law.LocalFileTarget(self.proxy_path)
+
+    def create_proxy(self, proxy_file):
+        self.publish_message("Creating voms proxy...")
+        proxy_file.makedirs()
+        ps_call(
+            [
+                "voms-proxy-init",
+                "-voms",
+                "cms",
+                "-rfc",
+                "-valid",
+                "192:00",
+                "--out",
+                proxy_file.path,
+            ]
+        )
+
+    def run(self):
+        proxy_file = self.output()
+        self.create_proxy(proxy_file)
+        if not proxy_file.exists():
+            raise RuntimeError("Unable to create voms proxy")

--- a/RunKit/grid_tools.py
+++ b/RunKit/grid_tools.py
@@ -1,0 +1,706 @@
+import datetime
+import json
+import os
+import re
+import sys
+
+if __name__ == "__main__":
+    file_dir = os.path.dirname(os.path.abspath(__file__))
+    sys.path.append(os.path.dirname(file_dir))
+    __package__ = "RunKit"
+
+from .run_tools import ps_call, repeat_until_success, adler32sum, PsCallError
+
+COPY_TMP_SUFFIX = ".tmp"
+COPY_TMP_LOCAL_FILE = os.path.join(
+    os.path.dirname(os.path.abspath(__file__)), ".gfal_copy_safe_tmp"
+)
+CHECK_WRITE_SUFFIX = ".check"
+
+
+class FileInfo:
+    def __init__(self, name=None, path=None, size=None, date=None, is_dir=None):
+        self.name = name
+        self.path = path
+        self.size = size
+        self.date = date
+        self.is_dir = is_dir
+
+    @property
+    def full_name(self):
+        return os.path.join(self.path, self.name)
+
+    def __str__(self):
+        date_str = (
+            self.date.strftime("%Y-%m-%dT%H:%M") if self.date is not None else None
+        )
+        return f'name="{self.name}", path="{self.path}", size={self.size}, date={date_str}, is_dir={self.is_dir}'
+
+    def __repr__(self):
+        return self.__str__()
+
+
+class GfalError(RuntimeError):
+    def __init__(self, msg):
+        super(GfalError, self).__init__(msg)
+
+
+def get_voms_proxy_info():
+    _, output, _ = ps_call(["voms-proxy-info"], catch_stdout=True, split="\n")
+    info = {}
+    for line in output:
+        if len(line) == 0:
+            continue
+        match = re.match(r"^(.+) : (.+)", line)
+        key = match.group(1).strip()
+        info[key] = match.group(2)
+    if "timeleft" in info:
+        h, m, s = info["timeleft"].split(":")
+        info["timeleft"] = float(h) + (float(m) + float(s) / 60.0) / 60.0
+    return info
+
+
+def get_voms_proxy_token(voms_token=None):
+    if voms_token is None:
+        return get_voms_proxy_info()["path"]
+    return voms_token
+
+
+def check_download(
+    local_file,
+    expected_adler32sum=None,
+    raise_error=False,
+    remote_file=None,
+    remove_bad_file=False,
+):
+    if expected_adler32sum is not None:
+        asum = adler32sum(local_file)
+        if asum != expected_adler32sum:
+            if remove_bad_file:
+                os.remove(local_file)
+            if raise_error:
+                remote_name = remote_file if remote_file is not None else "file"
+                raise RuntimeError(
+                    f"Unable to copy {remote_name} from remote. Failed adler32sum check."
+                    + f" {asum:x} != {expected_adler32sum:x}."
+                )
+            return False
+    return True
+
+
+def xrd_copy(
+    input_remote_file,
+    output_local_file,
+    n_retries=4,
+    n_retries_xrdcp=4,
+    n_streams=1,
+    retry_sleep_interval=10,
+    expected_adler32sum=None,
+    verbose=1,
+    prefixes=[
+        "root://cms-xrd-global.cern.ch/",
+        "root://xrootd-cms.infn.it/",
+        "root://cmsxrootd.fnal.gov/",
+    ],
+):
+    def download(prefix):
+        xrdcp_args = [
+            "xrdcp",
+            "--retry",
+            str(n_retries_xrdcp),
+            "--streams",
+            str(n_streams),
+        ]
+        if os.path.exists(output_local_file):
+            xrdcp_args.append("--continue")
+        if verbose == 0:
+            xrdcp_args.append("--silent")
+        xrdcp_args.extend([f"{prefix}{input_remote_file}", output_local_file])
+        ps_call(xrdcp_args, verbose=1)
+
+        check_download(
+            output_local_file,
+            expected_adler32sum=expected_adler32sum,
+            remove_bad_file=True,
+            raise_error=True,
+            remote_file=input_remote_file,
+        )
+
+    if os.path.exists(output_local_file):
+        os.remove(output_local_file)
+
+    if input_remote_file.startswith("/store/"):
+        optlist = [(prefix,) for prefix in prefixes]
+    else:
+        optlist = [("",)]
+
+    repeat_until_success(
+        download,
+        opt_list=optlist,
+        n_retries=n_retries,
+        retry_sleep_interval=retry_sleep_interval,
+        exception=GfalError(f"Unable to copy {input_remote_file} from remote."),
+        verbose=verbose,
+    )
+
+
+def create_tmp_local_file():
+    if not os.path.exists(COPY_TMP_LOCAL_FILE):
+        with open(COPY_TMP_LOCAL_FILE, "w") as f:
+            f.write("0")
+    return COPY_TMP_LOCAL_FILE
+
+
+def gfal_env(voms_token):
+    return {"X509_USER_PROXY": voms_token, "GFAL_PYTHONBIN": "/usr/bin/python3"}
+
+
+def gfal_copy_safe(
+    input_file,
+    output_file,
+    voms_token=None,
+    number_of_streams=2,
+    timeout=7200,
+    expected_adler32sum=None,
+    n_retries=4,
+    retry_sleep_interval=10,
+    copy_mode="copy_flag",
+    verbose=1,
+):
+    voms_token = get_voms_proxy_token(voms_token)
+    if expected_adler32sum is None:
+        try:
+            stat = gfal_stat(input_file, voms_token=voms_token)
+            if stat["type"] == "regular file":
+                expected_adler32sum = gfal_sum(
+                    input_file, voms_token=voms_token, sum_type="adler32"
+                )
+        except GfalError as e:
+            if verbose > 0:
+                print(f'WARNING: gfal_sum failed for "{input_file}".\n{e}')
+    if copy_mode not in ["copy_rename", "copy_flag"]:
+        raise RuntimeError(f'gfal_copy_safe: unknown copy mode "{copy_mode}".')
+    if copy_mode == "copy_flag":
+        tmp_local_file = create_tmp_local_file()
+    output_file_tmp = output_file + COPY_TMP_SUFFIX
+    output_file_sum_target = (
+        output_file if copy_mode == "copy_flag" else output_file_tmp
+    )
+    attempt = -1
+
+    def download():
+        nonlocal attempt
+        attempt += 1
+        active_verbose = min(verbose + attempt if verbose > 0 else 0, 2)
+        if gfal_exists(output_file, voms_token=voms_token):
+            gfal_rm(output_file, voms_token=voms_token, recursive=False)
+        if gfal_exists(output_file_tmp, voms_token=voms_token):
+            gfal_rm(output_file_tmp, voms_token=voms_token, recursive=False)
+        if copy_mode == "copy_flag":
+            gfal_copy(
+                tmp_local_file,
+                output_file_tmp,
+                voms_token=voms_token,
+                number_of_streams=number_of_streams,
+                timeout=timeout,
+                verbose=active_verbose,
+            )
+            gfal_copy(
+                input_file,
+                output_file,
+                voms_token=voms_token,
+                number_of_streams=number_of_streams,
+                timeout=timeout,
+                verbose=active_verbose,
+            )
+        elif copy_mode == "copy_rename":
+            gfal_copy(
+                input_file,
+                output_file_tmp,
+                voms_token=voms_token,
+                number_of_streams=number_of_streams,
+                timeout=timeout,
+                verbose=active_verbose,
+            )
+        if expected_adler32sum is not None:
+            output_adler32sum = gfal_sum(
+                output_file_sum_target, voms_token=voms_token, sum_type="adler32"
+            )
+            if output_adler32sum != expected_adler32sum:
+                raise GfalError(
+                    f'Failed adler32sum check for "{output_file_sum_target}".'
+                    f" {output_adler32sum:x} != {expected_adler32sum:x}."
+                )
+        if copy_mode == "copy_flag":
+            gfal_rm(output_file_tmp, voms_token=voms_token, recursive=False)
+        elif copy_mode == "copy_rename":
+            gfal_rename(output_file_tmp, output_file, voms_token=voms_token)
+            if not gfal_exists(output_file, voms_token=voms_token):
+                raise GfalError(
+                    f'Failed to rename "{output_file_tmp}" to "{output_file}".'
+                )
+
+    repeat_until_success(
+        download,
+        n_retries=n_retries,
+        retry_sleep_interval=retry_sleep_interval,
+        verbose=verbose,
+        exception=GfalError(f'Unable to copy "{input_file}" to "{output_file}".'),
+    )
+
+
+def gfal_copy(
+    input_file,
+    output_file,
+    voms_token=None,
+    number_of_streams=2,
+    timeout=7200,
+    verbose=1,
+):
+    voms_token = get_voms_proxy_token(voms_token)
+    try:
+        catch_output = verbose == 0
+        cmd = [
+            "gfal-copy",
+            "--parent",
+            "--recursive",
+            "--nbstreams",
+            str(number_of_streams),
+            "--timeout",
+            str(timeout),
+        ]
+        if verbose > 1:
+            n_v = min(3, verbose - 1)
+            cmd.append("-" + "v" * n_v)
+        cmd.extend([input_file, output_file])
+        ps_call(
+            cmd,
+            shell=False,
+            env=gfal_env(voms_token),
+            verbose=verbose,
+            catch_stdout=catch_output,
+            catch_stderr=catch_output,
+        )
+    except PsCallError as e:
+        raise GfalError(
+            f'gfal_copy: unable to copy "{input_file}" to "{output_file}"\n{e}'
+        ) from None
+
+
+def gfal_ls(path, voms_token=None, catch_stderr=False, verbose=1):
+    voms_token = get_voms_proxy_token(voms_token)
+    try:
+        _, output, _ = ps_call(
+            ["gfal-ls", "--long", "--all", "--time-style", "long-iso", path],
+            shell=False,
+            env=gfal_env(voms_token),
+            catch_stdout=True,
+            catch_stderr=catch_stderr,
+            split="\n",
+            verbose=verbose,
+        )
+    except PsCallError as e:
+        raise GfalError(f'gfal_ls: unable to list "{path}"\n{e}') from None
+    files = []
+    for line in output:
+        if len(line) == 0:
+            continue
+        items = re.match(
+            r"^([rwx\-d]+) +[0-9]+ +[0-9]+ +[0-9]+ +([0-9]+) +([0-9\-]+ [0-9:]+) +(.*)$",
+            line,
+        )
+        if items is None:
+            raise GfalError(f'gfal_ls: unable to parse "{line}"')
+        file = FileInfo()
+        file.name = items.group(4).strip()
+        if file.name in [".", ".."]:
+            continue
+        if file.name == path:
+            file.path, file.name = os.path.split(path)
+        else:
+            file.path = path
+        file.size = int(items.group(2))
+        file.date = datetime.datetime.strptime(items.group(3), "%Y-%m-%d %H:%M")
+        file.is_dir = items.group(1).startswith("d")
+        files.append(file)
+    return files
+
+
+def gfal_ls_recursive(path, voms_token=None, verbose=1):
+    voms_token = get_voms_proxy_token(voms_token)
+    all_files = []
+    path_files = gfal_ls(path, voms_token=voms_token, verbose=verbose)
+    for file in path_files:
+        all_files.append(file)
+        if file.is_dir:
+            all_files.extend(
+                gfal_ls_recursive(
+                    file.full_name, voms_token=voms_token, verbose=verbose
+                )
+            )
+    return sorted(set(all_files), key=lambda f: f.full_name)
+
+
+def gfal_ls_safe(path, voms_token=None, catch_stderr=False, verbose=1):
+    try:
+        return gfal_ls(
+            path, voms_token=voms_token, catch_stderr=catch_stderr, verbose=verbose
+        )
+    except GfalError:
+        return None
+
+
+def gfal_stat(path, voms_token=None):
+    voms_token = get_voms_proxy_token(voms_token)
+    result = {"size": None, "type": None}
+    try:
+        _, stdout, _ = ps_call(
+            ["gfal-stat", path],
+            shell=False,
+            env=gfal_env(voms_token),
+            catch_stdout=True,
+            catch_stderr=True,
+            decode=True,
+            split="\n",
+        )
+
+        if len(stdout) > 1:
+            match = re.match(r"  Size: ([0-9]+) *(.+)", stdout[1])
+            if match is not None:
+                result["size"] = int(match.group(1))
+                result["type"] = match.group(2).strip()
+    except PsCallError as e:
+        pass
+    return result
+
+
+def gfal_exists(path, voms_token=None):
+    voms_token = get_voms_proxy_token(voms_token)
+    try:
+        ps_call(
+            ["gfal-stat", path],
+            shell=False,
+            env=gfal_env(voms_token),
+            catch_stdout=True,
+            catch_stderr=True,
+        )
+    except PsCallError as e:
+        return False
+    return True
+
+
+def gfal_check_write(path, return_exception=False, voms_token=None, verbose=0):
+    voms_token = get_voms_proxy_token(voms_token)
+    target_path = path + CHECK_WRITE_SUFFIX
+    tmp_local_file = create_tmp_local_file()
+    result = (True, None)
+    try:
+        if gfal_exists(target_path, voms_token=voms_token):
+            gfal_rm(target_path, voms_token=voms_token, recursive=False)
+        gfal_copy(tmp_local_file, target_path, voms_token=voms_token, verbose=verbose)
+        gfal_rm(target_path, voms_token=voms_token, verbose=verbose)
+    except GfalError as e:
+        result = (False, e)
+    if return_exception:
+        return result
+    return result[0]
+
+
+def gfal_sum(path, voms_token=None, sum_type="adler32"):
+    voms_token = get_voms_proxy_token(voms_token)
+    try:
+        _, output, _ = ps_call(
+            ["gfal-sum", path, sum_type],
+            shell=False,
+            env=gfal_env(voms_token),
+            catch_stdout=True,
+        )
+        sum_str = output.split(" ")[-1]
+        sum_int = int(sum_str, 16)
+    except PsCallError as e:
+        raise GfalError(
+            f'gfal_sum: unable to get {sum_type} for "{path}"\n{e}'
+        ) from None
+    except ValueError as e:
+        raise GfalError(
+            f'gfal_sum: unable to parse {sum_type} for "{path}".'
+            f"\ngfal-sum output:\n--------\n{output}--------\n{e}"
+        ) from None
+    return sum_int
+
+
+def gfal_rm(path, voms_token=None, recursive=False, verbose=0, timeout=1800):
+    voms_token = get_voms_proxy_token(voms_token)
+    cmd = ["gfal-rm", "-t", str(timeout)]
+    if recursive:
+        cmd.append("-r")
+    cmd.append(path)
+    try:
+        ps_call(
+            cmd,
+            shell=False,
+            env=gfal_env(voms_token),
+            catch_stdout=(verbose == 0),
+            verbose=verbose,
+        )
+    except PsCallError as e:
+        raise GfalError(f'gfal_rm: unable to remove "{path}"\n{e}') from None
+
+
+def gfal_rm_recursive(path, voms_token=None, timeout=86400):
+    gfal_rm(path, voms_token=voms_token, recursive=True, verbose=1, timeout=timeout)
+
+
+def gfal_rename(path, new_path, voms_token=None):
+    voms_token = get_voms_proxy_token(voms_token)
+    try:
+        ps_call(
+            ["gfal-rename", path, new_path],
+            shell=False,
+            env=gfal_env(voms_token),
+            catch_stdout=True,
+        )
+    except PsCallError as e:
+        raise GfalError(
+            f'gfal_rename: unable to rename "{path}" to "{new_path}"\n{e}'
+        ) from None
+
+
+def lfn_to_pfn(server, lfn):
+    from rucio.client import Client
+
+    client = Client()
+    key = f"user.jdoe:{lfn}"
+    result = client.lfns2pfns(server, [key])
+    return result[key]
+
+
+def path_to_pfn(path, *sub_paths):
+    if path.startswith("T"):
+        server, lfn = path.split(":")
+        pfn = lfn_to_pfn(server, lfn)
+    else:
+        pfn = path
+    return os.path.join(pfn, *sub_paths)
+
+
+def get_local_site():
+    local_conf = "/cvmfs/cms.cern.ch/SITECONF/local"
+    if os.path.exists(local_conf) and os.path.islink(local_conf):
+        return os.readlink(local_conf)
+    return None
+
+
+def get_distances(local_site, sites):
+    distances = {}
+    try:
+        from rucio.client import Client
+    except ImportError:
+        try:
+            _, out, _ = ps_call(
+                """
+        ARCH=$(uname -m)/$(/cvmfs/cms.cern.ch/common/cmsos | cut -d_ -f1 | sed 's|^[a-z]*|rhel|');
+        echo /cvmfs/cms.cern.ch/rucio/$ARCH/py3/current;
+        echo /cvmfs/cms.cern.ch/rucio/$ARCH/py3/current/lib/python*/site-packages""",
+                shell=True,
+                catch_stdout=True,
+                split="\n",
+            )
+            sys.path.append(out[1])
+            os.environ["RUCIO_HOME"] = out[0]
+            from rucio.client import Client
+        except:
+
+            class Client:
+                def get_distance(self, site1, site2):
+                    return [{"distance": 1}]
+
+    client = Client()
+    for site in sites:
+        if local_site is None or site == local_site:
+            distances[site] = 0
+        else:
+            try:
+                dist = client.get_distance(site, local_site)
+            except:
+                dist = []
+            if len(dist) > 0:
+                distances[site] = dist[0]["distance"]
+            else:
+                distances[site] = float("inf")
+    return distances
+
+
+def run_dasgoclient(
+    query, inputDBS="global", json_output=False, timeout=None, verbose=0
+):
+    if inputDBS != "global":
+        query += f" instance=prod/{inputDBS}"
+    cmd = ["/cvmfs/cms.cern.ch/common/dasgoclient", "--query", query]
+    if json_output:
+        cmd.append("--json")
+    env = {
+        "PATH": "/usr/bin",
+        "X509_USER_PROXY": os.environ["X509_USER_PROXY"],
+        "HOME": os.environ.get("HOME", os.getcwd()),
+    }
+    split = None if json_output else "\n"
+    _, output, _ = ps_call(
+        cmd, catch_stdout=True, split=split, timeout=timeout, verbose=verbose, env=env
+    )
+    if json_output:
+        return json.loads(output)
+    return [line.strip() for line in output if len(line.strip()) > 0]
+
+
+def das_file_site_info(file, inputDBS="global", verbose=0):
+    return run_dasgoclient(
+        f"site file={file}", inputDBS=inputDBS, json_output=True, verbose=verbose
+    )
+
+
+def das_file_pfns(
+    file,
+    disk_only=True,
+    return_adler32=False,
+    inputDBS="global",
+    keep_rse=False,
+    verbose=0,
+):
+    site_info = das_file_site_info(file, inputDBS=inputDBS, verbose=verbose)
+    pfns_all = {}
+    adler32 = None
+    for entry in site_info:
+        if "site" not in entry:
+            continue
+        for site in entry["site"]:
+            if "pfns" not in site:
+                continue
+            for pfns_link, pfns_info in site["pfns"].items():
+                pnfs_type = pfns_info.get("type", "UNKNOWN")
+                if pnfs_type not in pfns_all:
+                    pfns_all[pnfs_type] = set()
+                entry = (pfns_link, pfns_info["rse"]) if keep_rse else pfns_link
+                pfns_all[pnfs_type].add(entry)
+            if "adler32" in site:
+                site_adler32 = int(site["adler32"], 16)
+                if adler32 is not None and adler32 != site_adler32:
+                    raise RuntimeError(f"Inconsistent adler32 sum for {file}")
+                adler32 = site_adler32
+    if disk_only:
+        pfns = pfns_all.get("DISK", set())
+    else:
+        pfns = pfns_all
+    if return_adler32:
+        return pfns, adler32
+    return pfns
+
+
+def copy_remote_file(
+    input_remote_file,
+    output_local_file,
+    inputDBS="global",
+    n_retries=4,
+    retry_sleep_interval=10,
+    custom_pfns_prefix="",
+    voms_token=None,
+    verbose=1,
+):
+    voms_token = get_voms_proxy_token(voms_token)
+    from_das = input_remote_file.startswith("/store/")
+    if from_das:
+        pfns_info, adler32 = das_file_pfns(
+            input_remote_file,
+            disk_only=True,
+            return_adler32=True,
+            inputDBS=inputDBS,
+            keep_rse=True,
+            verbose=verbose,
+        )
+        sites = [rse for _, rse in pfns_info]
+        local_site = get_local_site()
+        distances = get_distances(local_site, sites)
+        pfns_info = [(pfns, rse, distances[rse]) for pfns, rse in pfns_info]
+        pfns_info = sorted(pfns_info, key=lambda x: (x[2], x[1]))
+        if verbose > 0:
+            print("Avaliable pfns:")
+            for pfns, rse, dist in pfns_info:
+                print(f"  {rse} (distance={dist}): {pfns}")
+        pfns_list = [pfns for pfns, _, _ in pfns_info]
+    else:
+        if len(custom_pfns_prefix) > 0:
+            file_pfns = custom_pfns_prefix + input_remote_file
+        else:
+            file_pfns = input_remote_file
+        adler32 = gfal_sum(file_pfns, voms_token=voms_token, sum_type="adler32")
+        pfns_list = [file_pfns]
+    if os.path.exists(output_local_file):
+        if adler32 is not None and check_download(
+            output_local_file, expected_adler32sum=adler32
+        ):
+            return
+        os.remove(output_local_file)
+
+    if len(pfns_list) == 0:
+        raise RuntimeError(
+            f'Unable to find any remote location for "{input_remote_file}".'
+        )
+
+    def download(pfns):
+        if verbose > 0:
+            print(f"Trying to copy file from {pfns}")
+        if pfns.startswith("root:") or pfns.startswith("/store/"):
+            xrd_copy(
+                pfns,
+                output_local_file,
+                expected_adler32sum=adler32,
+                n_retries=1,
+                prefixes=[""],
+                verbose=verbose,
+            )
+        elif (
+            pfns.startswith("srm:")
+            or pfns.startswith("gsiftp")
+            or pfns.startswith("davs:")
+        ):
+            gfal_copy_safe(
+                pfns,
+                output_local_file,
+                voms_token,
+                expected_adler32sum=adler32,
+                n_retries=1,
+            )
+        else:
+            raise RuntimeError('Skipping an unknown remote source "{pfns}".')
+
+    repeat_until_success(
+        download,
+        opt_list=[(pfns,) for pfns in pfns_list],
+        n_retries=n_retries,
+        exception=GfalError(f"Unable to copy {input_remote_file} from remote."),
+        retry_sleep_interval=retry_sleep_interval,
+        verbose=verbose,
+    )
+
+
+if __name__ == "__main__":
+    import sys
+
+    cmd = sys.argv[1]
+    cmd_args = [f'"{arg}"' for arg in sys.argv[2:]]
+    cmd_str = cmd + "(" + ",".join(cmd_args) + ")"
+    print(f"> {cmd_str}")
+    try:
+        out = getattr(sys.modules[__name__], cmd)(*sys.argv[2:])
+        if out is not None:
+            try:
+                out_str = json.dumps(out, indent=2)
+            except TypeError:
+                if type(out) == list:
+                    out_str = "\n".join([str(o) for o in out])
+                else:
+                    out_str = out
+            print(out_str)
+    except RuntimeError as e:
+        print(f"ERROR: {type(e).__name__} -- {e}")
+        sys.exit(1)

--- a/RunKit/includeCMSSWlibs.py
+++ b/RunKit/includeCMSSWlibs.py
@@ -1,0 +1,27 @@
+from .run_tools import ps_call
+import os
+import re
+import ROOT
+
+pattern = "=|\n"
+
+
+def includeLibTool(tool="", wantLib=False):
+    command = ["scram", "tool", "info", tool]
+    directory = os.environ["CMSSW_BASE"]
+    returncode, output, err = ps_call(
+        command, catch_stdout=True, cwd=directory, verbose=0
+    )
+    result = re.split(pattern, output)
+    include_path = result[result.index("INCLUDE") + 1]
+    ROOT.gInterpreter.AddIncludePath(include_path)
+    if "LIBDIR" in result and wantLib:
+        lib_path = result[result.index("LIBDIR") + 1]
+        ROOT.gSystem.Load(f"{lib_path}/lib{tool}.so")
+        # if(tool=="tensorflow"):
+        # ROOT.gSystem.Load(f"{lib_path}/lib{tool}_framework.so")
+        # ROOT.gSystem.Load(f"{lib_path}/lib{tool}_cc.so")
+        # ROOT.gSystem.Load(f"{lib_path}/libtf2xla.so")
+    if "ROOT_INCLUDE_PATH" in result:
+        root_include_path = result[result.index("ROOT_INCLUDE_PATH") + 1]
+        ROOT.gInterpreter.AddIncludePath(root_include_path)

--- a/RunKit/inspectNanoFile.py
+++ b/RunKit/inspectNanoFile.py
@@ -1,0 +1,756 @@
+#!/usr/bin/env python3
+
+from builtins import range
+import sys, os.path, json
+from collections import defaultdict
+import ROOT
+
+ROOT.PyConfig.IgnoreCommandLineOptions = True
+ROOT.gROOT.SetBatch(True)
+
+
+class FileData:
+    def __init__(self, data):
+        self._json = data
+        for k, v in data.items():
+            setattr(self, k, v)
+        self.Events = self.trees.get("Events")
+        self.nevents = self.Events["entries"] if self.Events else 0
+        self.Runs = self.trees.get("Runs")
+        self.nruns = self.Runs["entries"] if self.Runs else 0
+        self.LuminosityBlocks = self.trees.get("LuminosityBlocks")
+        self.nluminosityblocks = (
+            self.LuminosityBlocks["entries"] if self.LuminosityBlocks else 0
+        )
+
+
+class Branch:
+    def __init__(self, tree, branch):
+        self.tree = tree
+        self.branch = branch
+        self.name = branch.GetName()
+        self.doc = branch.GetTitle()
+        self.tot = branch.GetZipBytes() / 1024.0
+        self.entries = None
+        self.single = True
+        self.kind = "Unknown"
+        if branch.GetNleaves() != 1:
+            sys.stderr.write(
+                "Cannot parse branch '%s' in tree %s (%d leaves)\n"
+                % (branch.GetName(), tree.GetName(), branch.GetNleaves())
+            )
+            return
+        self.leaf = branch.FindLeaf(branch.GetName())
+        if not self.leaf:
+            sys.stderr.write(
+                "Cannot parse branch '%s' in tree %s (no leaf)\n"
+                % (branch.GetName(), tree.GetName())
+            )
+            return
+        self.kind = self.leaf.GetTypeName()
+        if "Idx" in self.name:
+            self.kind += "(index to %s)" % (
+                (self.name[self.name.find("_") + 1 : self.name.find("Idx")]).title()
+            )
+        if self.leaf.GetLen() == 0 and self.leaf.GetLeafCount() != None:
+            self.single = False
+            self.counter = self.leaf.GetLeafCount().GetName()
+        elif self.kind.startswith("ROOT::VecOps::RVec<"):
+            self.single = False
+            self.counter = f'n{self.name.split("_")[0]}'
+
+    def toJSON(self):
+        return (
+            self.name,
+            dict(
+                name=self.name,
+                doc=self.doc,
+                tot=self.tot,
+                entries=self.entries,
+                single=self.single,
+                kind=self.kind,
+                counter=getattr(self, "counter", ""),
+            ),
+        )
+
+
+class BranchGroup:
+    def __init__(self, name):
+        self.name = name
+        self.tot = 0
+        self.entries = None
+        self.subs = []
+        self.kind = None
+        self.doc = ""
+
+    def append(self, sub):
+        self.subs.append(sub)
+        self.tot += sub.tot
+        if not self.doc:
+            self.doc = sub.doc
+
+    def getKind(self):
+        if self.kind:
+            return self.kind
+        if len(self.subs) == 1:
+            if self.subs[0].single:
+                self.kind = "Variable"
+            else:
+                self.kind = "Vector"
+                self.counter = self.subs[0].counter
+        else:
+            allsingles, commonCounter = True, True
+            counter = None
+            for s in self.subs:
+                if not s.single:
+                    allsingles = False
+                    if counter == None:
+                        counter = s.counter
+                    elif counter != s.counter:
+                        commonCounter = False
+            if allsingles:
+                self.kind = "Singleton"
+            elif commonCounter:
+                self.kind = "Collection"
+                self.counter = counter
+            else:
+                self.kind = "ItsComplicated"
+        return self.kind
+
+    def toJSON(self):
+        return (
+            self.name,
+            dict(
+                name=self.name,
+                doc=self.doc,
+                kind=self.kind,
+                tot=self.tot,
+                entries=self.entries,
+                subs=[s.name for s in self.subs],
+            ),
+        )
+
+
+def inspectRootFile(infile):
+    if not os.path.isfile(infile):
+        raise RuntimeError
+    filesize = os.path.getsize(infile) / 1024.0
+    tfile = ROOT.TFile.Open(infile)
+    trees = {}
+    for treeName in "Events", "Runs", "LuminosityBlocks":
+        toplevelDoc = {}
+        tree = tfile.Get(treeName)
+        if not tree:
+            continue
+        entries = tree.GetEntries()
+        trees[treeName] = tree
+        branchList = tree.GetListOfBranches()
+        allbranches = [Branch(tree, br) for br in branchList]
+        branchmap = dict((b.name, b) for b in allbranches)
+        branchgroups = {}
+        # make list of counters and countees
+        counters = defaultdict(list)
+        for b in allbranches:
+            if not b.single:
+                counters[b.counter].append(b.name)
+            else:
+                b.entries = entries
+        c1 = ROOT.TCanvas("c1", "c1")
+        for counter, countees in counters.items():
+            n = tree.Draw(counter + ">>htemp")
+            if n != 0:
+                htemp = ROOT.gROOT.FindObject("htemp")
+                n = htemp.GetEntries() * htemp.GetMean()
+                htemp.Delete()
+            branchmap[counter].entries = entries
+            for c in countees:
+                br = branchmap[c]
+                br.entries = n
+        # now we start to create branch groups
+        for b in allbranches:
+            if b.name in counters:
+                if len(b.doc) > 0:
+                    toplevelDoc[b.name[1:]] = b.doc
+                continue  # skip counters
+            if "_" in b.name:
+                head, tail = b.name.split("_", 1)
+            else:
+                head = b.name
+                toplevelDoc[b.name] = b.doc
+            if head not in branchgroups:
+                branchgroups[head] = BranchGroup(head)
+            branchgroups[head].append(b)
+        for bg in branchgroups.values():
+            if bg.name in toplevelDoc:
+                bg.doc = toplevelDoc[bg.name]
+            kind = bg.getKind()
+            bg.entries = bg.subs[0].entries
+            if kind == "Vector" or kind == "Collection":
+                bg.append(branchmap[bg.counter])
+            elif kind == "ItsComplicated":
+                for counter in set(s.counter for s in bg.subs if not s.single):
+                    bg.append(branchmap[counter])
+        allsize_c = sum(b.tot for b in allbranches)
+        allsize = sum(b.tot for b in branchgroups.values())
+        if abs(allsize_c - allsize) > 1e-6 * (allsize_c + allsize):
+            sys.stderr.write(
+                "Total size mismatch for tree %s: %10.4f kb vs %10.4f kb\n"
+                % (treeName, allsize, allsize_c)
+            )
+        trees[treeName] = dict(
+            entries=entries,
+            allsize=allsize,
+            branches=dict(b.toJSON() for b in allbranches),
+            branchgroups=dict(bg.toJSON() for bg in branchgroups.values()),
+        )
+        c1.Close()
+    tfile.Close()
+    return dict(filename=os.path.basename(infile), filesize=filesize, trees=trees)
+
+
+def makeSurvey(treeName, treeData):
+    allsize = treeData["allsize"]
+    entries = treeData["entries"]
+    survey = list(treeData["branchgroups"].values())
+    survey.sort(key=lambda bg: -bg["tot"])
+    scriptdata = []
+    runningtotal = 0
+    unit = treeName[:-1].lower()
+    for s in survey:
+        if s["tot"] < 0.01 * allsize:
+            tag = "<b>Others</b><br/>Size: %.0f b/%s (%.1f%%)" % (
+                (allsize - runningtotal) / entries * 1024,
+                unit,
+                (allsize - runningtotal) / allsize * 100,
+            )
+            scriptdata.append(
+                "{ 'label':'others', 'tag':'top', 'size':%s, 'tip':'%s' }"
+                % ((allsize - runningtotal) / entries, tag)
+            )
+            break
+        else:
+            tag = '<b><a href="#%s">%s</a></b><br/>' % (s["name"], s["name"])
+            tag += "Size: %.0f b/%s (%.1f%%)" % (
+                s["tot"] / entries * 1024,
+                unit,
+                s["tot"] / allsize * 100,
+            )
+            if (s["kind"] in ("Vector", "Collection")) and s["entries"] > 0:
+                tag += "<br/>Items/%s:  %.1f, %.0f b/item" % (
+                    unit,
+                    float(s["entries"]) / entries,
+                    s["tot"] / s["entries"] * 1024,
+                )
+            scriptdata.append(
+                "{ 'label':'%s', 'tag':'%s', 'size':%s, 'tip':'%s' }"
+                % (s["name"], s["name"], s["tot"] / entries, tag)
+            )
+        runningtotal += s["tot"]
+    return (survey, "\n,\t".join(scriptdata))
+
+
+def writeSizeReport(fileData, trees, stream, base_url):
+    filename = fileData.filename
+    filesize = fileData.filesize
+    events = fileData.nevents
+    surveys = {}
+    for treename, treeData in trees.items():
+        surveys[treename] = makeSurvey(treename, treeData)
+    title = "%s (%.3f Mb, %d events, %.2f kb/event)" % (
+        filename,
+        filesize / 1024.0,
+        events,
+        filesize / events,
+    )
+    stream.write(f"""
+    <html>
+    <head>
+        <title>{title}</title>
+        <link rel="stylesheet" type="text/css" href="{base_url}/patsize.css" />
+        <script type="text/javascript" src="{base_url}/rgraph/RGraph.common.core.js"></script>
+        <script type="text/javascript" src="{base_url}/rgraph/RGraph.pie.js"></script>
+        <script type="text/javascript" src="{base_url}/rgraph/RGraph.common.dynamic.js"></script>
+        <script type="text/javascript" src="{base_url}/rgraph/RGraph.common.tooltips.js"></script>
+        <script type="text/javascript" src="{base_url}/rgraph/RGraph.common.key.js"></script>
+    </head>
+    <body>
+    <a name="top" id="top"><h1>{title}</h1></a>
+    """)
+    stream.write("\n".join("""
+    <h1>{treename} data</h1>
+    <canvas id="{treename}Canvas" width="800" height="300">[No canvas support]</canvas>
+    """.format(treename=treename) for treename in surveys.keys()))
+    stream.write('    <script type="text/javascript">\n')
+    stream.write(
+        "\n".join(
+            """
+        var data_{treename} = [ {scriptdata} ];
+        """.format(treename=treename, scriptdata=scriptdata)
+            for treename, (_, scriptdata) in surveys.items()
+        )
+    )
+    stream.write(
+        """
+        window.onload = function() {{
+            {0}
+        }}
+    </script>
+    """.format(
+            "\n".join(
+                """
+            values = [];
+            labels = [];
+            keys   = [];
+            tips   = [];
+            for (var i = 0; i < data_{treename}.length; i++) {{
+                values.push( data_{treename}[i].size );
+                labels.push( data_{treename}[i].label );
+                keys.push( data_{treename}[i].label );
+                tips.push( data_{treename}[i].tip );
+            }}
+            var chart_{treename} = new RGraph.Pie("{treename}Canvas", values)
+                        .Set('exploded', 7)
+                        .Set('tooltips', tips)
+                        .Set('tooltips.event', 'onmousemove')
+                        .Set('key', labels)
+                        .Set('key.position.graph.boxed', false)
+                        .Draw();
+            """.format(treename=treename, scriptdata=scriptdata)
+                for treename, (_, scriptdata) in surveys.items()
+            )
+        )
+    )
+
+    if len(trees) > 1:
+        stream.write("    <h1>Collections summary</h1>\n")
+    stream.write("    <table>\n")
+    stream.write(
+        "<tr class='header'><th>"
+        + "</th><th>".join(
+            ["collection", "kind", "vars", "items/evt", "kb/evt", "b/item", "plot", "%"]
+        )
+        + '</th><th colspan="2">cumulative %</th></tr>\n'
+    )
+    runningtotal = 0
+    for treename, (survey, _) in surveys.items():
+        treetotal = trees[treename]["allsize"]
+        treerunningtotal = 0
+        for s in survey:
+            treerunningtotal += s["tot"]
+            runningtotal += s["tot"]
+            stream.write(
+                "<tr><th title=\"%s\"><a href='#%s'>%s</a></th><td style='text-align : left;'>%s</td><td>%d</td>"
+                % (s["doc"], s["name"], s["name"], s["kind"].lower(), len(s["subs"]))
+            )
+            stream.write(
+                "<td>%.2f</td><td>%.3f</td><td>%.1f</td>"
+                % (
+                    s["entries"] / events,
+                    s["tot"] / events,
+                    s["tot"] / s["entries"] * 1024 if s["entries"] else 0,
+                )
+            )
+            stream.write(
+                f"<td class=\"img\"><img src='{base_url}/blue-dot.gif' width='{s['tot']/treetotal*200}' height='10' /></td>"
+            )
+            stream.write("<td>%.1f%%</td>" % (s["tot"] / treetotal * 100.0))
+            stream.write(
+                "<td>%.1f%%</td>" % (float(treerunningtotal) / treetotal * 100.0)
+            )
+            stream.write("<td>%.1f%%</td>" % (float(runningtotal) / filesize * 100.0))
+            stream.write("</tr>\n")
+
+        # all known data
+        stream.write("<tr><th>All %s data</th>" % treename)
+        stream.write(
+            "<td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td><td><b>%.2f</b></td><td>&nbsp;</td>"
+            % (treetotal / events)
+        )
+        stream.write(
+            f"<td class=\"img\"><img src=\"{base_url}/green-dot.gif\" width='{treetotal/filesize*100.0}' height='10' />"
+        )
+        stream.write(
+            "</td><td>%.1f%%<sup>a</sup></td>" % (treetotal / filesize * 100.0)
+        )
+        stream.write("</tr>\n")
+
+        if treename == "Events":
+            # non-event
+            stream.write("<tr><th>Non per-event data or overhead</th>")
+            stream.write(
+                "<td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td><td>%.2f</td><td>&nbsp;</td>"
+                % ((filesize - treetotal) / events)
+            )
+            stream.write(
+                f"<td class=\"img\"><img src='{base_url}/red-dot.gif' width='{(filesize-treetotal)/filesize * 100}' height='10' /></td>"
+            )
+            stream.write(
+                "<td>%.1f%%<sup>a</sup></td>"
+                % ((filesize - treetotal) / filesize * 100.0)
+            )
+            stream.write("</tr>\n")
+
+    if len(surveys) > 1:
+        # other, unknown overhead
+        stream.write("<tr><th>Overhead</th>")
+        stream.write(
+            "<td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td><td>%.2f</td><td>&nbsp;</td>"
+            % ((filesize - runningtotal) / events)
+        )
+        stream.write(
+            f"<td class=\"img\"><img src='{base_url}/red-dot.gif' width='{(filesize-runningtotal)/filesize * 100}' height='10' /></td>"
+        )
+        stream.write(
+            "<td>%.1f%%<sup>a</sup></td>"
+            % ((filesize - runningtotal) / filesize * 100.0)
+        )
+        stream.write("</tr>\n")
+
+    # all file
+    stream.write("<tr><th>File size</th>")
+    stream.write(
+        "<td>&nbsp;</td><td>&nbsp;</td><td>&nbsp;</td><td><b>%.2f</b></td><td>&nbsp;</td>"
+        % (filesize / events)
+    )
+    stream.write("<td>&nbsp;</td><td>&nbsp;</td></tr>\n")
+
+    stream.write("""
+    </table>
+    Note: size percentages of individual event products are relative to the total size of Event data only (or equivalent for non-Events trees).<br />
+    Percentages with <sup>a</sup> are instead relative to the full file size.
+    """)
+    for treename, treeData in trees.items():
+        stream.write("""
+        <h1>%s detail</h1>
+        """ % treename)
+        for s in sorted(surveys[treename][0], key=lambda s: s["name"]):
+            stream.write(
+                "<h2><a name='%s' id='%s'>%s</a> (%.1f items/evt, %.3f kb/evt) <sup><a href=\"#top\">[back to top]</a></sup></h2>"
+                % (
+                    s["name"],
+                    s["name"],
+                    s["name"],
+                    s["entries"] / events,
+                    s["tot"] / events,
+                )
+            )
+            stream.write("<table>\n")
+            stream.write(
+                "<tr class='header'><th>"
+                + "</th><th>".join(["branch", "kind", "b/event", "b/item", "plot", "%"])
+                + "</th></tr>\n"
+            )
+            subs = [treeData["branches"][b] for b in s["subs"]]
+            for b in sorted(subs, key=lambda s: -s["tot"]):
+                stream.write(
+                    "<tr><th title=\"%s\">%s</th><td style='text-align : left;'>%s</td><td>%.1f</td><td>%.1f</td>"
+                    % (
+                        b["doc"],
+                        b["name"],
+                        b["kind"],
+                        b["tot"] / events * 1024,
+                        b["tot"] / s["entries"] * 1024 if s["entries"] else 0,
+                    )
+                )
+                stream.write(
+                    f"<td class=\"img\"><img src='{base_url}/blue-dot.gif' width='{b['tot']/s['tot']*200}' height='10' /></td>"
+                )
+                stream.write("<td>%.1f%%</td>" % (b["tot"] / s["tot"] * 100.0))
+                stream.write("</tr>\n")
+            stream.write("</table>\n")
+    stream.write("""
+    </body></html>
+    """)
+
+
+def writeDocReport(fileName, trees, stream, base_url):
+    stream.write(f"""
+    <html>
+    <head>
+        <title>Documentation for {fileName} </title>
+        <link rel="stylesheet" type="text/css" href="{base_url}/patsize.css" />
+    </head>
+    <body>
+    """)
+    for treename, treeData in trees.items():
+        stream.write("""
+        <h1>{treename} Content</h1>
+        <table>
+        """.format(treename=treename))
+        stream.write(
+            "<tr class='header'><th>Collection</th><th>Description</th></tr>\n"
+        )
+        groups = list(treeData["branchgroups"].values())
+        groups.sort(key=lambda s: s["name"])
+        for s in groups:
+            stream.write(
+                "<th><a href='#%s'>%s</a></th><td style='text-align : left;'>%s</td></tr>\n"
+                % (s["name"], s["name"], s["doc"])
+            )
+        stream.write(
+            "</table>\n\n<h1>{treename} detail</h1>\n".format(treename=treename)
+        )
+        for s in groups:
+            stream.write(
+                "<h2><a name='%s' id='%s'>%s</a> <sup><a href=\"#top\">[back to top]</a></sup></h2>\n"
+                % (s["name"], s["name"], s["name"])
+            )
+            stream.write("<table>\n")
+            stream.write(
+                "<tr class='header'><th>Object property</th><th>Type</th><th>Description</th></tr>\n"
+            )
+            subs = [treeData["branches"][b] for b in s["subs"]]
+            for b in sorted(subs, key=lambda s: s["name"]):
+                stream.write(
+                    "<th>%s</th><td style='text-align : left;'>%s</td><td style='text-align : left;'>%s</td>"
+                    % (b["name"], b["kind"], b["doc"])
+                )
+                stream.write("</tr>\n")
+            stream.write("</table>\n")
+    stream.write("""
+    </body></html>
+    """)
+
+
+def writeMarkdownSizeReport(fileData, trees, stream, base_url):
+    filename = fileData.filename
+    filesize = fileData.filesize
+    events = fileData.nevents
+    surveys = {}
+    for treename, treeData in trees.items():
+        surveys[treename] = makeSurvey(treename, treeData)[0]
+
+    stream.write(
+        "**%s (%.3f Mb, %d events, %.2f kb/event)**\n"
+        % (filename, filesize / 1024.0, events, filesize / events)
+    )
+    stream.write("\n# Event data\n" if len(trees) == 1 else "\n# Collection data\n")
+    stream.write(
+        "| collection | kind | vars | items/evt | kb/evt | b/item | plot	| % | ascending cumulative % | descending cumulative % |\n"
+    )
+    stream.write("| - | - | - | - | - | - | - | - | - | - |\n")
+    runningtotal = 0
+    for treename, survey in surveys.items():
+        treetotal = trees[treename]["allsize"]
+        treerunningtotal = 0
+        for s in survey:
+            stream.write(
+                "| [**%s**](#%s '%s') | %s | %d"
+                % (
+                    s["name"],
+                    s["name"].lower(),
+                    s["doc"].replace("|", "\|").replace("'", '"'),
+                    s["kind"].lower(),
+                    len(s["subs"]),
+                )
+            )
+            stream.write(
+                "| %.2f|%.3f|%.1f"
+                % (
+                    s["entries"] / events,
+                    s["tot"] / events,
+                    s["tot"] / s["entries"] * 1024 if s["entries"] else 0,
+                )
+            )
+            stream.write(
+                f"| <img src='{base_url}/blue-dot.gif' width='{s['tot'] / treetotal * 200}' height='10' />"
+            )
+            stream.write("| %.1f%%" % (s["tot"] / treetotal * 100.0))
+            stream.write("| %.1f%%" % ((runningtotal + s["tot"]) / treetotal * 100.0))
+            stream.write(
+                "| %.1f%% |\n" % ((treetotal - runningtotal) / treetotal * 100.0)
+            )
+            runningtotal += s["tot"]
+
+        # all known data
+        stream.write("**All %s data**" % treename)
+        stream.write("| | | | **%.2f**" % (treetotal / events))
+        stream.write(
+            f"| | <img src='{base_url}/green-dot.gif' width='{treetotal / filesize * 100.0}' height='10' />"
+        )
+        stream.write("| %.1f%%<sup>a</sup> | | |\n" % (treetotal / filesize * 100.0))
+
+        if treename == "Events":
+            # non-event
+            stream.write("**Non per-event data or overhead**")
+            stream.write("| | | | %.2f" % ((filesize - treetotal) / events))
+            stream.write(
+                f"| | <img src='{base_url}/red-dot.gif' width='{(filesize - treetotal) / filesize * 100}' height='10' />"
+            )
+            stream.write(
+                "| %.1f%%<sup>a</sup> | | |\n"
+                % ((filesize - treetotal) / filesize * 100.0)
+            )
+
+    if len(surveys) > 1:
+        # other, unknown overhead
+        stream.write("**Overhead**")
+        stream.write("| | | | %.2f" % ((filesize - runningtotal) / events))
+        stream.write(
+            f"| | <img src='{base_url}/red-dot.gif' width='{(filesize - runningtotal) / filesize * 100}' height='10' />"
+        )
+        stream.write(
+            "| %.1f%%<sup>a</sup> | | |\n"
+            % ((filesize - runningtotal) / filesize * 100.0)
+        )
+
+    # all file
+    stream.write("**File size**")
+    stream.write("| | | | **%.2f**" % (filesize / events))
+    stream.write("| | | | | |\n\n")
+
+    stream.write(
+        "Note: size percentages of individual event products are relative to the total size of Event data only (or equivalent for non-Events trees).\\\n"
+    )
+    stream.write(
+        "Percentages with <sup>a</sup> are instead relative to the full file size.\n\n"
+    )
+
+    for treename, survey in surveys.items():
+        stream.write("# %s detail\n" % treename)
+        for s in sorted(survey, key=lambda s: s["name"]):
+            stream.write(
+                "## <a id='%s'></a>%s (%.1f items/evt, %.3f kb/evt) [<sup>[back to top]</sup>](#event-data)\n"
+                % (
+                    s["name"].lower(),
+                    s["name"],
+                    s["entries"] / events,
+                    s["tot"] / events,
+                )
+            )
+            stream.write("| branch | kind | b/event | b/item | plot | % |\n")
+            stream.write("| - | - | - | - | - | - |\n")
+            subs = [trees[treename]["branches"][b] for b in s["subs"]]
+            for b in sorted(subs, key=lambda s: -s["tot"]):
+                stream.write(
+                    "| <b title='%s'>%s</b> | %s | %.1f | %.1f"
+                    % (
+                        b["doc"].replace("|", "\|").replace("'", '"'),
+                        b["name"],
+                        b["kind"],
+                        b["tot"] / events * 1024,
+                        b["tot"] / s["entries"] * 1024 if s["entries"] else 0,
+                    )
+                )
+                stream.write(
+                    f"| <img src='{base_url}/blue-dot.gif' width='{b['tot'] / s['tot'] * 200}' height='10' />"
+                )
+                stream.write("| %.1f%% |\n" % (b["tot"] / s["tot"] * 100.0))
+            stream.write("\n")
+
+
+def writeMarkdownDocReport(trees, stream):
+    for treename, treeData in trees.items():
+        stream.write("# %s Content\n" % treename)
+        stream.write("\n| Collection | Description |\n")
+        stream.write("| - | - |\n")
+        groups = list(treeData["branchgroups"].values())
+        groups.sort(key=lambda s: s["name"])
+        for s in groups:
+            stream.write(
+                "| [**%s**](#%s) | %s |\n" % (s["name"], s["name"].lower(), s["doc"])
+            )
+        stream.write("\n# %s detail\n" % treename)
+        for s in groups:
+            stream.write(
+                "\n## <a id='%s'></a>%s [<sup>[back to top]</sup>](#content)\n"
+                % (s["name"].lower(), s["name"])
+            )
+            stream.write("| Object property | Type | Description |\n")
+            stream.write("| - | - | - |\n")
+            subs = [treeData["branches"][b] for b in s["subs"]]
+            for b in sorted(subs, key=lambda s: s["name"]):
+                stream.write("| **%s** | %s| %s |\n" % (b["name"], b["kind"], b["doc"]))
+        stream.write("\n")
+
+
+def _maybeOpen(filename):
+    return open(filename, "w") if filename != "-" else sys.stdout
+
+
+if __name__ == "__main__":
+    from optparse import OptionParser
+
+    parser = OptionParser(usage="%prog [options] inputFile")
+    parser.add_option(
+        "-j",
+        "--json",
+        dest="json",
+        type="string",
+        default=None,
+        help="Write out json file",
+    )
+    parser.add_option(
+        "-d",
+        "--doc",
+        dest="doc",
+        type="string",
+        default=None,
+        help="Write out html doc",
+    )
+    parser.add_option(
+        "-s",
+        "--size",
+        dest="size",
+        type="string",
+        default=None,
+        help="Write out html size report",
+    )
+    parser.add_option(
+        "--docmd",
+        dest="docmd",
+        type="string",
+        default=None,
+        help="Write out markdown doc",
+    )
+    parser.add_option(
+        "--sizemd",
+        dest="sizemd",
+        type="string",
+        default=None,
+        help="Write out markdown size report",
+    )
+    parser.add_option(
+        "--base-url",
+        type="string",
+        default="https://cms-xpog.docs.cern.ch",
+        help="Base URL for style and scripts",
+    )
+    options, args = parser.parse_args()
+    if len(args) != 1:
+        raise RuntimeError("Please specify one input file")
+
+    if args[0].endswith(".root"):
+        filedata = FileData(inspectRootFile(args[0]))
+    elif args[0].endswith(".json"):
+        filedata = FileData(json.load(open(args[0], "r")))
+    else:
+        raise RuntimeError("Input file %s is not a root or json file" % args[0])
+
+    if options.json:
+        json.dump(filedata._json, _maybeOpen(options.json), indent=4)
+        sys.stderr.write("JSON output saved to %s\n" % options.json)
+
+    treedata = {}  # trees for (HTML or markdown) doc report
+    if filedata.Runs and len(filedata.Runs["branches"]) > 1:  # default: run number
+        treedata["Runs"] = filedata.Runs
+    if (
+        filedata.LuminosityBlocks and len(filedata.LuminosityBlocks["branches"]) > 2
+    ):  # default: run number, lumiblock
+        treedata["LuminosityBlocks"] = filedata.LuminosityBlocks
+    treedata["Events"] = filedata.Events
+
+    if options.doc:
+        writeDocReport(
+            filedata.filename, treedata, _maybeOpen(options.doc), options.base_url
+        )
+        sys.stderr.write("HTML documentation saved to %s\n" % options.doc)
+    if options.size:
+        writeSizeReport(filedata, treedata, _maybeOpen(options.size), options.base_url)
+        sys.stderr.write("HTML size report saved to %s\n" % options.size)
+    if options.docmd:
+        writeMarkdownDocReport(treedata, _maybeOpen(options.docmd))
+        sys.stderr.write("Markdown documentation saved to %s\n" % options.docmd)
+    if options.sizemd:
+        writeMarkdownSizeReport(filedata, treedata, _maybeOpen(options.sizemd))
+        sys.stderr.write("Markdown size report saved to %s\n" % options.sizemd)

--- a/RunKit/kinit.py
+++ b/RunKit/kinit.py
@@ -1,0 +1,21 @@
+import shutil
+import threading
+
+from .run_tools import ps_call
+
+cond = threading.Condition()
+
+
+def update_kinit(verbose=0):
+    if shutil.which("kinit"):
+        ps_call(["kinit", "-R"], expected_return_codes=None, verbose=verbose)
+    if shutil.which("aklog"):
+        ps_call(["aklog"], expected_return_codes=None, verbose=verbose)
+
+
+def update_kinit_thread():
+    timeout = 60.0 * 60  # 1 hour
+    cond.acquire()
+    while not cond.wait(timeout):
+        update_kinit(verbose=1)
+    cond.release()

--- a/RunKit/law_das.py
+++ b/RunKit/law_das.py
@@ -1,0 +1,145 @@
+import datetime
+import os
+from law.target.remote.interface import RemoteFileInterface
+from .grid_tools import get_voms_proxy_info, copy_remote_file, run_dasgoclient
+
+
+class DASFileInterface(RemoteFileInterface):
+    local_prefix = "file://"
+
+    def __init__(self, *, ls_cache_validity_period=60):
+        self.voms_token = get_voms_proxy_info()["path"]
+        self.dataset_available_files = {}
+        self.dataset_file_records = {}
+        super(DASFileInterface, self).__init__(base=["/"])
+
+    def is_local(self, path):
+        return path.startswith(DASFileInterface.local_prefix)
+
+    def exists(self, path, base=None, **kwargs):
+        self._raise_not_implemented("exists")
+
+    def remove(self, path, base=None, silent=True, **kwargs):
+        self._raise_not_implemented("remove")
+
+    def filecopy(self, src, dst, base=None, **kwargs):
+        src_local = self.is_local(src)
+        dst_local = self.is_local(dst)
+        if not (not src_local and dst_local):
+            raise RuntimeError(
+                "DASFileInterface: only copy from remote to local is supported"
+            )
+        dst_path = dst[len(DASFileInterface.local_prefix) :]
+        copy_remote_file(src, dst_path, voms_token=self.voms_token)
+        return src, dst
+
+    def get_dataset_sites(self, dataset, disk_only=True, verbose=0):
+        output = run_dasgoclient(
+            f"site dataset={dataset}",
+            inputDBS="global",
+            json_output=True,
+            verbose=verbose,
+        )
+        sites = []
+        for entry in output:
+            if "site" not in entry:
+                continue
+            for site_entry in entry["site"]:
+                if disk_only and site_entry["kind"] != "DISK":
+                    continue
+                sites.append((site_entry["name"], site_entry["total_files"]))
+
+        sites = sorted(sites, key=lambda x: x[1], reverse=True)
+        site_list = []
+        for site in sites:
+            if site[0] not in site_list:
+                site_list.append(site[0])
+        return site_list
+
+    def is_available(self, dataset, file, verbose=0):
+        if dataset not in self.dataset_available_files:
+            if verbose > 0:
+                print(f"{dataset}: searching for available files...")
+            all_files = set(self.listdir(dataset, verbose=verbose))
+            sites = self.get_dataset_sites(dataset, verbose=verbose)
+            available_files = set()
+            for site in sites:
+                if all_files == available_files:
+                    break
+                output = run_dasgoclient(
+                    f"file site={site} dataset={dataset}",
+                    inputDBS="global",
+                    json_output=True,
+                    verbose=verbose,
+                )
+                for entry in output:
+                    if "file" not in entry:
+                        continue
+                    for file_entry in entry["file"]:
+                        file_name = file_entry["name"]
+                        if file_name in all_files:
+                            available_files.add(file_name)
+                if verbose > 0:
+                    print(
+                        f"  {len(available_files)}/{len(all_files)} available files found"
+                    )
+            self.dataset_available_files[dataset] = available_files
+        return file in self.dataset_available_files[dataset]
+
+    def file_records(self, dataset, verbose=0):
+        if dataset not in self.dataset_file_records:
+            output = run_dasgoclient(
+                f"file dataset={dataset}",
+                inputDBS="global",
+                json_output=True,
+                verbose=verbose,
+            )
+            file_records = {}
+            for entry in output:
+                if "file" not in entry:
+                    continue
+                for file_entry in entry["file"]:
+                    file_name = file_entry["name"]
+                    file_records[file_name] = file_entry
+            self.dataset_file_records[dataset] = file_records
+        return self.dataset_file_records[dataset]
+
+    def n_events(self, dataset, file, verbose=0):
+        file_records = self.file_records(dataset, verbose=verbose)
+        if file not in file_records:
+            raise RuntimeError(f'File "{file}" record not found in dataset "{dataset}"')
+        return file_records[file]["nevents"]
+
+    def listdir(self, path, base=None, silent=False, **kwargs):
+        file_records = self.file_records(path, verbose=0)
+        return list(file_records.keys())
+
+    @staticmethod
+    def _raise_not_implemented(method_name):
+        raise NotImplementedError(
+            f"{method_name} is not supported by the DAS interface"
+        )
+
+    def chmod(self, file, perm, **kwargs):
+        self._raise_not_implemented("chmod")
+
+    def isdir(self, path, **kwargs):
+        self._raise_not_implemented("isdir")
+
+    def isfile(self):
+        self._raise_not_implemented("isfile")
+
+    def mkdir(self):
+        self._raise_not_implemented("mkdir")
+
+    def mkdir_rec(self):
+        self._raise_not_implemented("mkdir_rec")
+
+    def rmdir(self):
+        self._raise_not_implemented("rmdir")
+
+    def stat(self):
+        self._raise_not_implemented("stat")
+
+    def unlink(self):
+        self._raise_not_implemented("unlink")

--- a/RunKit/law_gfal.py
+++ b/RunKit/law_gfal.py
@@ -1,0 +1,304 @@
+import time
+import os
+import sys
+
+from law.target.remote.interface import RemoteFileInterface
+from .grid_tools import (
+    get_voms_proxy_info,
+    GfalError,
+    gfal_copy_safe,
+    gfal_ls_safe,
+    gfal_rm,
+    gfal_stat,
+    gfal_exists,
+)
+from .run_tools import repeat_until_success
+from .pathCacheClient import (
+    set_status as set_remote_cache_status,
+    get_status as get_remote_cache_status,
+)
+
+
+class PathCacheEntry:
+    def __init__(self, path, exists, expiration_time):
+        self.path = path
+        self.exists = exists
+        self.expiration_time = expiration_time
+
+    def is_valid(self):
+        return self.expiration_time >= time.time()
+
+
+class PathCache:
+    def __init__(self, validity_period):
+        self.validity_period = validity_period
+        self.cache = {}
+
+    def set(self, path, exists):
+        self.cache[path] = PathCacheEntry(
+            path, exists, time.time() + self.validity_period
+        )
+
+    def set_exists(self, base_dir, items):
+        for item in items:
+            path = os.path.join(base_dir, item)
+            self.set(path, True)
+
+    def get(self, path):
+        if path in self.cache:
+            entry = self.cache[path]
+            if entry.is_valid():
+                return entry.exists, True
+            else:
+                del self.cache[path]
+        return None, True
+
+    def invalidate(self, path):
+        to_remove = []
+        for p in self.cache:
+            if path.startswith(p):
+                to_remove.append(p)
+        for p in to_remove:
+            del self.cache[p]
+
+
+class RemotePathCache:
+    def __init__(self, host, port, local_cache_validity_period, timeout=5, verbose=0):
+        self.host = host
+        self.port = port
+        self.timeout = timeout
+        self.verbose = verbose
+        self.local_cache = PathCache(local_cache_validity_period)
+
+    def set(self, path, exists):
+        set_remote_cache_status(
+            [
+                (path, exists),
+            ],
+            self.host,
+            self.port,
+            self.timeout,
+            verbose=self.verbose,
+        )
+        self.local_cache.set(path, exists)
+
+    def set_exists(self, base_dir, items):
+        entries = []
+        for item in items:
+            path = os.path.join(base_dir, item)
+            entries.append((path, True))
+        entries.append((base_dir, True))
+        set_remote_cache_status(
+            entries, self.host, self.port, self.timeout, verbose=self.verbose
+        )
+        self.local_cache.set_exists(base_dir, items)
+
+    def get(self, path):
+        local_result, _ = self.local_cache.get(path)
+        if local_result is not None:
+            return local_result, True
+        remote_result = get_remote_cache_status(
+            path, self.host, self.port, self.timeout, verbose=self.verbose
+        )
+        if remote_result is not None:
+            self.local_cache.set(path, remote_result)
+        return remote_result, False
+
+    def invalidate(self, path):
+        set_remote_cache_status(
+            [
+                (path, None),
+            ],
+            self.host,
+            self.port,
+            self.timeout,
+            verbose=self.verbose,
+        )
+        self.local_cache.invalidate(path)
+
+
+class GFALFileInterface(RemoteFileInterface):
+    local_prefix = "file://"
+
+    def __init__(
+        self,
+        base,
+        local_path_cache_validity_period=60,
+        path_cache_host=None,
+        path_cache_port=None,
+        verbose=0,
+    ):
+        self.voms_token = get_voms_proxy_info()["path"]
+        if path_cache_host is None:
+            self.path_cache = PathCache(local_path_cache_validity_period)
+        else:
+            self.path_cache = RemotePathCache(
+                path_cache_host,
+                path_cache_port,
+                local_cache_validity_period=local_path_cache_validity_period,
+                verbose=verbose,
+            )
+        self.verbose = verbose
+        super(GFALFileInterface, self).__init__(base=base)
+
+    def is_local(self, path):
+        return path.startswith(GFALFileInterface.local_prefix)
+
+    exists_counter = 0
+    remove_counter = 0
+    filecopy_counter = 0
+    listdir_counter = 0
+
+    def exists(self, path, base=None, **kwargs):
+        GFALFileInterface.exists_counter += 1
+        path_dir, path_name = os.path.split(path)
+        path_uri = self.uri(path, base=base)
+        dir_uri = self.uri(path_dir, base=base)
+        result = False
+        cached_result, from_local_cache = self.path_cache.get(path_uri)
+        if cached_result is None:
+            cached_dir_result, from_local_cache = self.path_cache.get(dir_uri)
+            if cached_dir_result is not None:
+                cached_result = False
+        use_cache = cached_result is not None
+
+        if use_cache:
+            result = cached_result
+        else:
+            path_dir, path_name = os.path.split(path)
+            dir_entries = self.listdir(path_dir, base=base, silent=True)
+            result = path_name in dir_entries
+            if not result:
+                self.path_cache.set(path_uri, False)
+
+        if self.verbose > 0:
+            print(
+                f"GFALFileInterface.exists: cnt={GFALFileInterface.exists_counter} path={path} taken_from_cache={use_cache} from_local_cache={from_local_cache} result={result}",
+                file=sys.stderr,
+            )
+
+        return result
+
+    def remove(self, path, base=None, silent=True, **kwargs):
+        GFALFileInterface.remove_counter += 1
+        path_uri = self.uri(path, base=base)
+        if self.verbose > 0:
+            print(
+                f"GFALFileInterface.remove: cnt={GFALFileInterface.remove_counter} path={path}",
+                file=sys.stderr,
+            )
+        try:
+            if gfal_exists(path_uri, voms_token=self.voms_token):
+                gfal_rm(path_uri, voms_token=self.voms_token, recursive=True)
+            self.path_cache.set(path_uri, False)
+            return True
+        except GfalError as e:
+            if not silent:
+                raise e
+        return False
+
+    def filecopy(self, src, dst, base=None, **kwargs):
+        GFALFileInterface.filecopy_counter += 1
+        if self.verbose > 0:
+            print(
+                f"GFALFileInterface.filecopy: cnt={GFALFileInterface.filecopy_counter} src={src} dst={dst}",
+                file=sys.stderr,
+            )
+        src_local = self.is_local(src)
+        dst_local = self.is_local(dst)
+        if src_local and not dst_local:
+            dst_uris = self.uri(dst, base=base, return_all=True)
+            src_uri = src
+            for dst_uri in dst_uris:
+                dst_dir_uri, _ = os.path.split(dst_uri)
+                self.path_cache.set(dst_uri, False)
+                gfal_copy_safe(src_uri, dst_uri, voms_token=self.voms_token, verbose=0)
+                self.path_cache.set(dst_uri, True)
+                cached_dst_dir, _ = self.path_cache.get(dst_dir_uri)
+                if cached_dst_dir is not None and not cached_dst_dir:
+                    self.path_cache.set(dst_dir_uri, True)
+            return src_uri, dst_uris
+        elif dst_local and not src_local:
+            dst_uri = dst
+            src_uris = self.uri(src, base=base, return_all=True)
+            opt_list = [
+                [
+                    uri,
+                ]
+                for uri in src_uris
+            ]
+            successful_src_uri = None
+
+            def copy(src_uri):
+                nonlocal successful_src_uri
+                gfal_copy_safe(
+                    src_uri, dst_uri, voms_token=self.voms_token, n_retries=1, verbose=0
+                )
+                successful_src_uri = src_uri
+
+            repeat_until_success(
+                copy,
+                opt_list=opt_list,
+                exception=GfalError(
+                    f"GFALFileInterface: failed to copy {src} to {dst}"
+                ),
+            )
+            return successful_src_uri, dst_uri
+        raise RuntimeError(
+            f"GFALFileInterface: unable to copy {src} -> {dst}. Either source or destination must be local"
+        )
+
+    def listdir(self, path, base=None, silent=False, **kwargs):
+        GFALFileInterface.listdir_counter += 1
+        if self.verbose > 0:
+            print(
+                f"GFALFileInterface.listdir: cnt={GFALFileInterface.listdir_counter} path={path}",
+                file=sys.stderr,
+            )
+        path_uri = self.uri(path, base=base)
+        entries = gfal_ls_safe(
+            path_uri, voms_token=self.voms_token, catch_stderr=True, verbose=0
+        )
+        if entries is None:
+            if not silent:
+                gfal_ls_safe(
+                    path_uri, voms_token=self.voms_token, catch_stderr=False, verbose=1
+                )
+                raise GfalError(f"GFALFileInterface: failed to list directory {path}")
+            entry_names = []
+            self.path_cache.set(path_uri, False)
+        else:
+            entry_names = [entry.name for entry in entries]
+            self.path_cache.set_exists(path_uri, entry_names)
+        return entry_names
+
+    @staticmethod
+    def _raise_not_implemented(method_name):
+        raise NotImplementedError(
+            f"{method_name} is not supported by the GFAL interface"
+        )
+
+    def chmod(self, file, perm, **kwargs):
+        return True
+
+    def isdir(self, path, **kwargs):
+        stat = gfal_stat(path, voms_token=self.voms_token)
+        return stat["type"] == "directory"
+
+    def isfile(self):
+        self._raise_not_implemented("isfile")
+
+    def mkdir(self, *args, **kwargs):
+        return True
+
+    def mkdir_rec(self, *args, **kwargs):
+        return True
+
+    def rmdir(self):
+        self._raise_not_implemented("rmdir")
+
+    def stat(self):
+        self._raise_not_implemented("stat")
+
+    def unlink(self):
+        self._raise_not_implemented("unlink")

--- a/RunKit/law_wlcg.py
+++ b/RunKit/law_wlcg.py
@@ -1,0 +1,65 @@
+# coding: utf-8
+
+"""
+WLCG remote file system and targets.
+"""
+
+__all__ = ["WLCGFileSystem", "WLCGTarget", "WLCGFileTarget", "WLCGDirectoryTarget"]
+
+
+import law
+from law.target.remote import (
+    RemoteFileSystem,
+    RemoteTarget,
+    RemoteFileTarget,
+    RemoteDirectoryTarget,
+)
+from law.logger import get_logger
+
+logger = get_logger(__name__)
+
+from .law_gfal import GFALFileInterface
+from .law_das import DASFileInterface
+from .grid_tools import path_to_pfn
+
+
+class WLCGFileSystem(RemoteFileSystem):
+    def __init__(
+        self,
+        base,
+        local_path_cache_validity_period=600,
+        path_cache_host=None,
+        path_cache_port=None,
+        verbose=0,
+    ):
+        if base == "DAS":
+            file_interface = DASFileInterface()
+        else:
+            if type(base) is str:
+                base = [base]
+            base_pfns = [path_to_pfn(b) for b in base]
+            file_interface = GFALFileInterface(
+                base_pfns,
+                local_path_cache_validity_period=local_path_cache_validity_period,
+                path_cache_host=path_cache_host,
+                path_cache_port=path_cache_port,
+                verbose=verbose,
+            )
+        super(WLCGFileSystem, self).__init__(file_interface)
+
+
+class WLCGTarget(RemoteTarget):
+    def __init__(self, path, fs, **kwargs):
+        RemoteTarget.__init__(self, path, fs, **kwargs)
+
+
+class WLCGFileTarget(WLCGTarget, RemoteFileTarget):
+    pass
+
+
+class WLCGDirectoryTarget(WLCGTarget, RemoteDirectoryTarget):
+    pass
+
+
+WLCGTarget.file_class = WLCGFileTarget
+WLCGTarget.directory_class = WLCGDirectoryTarget

--- a/RunKit/pathCacheClient.py
+++ b/RunKit/pathCacheClient.py
@@ -1,0 +1,135 @@
+import socket
+import sys
+
+
+def set_status(entries, host, port, timeout, verbose=0):
+    try:
+        with socket.create_connection((host, port), timeout=timeout) as sock:
+            file = sock.makefile(mode="rwb", buffering=0)
+            for path, status in entries:
+                if status is None or status == "u":
+                    val = "u"
+                elif status == "U":
+                    val = "U"
+                elif isinstance(status, bool):
+                    val = "1" if status else "0"
+                else:
+                    raise ValueError(
+                        f"Invalid status value: {status!r} for path: {path!r}"
+                    )
+                request = f"SET {path} {val}\n".encode("utf-8")
+                file.write(request)
+                file.flush()
+                line = file.readline()
+
+                if verbose > 0:
+                    if line:
+                        line = line.decode("utf-8").strip()
+                        if line != "OK":
+                            print(
+                                f"pathCacheClient.set_status: SET failed: {line!r}",
+                                file=sys.stderr,
+                            )
+                    else:
+                        print(
+                            "pathCacheClient.set_status: no response from server",
+                            file=sys.stderr,
+                        )
+
+    except TimeoutError as e:
+        if verbose > 0:
+            print(
+                f"pathCacheClient.set_status: connection to server timed out: {e}",
+                file=sys.stderr,
+            )
+    except Exception as e:
+        if verbose > 0:
+            print(f"pathCacheClient.set_status: unexpected error: {e}", file=sys.stderr)
+
+
+def get_status(path, host, port, timeout, verbose=0):
+    try:
+        with socket.create_connection((host, port), timeout=timeout) as sock:
+            file = sock.makefile(mode="rwb", buffering=0)
+            request = f"GET {path}\n".encode("utf-8")
+            file.write(request)
+            file.flush()
+
+            line = file.readline()
+            if not line:
+                if verbose > 0:
+                    print(
+                        "pathCacheClient.get_status: no response from server",
+                        file=sys.stderr,
+                    )
+                return None
+            line = line.decode("utf-8").strip()
+
+            if line == "1":
+                return True
+            elif line == "0":
+                return False
+            elif line == "u":
+                return None
+            else:
+                if verbose > 0:
+                    print(
+                        f"pathCacheClient.get_status: unexpected response: {line!r}",
+                        file=sys.stderr,
+                    )
+                return None
+    except TimeoutError as e:
+        if verbose > 0:
+            print(
+                f"pathCacheClient.get_status: connection to server timed out: {e}",
+                file=sys.stderr,
+            )
+    except Exception as e:
+        if verbose > 0:
+            print(f"pathCacheClient.get_status: unexpected error: {e}", file=sys.stderr)
+    return None
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Path cache client.")
+    parser.add_argument("--host", required=True, type=str, help="host")
+    parser.add_argument("--port", required=True, type=str, help="port")
+    parser.add_argument("--command", required=True, type=str, help="command to execute")
+    parser.add_argument("--path", required=True, type=str, help="path to query/set")
+    parser.add_argument(
+        "--path-exists",
+        required=False,
+        default=None,
+        type=int,
+        help="exists flag when setting",
+    )
+    parser.add_argument(
+        "--timeout",
+        required=False,
+        default=5,
+        type=float,
+        help="connection timeout in seconds",
+    )
+    args = parser.parse_args()
+
+    if args.command == "get":
+        status = get_status(args.path, args.host, args.port, args.timeout, verbose=1)
+        print(f"Result: {status}")
+    elif args.command == "set":
+        if args.path_exists is None or args.path_exists not in [0, 1]:
+            print(
+                "Error: --path-exists must be provided for set command and its values should be 0 or 1",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        exists = True if args.path_exists == 1 else False
+        set_status([(args.path, exists)], args.host, args.port, args.timeout, verbose=1)
+    elif args.command == "invalidate":
+        set_status([(args.path, None)], args.host, args.port, args.timeout, verbose=1)
+    elif args.command == "invalidate_regex":
+        set_status([(args.path, "U")], args.host, args.port, args.timeout, verbose=1)
+    else:
+        print(f"Error: unknown command {args.command!r}", file=sys.stderr)
+        sys.exit(1)

--- a/RunKit/pathCacheServer.py
+++ b/RunKit/pathCacheServer.py
@@ -1,0 +1,415 @@
+import copy
+import socket
+import threading
+import datetime
+import json
+import time
+import sys
+import multiprocessing
+import os
+import yaml
+import re
+import shutil
+from concurrent.futures import ThreadPoolExecutor
+
+MSG_UNKNOWN = 0
+MSG_FORMAT_ERROR = 1
+MSG_GET = 2
+MSG_SET = 3
+MSG_INVALIDATE = 4
+
+
+def timestamp_str(timestamp=None):
+    t = timestamp or datetime.datetime.now()
+    return t.strftime("%Y-%m-%d %H:%M:%S")
+
+
+def print_ts(msg, prefix="", timestamp=None, *args, **kwargs):
+    print(f"{prefix}[{timestamp_str(timestamp=timestamp)}] {msg}", *args, **kwargs)
+
+
+class Logger:
+    message_texts = {
+        MSG_UNKNOWN: "Unknown message: {entry}",
+        MSG_FORMAT_ERROR: "Format error for message: {entry}. Error: {error}.",
+        MSG_GET: "({n_calls}) get: {path} exists={exists} addr={addr_str}",
+        MSG_SET: "({n_calls}) set: {path} exists={exists_bool} addr={addr_str}",
+        MSG_INVALIDATE: "({n_calls}) invalidate: {path} n_invalidated_entries={n_invalidated_entries} addr={addr_str}",
+    }
+
+    def __init__(self):
+        self.queue = multiprocessing.Queue()
+        self.process = multiprocessing.Process(target=self._logger_process, daemon=True)
+
+    def __enter__(self):
+        self.process.start()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.join()
+        return False
+
+    def log(self, msg, **kwargs):
+        entry = msg if len(kwargs) == 0 else (msg, kwargs)
+        self.queue.put(entry)
+
+    def join(self):
+        self.queue.put(None)
+        self.process.join()
+
+    def get_text(self, entry):
+        if isinstance(entry, tuple):
+            entry = list(entry)
+        if isinstance(entry, int):
+            entry = [entry, {}]
+        if isinstance(entry, str):
+            return entry
+        if not isinstance(entry, list) or len(entry) != 2:
+            return None
+        msg_id, format_args = entry
+        if msg_id not in Logger.message_texts:
+            return None
+        msg_format = Logger.message_texts[msg_id]
+        try:
+            msg = msg_format.format(**format_args)
+            return msg
+        except Exception as e:
+            return Logger.message_texts[MSG_FORMAT_ERROR].format(
+                entry=entry, error=str(e)
+            )
+
+    def _logger_process(self):
+        while True:
+            try:
+                entry = self.queue.get()
+                if entry is None:
+                    break
+                message = self.get_text(entry)
+                if message is None:
+                    message = Logger.message_texts[MSG_UNKNOWN].format(entry=entry)
+                print_ts(message, file=sys.stderr)
+            except KeyboardInterrupt as e:
+                pass
+
+
+class ValidityPeriodDB:
+    def __init__(self, periods):
+        self.periods = {}
+        for prefix, validity in periods.items():
+            if not isinstance(prefix, str):
+                raise RuntimeError(
+                    f"Validity period prefix must be a string, got: {prefix}"
+                )
+            if isinstance(validity, str):
+                validity = eval(validity, {}, {})
+            if not isinstance(validity, (int, float)):
+                raise RuntimeError(
+                    f"Validity period must be a number of seconds, got: {validity} for prefix: {prefix}"
+                )
+            self.periods[prefix] = validity
+        if "default" not in self.periods:
+            raise RuntimeError("Validity periods must include a 'default' entry")
+
+    def get_validity(self, path):
+        for prefix, validity in self.periods.items():
+            if path.startswith(prefix):
+                return validity
+        return self.periods["default"]
+
+
+def standardize_path_name(path):
+    parts = path.split("/")
+    standardized_parts = [p for p in parts if len(p) > 0]
+    if path.startswith("/"):
+        standardized_parts.insert(0, "")
+    return "/".join(standardized_parts)
+
+
+class PathCache:
+    def __init__(self, validity_db, logger, cache_file=None, cache_write_interval=-1):
+        self.validity_db = validity_db
+        self.logger = logger
+        self.lock = threading.Lock()
+        self.cache_file = cache_file
+        self.cache_write_interval = (
+            cache_write_interval if cache_file is not None else -1
+        )
+        if cache_file is not None and os.path.exists(cache_file):
+            with open(cache_file, "r") as f:
+                data = json.load(f)
+            self.cache = {}
+            for path, entry in data["cache"].items():
+                fixed_path = standardize_path_name(path)
+                fixed_entry = {}
+                entry_valid = True
+                current_time = time.time()
+                for key, type in (("exists", bool), ("expiration_time", int)):
+                    if key not in entry:
+                        entry_valid = False
+                        break
+                    value = entry[key]
+                    if not isinstance(value, type):
+                        entry_valid = False
+                        break
+                    fixed_entry[key] = value
+                entry_valid = (
+                    entry_valid and fixed_entry["expiration_time"] >= current_time
+                )
+                if entry_valid:
+                    self.cache[fixed_path] = fixed_entry
+
+            self.n_calls = data["n_calls"]
+            self.last_write_time = data["last_write_time"]
+            self.cache_write_interval = cache_write_interval
+            logger.log(
+                f"Cache loaded from {cache_file} with {len(self.cache)} entries and n_calls={self.n_calls}"
+            )
+        else:
+            self.cache = {}
+            self.n_calls = 0
+            self.last_write_time = 0
+
+    def write(self, current_time=None, force=False, as_thread=True):
+        if self.cache_file is not None:
+            current_time = current_time or time.time()
+            need_write = force or (
+                self.cache_write_interval >= 0
+                and (current_time - self.last_write_time) >= self.cache_write_interval
+            )
+            if need_write:
+                self.last_write_time = current_time
+                if as_thread:
+                    threading.Thread(
+                        target=self._write, args=(True,), daemon=True
+                    ).start()
+                else:
+                    self._write(need_lock=False)
+
+    def _write(self, need_lock):
+        if need_lock:
+            with self.lock:
+                n_calls = self.n_calls
+                cache = copy.deepcopy(self.cache)
+                last_write_time = self.last_write_time
+        else:
+            n_calls = self.n_calls
+            cache = self.cache
+            last_write_time = self.last_write_time
+        data = {"n_calls": n_calls, "last_write_time": last_write_time, "cache": cache}
+        tmp_file = self.cache_file + ".tmp"
+        backup_file = self.cache_file + ".bak"
+        with open(tmp_file, "w") as f:
+            json.dump(data, f, indent=2)
+        if os.path.exists(self.cache_file):
+            shutil.move(self.cache_file, backup_file)
+        shutil.move(tmp_file, self.cache_file)
+        self.logger.log(
+            f"Cache written to {self.cache_file} with {len(cache)} entries and n_calls={n_calls}"
+        )
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        with self.lock:
+            self.write(force=True, as_thread=False)
+        return False
+
+    def set(self, path, exists):
+        path = standardize_path_name(path)
+        with self.lock:
+            current_time = time.time()
+            expiration_time = int(current_time + self.validity_db.get_validity(path))
+            self.cache[path] = {"exists": exists, "expiration_time": expiration_time}
+            self.n_calls += 1
+            self.write(current_time=current_time)
+            return path, self.n_calls
+
+    def get(self, path):
+        path = standardize_path_name(path)
+        with self.lock:
+            result = None
+            if path in self.cache:
+                entry = self.cache[path]
+                current_time = time.time()
+                if entry["expiration_time"] >= current_time:
+                    result = entry["exists"]
+                else:
+                    del self.cache[path]
+                    self.write(current_time=current_time)
+            self.n_calls += 1
+            return path, result, self.n_calls
+
+    def invalidate(self, path):
+        path = standardize_path_name(path)
+        with self.lock:
+            n_removed = 0
+            if path in self.cache:
+                del self.cache[path]
+                n_removed = 1
+            if n_removed > 0:
+                self.write()
+            return path, n_removed, self.n_calls
+
+    def invalidate_all(self, path_pattern):
+        pattern = re.compile(path_pattern)
+        with self.lock:
+            to_remove = []
+            for path in self.cache.keys():
+                if pattern.match(path):
+                    to_remove.append(path)
+            for path in to_remove:
+                del self.cache[path]
+            n_removed = len(to_remove)
+            if n_removed > 0:
+                self.write()
+            return n_removed, self.n_calls
+
+
+def result_to_string(result):
+    if result is None:
+        return "u"
+    return "1" if result else "0"
+
+
+def handle_client(conn, addr, cache, logger):
+    try:
+        addr_str = f"{addr[0]}:{addr[1]}"
+        with conn:
+            file = conn.makefile(mode="rwb", buffering=0)
+
+            for line in file:
+                line = line.decode("utf-8").strip()
+                if not line:
+                    break
+
+                parts = line.split(" ", 2)
+                cmd = parts[0].upper()
+
+                if cmd == "GET":
+                    # GET <path>
+                    if len(parts) != 2:
+                        file.write(b"ERROR invalid GET command\n")
+                        file.flush()
+                        logger.log(
+                            f'ERROR: invalid GET command: "{line}". addr={addr_str}'
+                        )
+                        continue
+
+                    path = parts[1]
+                    path, exists, n_calls = cache.get(path)
+                    response = f"{result_to_string(exists)}\n"
+                    file.write(response.encode("utf-8"))
+                    file.flush()
+                    logger.log(
+                        MSG_GET,
+                        n_calls=n_calls,
+                        path=path,
+                        exists=exists,
+                        addr_str=addr_str,
+                    )
+                elif cmd == "SET":
+                    # SET <path> <0|1|u|U>
+                    if len(parts) != 3:
+                        file.write(b"ERROR invalid SET command\n")
+                        file.flush()
+                        logger.log(
+                            f'ERROR: invalid SET command: "{line}". addr={addr_str}'
+                        )
+                        continue
+
+                    path = parts[1]
+                    val_str = parts[2]
+                    if val_str not in ("0", "1", "u", "U"):
+                        file.write(b"ERROR SET value must be 0, 1, u or U\n")
+                        file.flush()
+                        logger.log(
+                            f'ERROR: invalid SET value: "{val_str}" in line: "{line}". addr={addr_str}'
+                        )
+                        continue
+
+                    if val_str == "u":
+                        path, n_invalidated_entries, n_calls = cache.invalidate(path)
+                    elif val_str == "U":
+                        n_invalidated_entries, n_calls = cache.invalidate_all(path)
+                    else:
+                        exists_bool = val_str == "1"
+                        path, n_calls = cache.set(path, exists_bool)
+
+                    file.write(b"OK\n")
+                    file.flush()
+                    if val_str.lower() == "u":
+                        logger.log(
+                            MSG_INVALIDATE,
+                            n_calls=n_calls,
+                            path=path,
+                            n_invalidated_entries=n_invalidated_entries,
+                            addr_str=addr_str,
+                        )
+                    else:
+                        logger.log(
+                            MSG_SET,
+                            n_calls=n_calls,
+                            path=path,
+                            exists_bool=exists_bool,
+                            addr_str=addr_str,
+                        )
+                else:
+                    file.write(b"ERROR unknown command\n")
+                    file.flush()
+                    logger.log(f'ERROR: unknown command: "{line}". addr={addr_str}')
+
+    except Exception as e:
+        logger.log(f"Error handling client {addr_str}: {e}")
+
+
+def start_server(cfg, cache_file, n_threads):
+    host = cfg["host"]
+    port = cfg["port"]
+    max_connections = cfg["max_connections"]
+    validity_db = ValidityPeriodDB(cfg["validity_periods"])
+
+    with Logger() as logger:
+        with PathCache(
+            validity_db,
+            logger,
+            cache_file=cache_file,
+            cache_write_interval=cfg.get("cache_write_interval", 60),
+        ) as cache:
+            with ThreadPoolExecutor(max_workers=n_threads) as executor:
+                try:
+                    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+                        s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+                        s.bind((host, port))
+                        s.listen(max_connections)
+                        logger.log(f"Cache server listening on {host}:{port}")
+
+                        while True:
+                            conn, addr = s.accept()
+                            executor.submit(handle_client, conn, addr, cache, logger)
+                except KeyboardInterrupt:
+                    logger.log("Server shutting down due to keyboard interrupt.")
+                except Exception as e:
+                    logger.log(f"Server error: {e}")
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Path cache server.")
+    parser.add_argument("--cfg", required=True, type=str, help="configuration file")
+    parser.add_argument(
+        "--cache-file", required=False, default=None, type=str, help="cache file"
+    )
+    parser.add_argument(
+        "--n-threads",
+        required=False,
+        default=16,
+        type=int,
+        help="number of threads for handling clients",
+    )
+    args = parser.parse_args()
+
+    with open(args.cfg, "r") as f:
+        cfg = yaml.safe_load(f)
+    start_server(cfg, args.cache_file, args.n_threads)

--- a/RunKit/pathCacheServerCfg.yaml
+++ b/RunKit/pathCacheServerCfg.yaml
@@ -1,0 +1,6 @@
+host: "0.0.0.0"
+port: 5000
+max_connections: 10000
+cache_write_interval: 600  # interval in seconds to write the cache to disk
+validity_periods:
+  default: 24 * 60 * 60  # default validity period in seconds

--- a/RunKit/run_tools.py
+++ b/RunKit/run_tools.py
@@ -1,0 +1,283 @@
+import datetime
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import time
+import traceback
+import zlib
+from threading import Timer
+
+
+class PsCallError(RuntimeError):
+    def __init__(self, cmd_str, return_code, additional_message=None):
+        msg = f'Error while running "{cmd_str}".'
+        if return_code is not None:
+            msg += f" Error code: {return_code}"
+        if additional_message is not None:
+            msg += f" {additional_message}"
+        super(PsCallError, self).__init__(msg)
+        self.cmd_str = cmd_str
+        self.return_code = return_code
+        self.message = additional_message
+
+
+def ps_call(
+    cmd,
+    shell=False,
+    catch_stdout=False,
+    catch_stderr=False,
+    decode=True,
+    split=None,
+    print_output=False,
+    expected_return_codes=[0],
+    env=None,
+    cwd=None,
+    timeout=None,
+    singularity_cmd=None,
+    verbose=0,
+):
+    if isinstance(cmd, str):
+        cmd = [cmd]
+    if shell:
+        if not (isinstance(cmd, list) and len(cmd) == 1):
+            raise ValueError(
+                "cmd must be a string or a list with a single element when shell=True"
+            )
+    if singularity_cmd is not None:
+        env_list = []
+        if env is not None:
+            for key in ["PATH", "LD_LIBRARY_PATH"]:
+                if key in env:
+                    env_list.append(f'{key}="{env[key]}"')
+        if shell:
+            env_str = " ".join(env_list)
+            if len(env_str) > 0:
+                env_str += " "
+            full_cmd = [f"{singularity_cmd} --command-to-run '{env_str}{cmd[0]}'"]
+        else:
+            full_cmd = [singularity_cmd, "--command-to-run", "env"] + env_list + cmd
+        if env is not None:
+            env_str = ""
+            for key in ["PATH", "LD_LIBRARY_PATH"]:
+                if key in env:
+                    env_str += f'{key}="{env[key]}" '
+
+    else:
+        full_cmd = cmd
+    cmd_str = []
+    for s in cmd:
+        if " " in s and not shell:
+            s = f"'{s}'"
+        cmd_str.append(s)
+    cmd_str = " ".join(cmd_str)
+    if verbose > 0:
+        if singularity_cmd is not None:
+            print(f"Entering {singularity_cmd} ...", file=sys.stderr)
+        print(f">> {cmd_str}", file=sys.stderr)
+    kwargs = {
+        "shell": shell,
+    }
+    if catch_stdout:
+        kwargs["stdout"] = subprocess.PIPE
+    if catch_stderr:
+        if print_output:
+            kwargs["stderr"] = subprocess.STDOUT
+        else:
+            kwargs["stderr"] = subprocess.PIPE
+    if env is not None:
+        kwargs["env"] = env
+    if cwd is not None:
+        kwargs["cwd"] = cwd
+
+    # psutil.Process.children does not work.
+    def kill_proc(pid):
+        child_list = subprocess.run(
+            ["ps", "h", "--ppid", str(pid)], capture_output=True, encoding="utf-8"
+        )
+        for line in child_list.stdout.split("\n"):
+            child_info = line.split(" ")
+            child_info = [s for s in child_info if len(s) > 0]
+            if len(child_info) > 0:
+                child_pid = child_info[0]
+                kill_proc(child_pid)
+        subprocess.run(["kill", "-9", str(pid)], capture_output=True)
+
+    proc = subprocess.Popen(full_cmd, **kwargs)
+
+    def kill_main_proc():
+        print(f"\nTimeout is reached while running:\n\t{cmd_str}", file=sys.stderr)
+        print(f"Killing process tree...", file=sys.stderr)
+        print(f"Main process PID = {proc.pid}", file=sys.stderr)
+        kill_proc(proc.pid)
+
+    timer = Timer(timeout, kill_main_proc) if timeout is not None else None
+    try:
+        if timer is not None:
+            timer.start()
+        if catch_stdout and print_output:
+            output = b""
+            err = b""
+            for line in proc.stdout:
+                output += line
+                print(line.decode("utf-8"), end="")
+            proc.stdout.close()
+            proc.wait()
+        else:
+            output, err = proc.communicate()
+    finally:
+        if timer is not None:
+            timer.cancel()
+    if (
+        expected_return_codes is not None
+        and proc.returncode not in expected_return_codes
+    ):
+        raise PsCallError(cmd_str, proc.returncode)
+    if decode:
+        if catch_stdout:
+            output_decoded = output.decode("utf-8")
+            if split is None:
+                output = output_decoded
+            else:
+                output = output_decoded.split(split)
+        if catch_stderr:
+            err_decoded = err.decode("utf-8")
+            if split is None:
+                err = err_decoded
+            else:
+                err = err_decoded.split(split)
+
+    return proc.returncode, output, err
+
+
+def timestamp_str(timestamp=None):
+    t = timestamp or datetime.datetime.now()
+    return t.strftime("%Y-%m-%d %H:%M:%S")
+
+
+def print_ts(msg, prefix="", timestamp=None, *args, **kwargs):
+    print(f"{prefix}[{timestamp_str(timestamp=timestamp)}] {msg}", *args, **kwargs)
+
+
+class PrintOpt:
+    def __init__(self, min_interval=60):
+        self.last_print = None
+        self.min_interval = min_interval
+
+    def __call__(self, msg, force=False, prefix="", *args, **kwargs):
+        now = datetime.datetime.now()
+        if force or (
+            self.last_print is None
+            or (now - self.last_print).total_seconds() >= self.min_interval
+        ):
+            print_ts(msg, prefix=prefix, timestamp=now, *args, **kwargs)
+            self.last_print = now
+
+
+def update_kerberos_ticket(verbose=1):
+    ps_call(["kinit", "-R"], verbose=verbose)
+
+
+def timed_call_wrapper(fn, update_interval, verbose=0):
+    last_update = None
+
+    def update(*args, **kwargs):
+        nonlocal last_update
+        now = datetime.datetime.now()
+        delta_t = (
+            (now - last_update).total_seconds()
+            if last_update is not None
+            else float("inf")
+        )
+        if verbose > 0:
+            print(f"timed_call for {fn.__name__}: delta_t = {delta_t} seconds")
+        if delta_t >= update_interval:
+            fn(*args, **kwargs)
+            last_update = now
+
+    return update
+
+
+def adler32sum(file_name):
+    block_size = 256 * 1024 * 1024
+    asum = 1
+    with open(file_name, "rb") as f:
+        while data := f.read(block_size):
+            asum = zlib.adler32(data, asum)
+    return asum
+
+
+def repeat_until_success(
+    fn, opt_list=([],), exception=None, n_retries=4, retry_sleep_interval=10, verbose=1
+):
+    for n in range(n_retries):
+        for opt in opt_list:
+            try:
+                fn(*opt)
+                return True
+            except:
+                if verbose > 0:
+                    print(traceback.format_exc())
+        if n != n_retries - 1:
+            sleep_interval = retry_sleep_interval ** (n + 1)
+            if verbose > 0:
+                print(f"Waiting for {sleep_interval} seconds before the next try.")
+            time.sleep(sleep_interval)
+
+    if exception is not None:
+        raise exception
+    return False
+
+
+def natural_sort(l):
+    convert = lambda text: int(text) if text.isdigit() else text.lower()
+    alphanum_key = lambda key: [convert(c) for c in re.split("([0-9]+)", key)]
+    return sorted(l, key=alphanum_key)
+
+
+def check_root_file_integrity(file_name, tmp_file=None, verbose=1):
+    if tmp_file is None:
+        tmp_file_desc, tmp_file = tempfile.mkstemp()
+        os.close(tmp_file_desc)
+    try:
+        ret_code, std_out, std_err = ps_call(
+            ["hadd", "-f", "-O", tmp_file, file_name],
+            catch_stderr=True,
+            catch_stdout=True,
+            decode=True,
+            split="\n",
+            verbose=verbose,
+        )
+        all_ok = True
+        for line in std_err:
+            if line.lower().startswith("error"):
+                all_ok = False
+                if verbose > 0:
+                    print(line, file=sys.stderr)
+                else:
+                    break
+        return all_ok
+    except PsCallError as e:
+        if verbose > 0:
+            print(
+                f"Error while checking integrity of {file_name}: {e}", file=sys.stderr
+            )
+        return False
+    finally:
+        if os.path.exists(tmp_file):
+            os.remove(tmp_file)
+
+
+if __name__ == "__main__":
+    import sys
+
+    cmd = sys.argv[1]
+    out = getattr(sys.modules[__name__], cmd)(*sys.argv[2:])
+    if out is not None:
+        out_t = type(out)
+        if out_t in [list, dict]:
+            print(json.dumps(out, indent=2))
+        else:
+            print(out)

--- a/RunKit/skim_tree.py
+++ b/RunKit/skim_tree.py
@@ -1,0 +1,600 @@
+#!/usr/bin/env python
+
+import importlib
+import os
+import re
+import sys
+import ROOT
+
+ROOT.gROOT.SetBatch(True)
+
+
+def get_file_path(file):
+    if os.path.exists(file):
+        return file
+    file_name = os.path.basename(file)
+    if os.path.exists(file_name):
+        return file_name
+    if "ANALYSIS_PATH" in os.environ:
+        file_path = os.path.join(os.environ["ANALYSIS_PATH"], file)
+        if os.path.exists(file_path):
+            return file_path
+    if "CMSSW_BASE" in os.environ:
+        file_path = os.path.join(os.environ["CMSSW_BASE"], "src", file)
+        if os.path.exists(file_path):
+            return file_path
+    raise RuntimeError(f"Unable to find {file}")
+
+
+def load_module(module_path):
+    module_path = os.path.abspath(get_file_path(module_path))
+    module_dir, module_file = os.path.split(module_path)
+    module_name, _ = os.path.splitext(module_file)
+    package_dir, package_name = os.path.split(module_dir)
+    if len(package_dir) > 0 and package_dir not in sys.path:
+        sys.path.append(package_dir)
+    if len(package_name) == 0:
+        package_name = module_name
+    spec = importlib.util.spec_from_file_location(
+        f"{package_name}.{module_name}", module_path
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def select_items(all_items, filters, verbose=0):
+    def name_match(name, pattern):
+        if pattern[0] == "^":
+            return re.match(pattern, name) is not None
+        return name == pattern
+
+    selected_items = {c for c in all_items}
+    excluded_items = set()
+    keep_prefix = "keep "
+    drop_prefix = "drop "
+    used_filters = set()
+    for item_filter in filters:
+        if item_filter.startswith(keep_prefix):
+            keep = True
+            items_from = excluded_items
+            items_to = selected_items
+            prefix = keep_prefix
+        elif item_filter.startswith(drop_prefix):
+            keep = False
+            items_from = selected_items
+            items_to = excluded_items
+            prefix = drop_prefix
+        else:
+            raise RuntimeError(f'Unsupported filter = "{item_filter}".')
+        pattern = item_filter[len(prefix) :]
+        if len(pattern) == 0:
+            raise RuntimeError(f"Filter with an empty pattern expression.")
+
+        to_move = [item for item in items_from if name_match(item, pattern)]
+        if len(to_move) > 0:
+            used_filters.add(item_filter)
+            for column in to_move:
+                items_from.remove(column)
+                items_to.add(column)
+
+    unused_filters = set(filters) - used_filters
+    if len(unused_filters) > 0 and verbose > 0:
+        print("Unused filters: " + " ".join(unused_filters))
+
+    return sorted(selected_items)
+
+
+def select_inputs(all_inputs, obj_names, ignore_absent, skip_empty, verbose=0):
+    inputs = {}
+    for obj_name in obj_names:
+        inputs[obj_name] = ROOT.vector("string")()
+    if not ignore_absent and not skip_empty:
+        for input in all_inputs:
+            for obj_name in obj_names:
+                inputs[obj_name].push_back(input)
+    else:
+        for input in all_inputs:
+            file = ROOT.TFile.Open(input, "READ")
+            if not file:
+                raise RuntimeError(f"Failed to open file '{input}'.")
+            for obj_name in obj_names:
+                obj = file.Get(obj_name)
+                if obj:
+                    if (
+                        not skip_empty
+                        or not hasattr(obj, "GetEntries")
+                        or obj.GetEntries() > 0
+                    ):
+                        inputs[obj_name].push_back(input)
+                else:
+                    if ignore_absent:
+                        if verbose > 0:
+                            print(
+                                f"WARNING: object '{obj_name}' is not found in file '{input}'."
+                            )
+                    else:
+                        raise RuntimeError(
+                            f"Object '{obj_name}' is not found in file '{input}'."
+                        )
+            file.Close()
+    return inputs
+
+
+def get_columns(df):
+    all_columns = [str(c) for c in df.GetColumnNames()]
+    simple_types = ["Int_t", "UInt_t", "Long64_t", "ULong64_t", "int", "long"]
+    column_types = {c: str(df.GetColumnType(c)) for c in all_columns}
+    all_columns = sorted(
+        all_columns, key=lambda c: (column_types[c] not in simple_types, c)
+    )
+    return all_columns, column_types
+
+
+processing_modules = {}
+
+
+def skim_tree(
+    inputs,
+    input_tree,
+    output,
+    output_tree,
+    input_range,
+    output_range,
+    snapshot_options,
+    column_filters,
+    sel,
+    invert_sel,
+    processing_module,
+    processing_function,
+    processing_arguments,
+    verbose=0,
+):
+    def create_empty_file(msg):
+        if verbose > 0:
+            print(msg)
+        if not os.path.exists(output):
+            if verbose > 0:
+                print("Creating an empty output file.")
+            compression_settings = (
+                snapshot_options.fCompressionAlgorithm * 100
+                + snapshot_options.fCompressionLevel
+            )
+            output_file = ROOT.TFile.Open(output, "RECREATE", "", compression_settings)
+            output_file.Close()
+
+    if len(inputs) == 0:
+        create_empty_file(f"No inputs files to skim {input_tree}.")
+        return
+
+    df = ROOT.RDataFrame(input_tree, inputs)
+
+    if input_range:
+        df = df.Range(*input_range)
+
+    if processing_module:
+        if verbose > 0:
+            arg_str = ", ".join(["df"] + processing_arguments)
+            print(f"Running {processing_module}:{processing_function}({arg_str}) ...")
+        if processing_module not in processing_modules:
+            processing_modules[processing_module] = load_module(processing_module)
+        module = processing_modules[processing_module]
+        fn = getattr(module, processing_function)
+        df = fn(df, *processing_arguments)
+
+    all_columns, column_types = get_columns(df)
+    selected_columns = select_items(all_columns, column_filters, verbose=verbose)
+
+    if len(selected_columns) == 0:
+        create_empty_file(f"No columns were selected to skim {input_tree}.")
+        return
+
+    branches = ROOT.vector("string")()
+    for column in all_columns:
+        if column in selected_columns:
+            branches.push_back(column)
+            if verbose > 2:
+                print(f"Adding column '{column_types[column]} {column}'...")
+
+    if sel:
+        if invert_sel:
+            df = df.Define("__passSkimSel", sel).Filter("!__passSkimSel")
+        else:
+            df = df.Filter(sel)
+
+    if output_range is not None:
+        df = df.Range(*output_range)
+
+    if verbose > 0:
+        print("Creating a snapshot...")
+    df.Snapshot(output_tree, output, branches, snapshot_options)
+    if processing_module:
+        module = processing_modules[processing_module]
+        if hasattr(module, "OnTreeSkimFinish"):
+            if verbose > 0:
+                print(
+                    f"Running {processing_module}:OnTreeSkimFinish({input_tree}, {output_tree}) ..."
+                )
+            module.OnTreeSkimFinish(input_tree, output_tree)
+
+
+def copy_tree(inputs, tree_name, output, snapshot_options, verbose=0):
+    if verbose > 0:
+        print(f"Copying {tree_name}...")
+    df = ROOT.RDataFrame(tree_name, inputs)
+    branches = ROOT.vector("string")()
+    all_columns, column_types = get_columns(df)
+    for column in all_columns:
+        branches.push_back(column)
+        if verbose > 2:
+            print(f"\tAdding column '{column_types[column]} {column}'...")
+    df.Snapshot(tree_name, output, branches, snapshot_options)
+
+
+def copy_histograms(
+    all_inputs, inputs, hist_names, output, snapshot_options, verbose=0
+):
+    if verbose > 0:
+        print(f"Copying histograms {hist_names}...")
+    hists = {}
+    for input in all_inputs:
+        input_file = None
+        for hist_name in hist_names:
+            if input in inputs[hist_name]:
+                if not input_file:
+                    input_file = ROOT.TFile.Open(input, "READ")
+                    if not input_file:
+                        raise RuntimeError(f"Failed to open file '{input}'.")
+                hist = input_file.Get(hist_name)
+                if not hist:
+                    raise RuntimeError(
+                        f"Failed to get histogram '{hist_name}' from file '{input}'."
+                    )
+                if hist_name in hists:
+                    hists[hist_name].Add(hist)
+                else:
+                    hist_copy = hist.Clone()
+                    hist_copy.SetDirectory(0)
+                    hists[hist_name] = hist_copy
+        if input_file:
+            input_file.Close()
+
+    compression_settings = (
+        snapshot_options.fCompressionAlgorithm * 100
+        + snapshot_options.fCompressionLevel
+    )
+    output_file = ROOT.TFile.Open(output, "UPDATE", "", compression_settings)
+    for hist_name, hist in hists.items():
+        output_file.WriteTObject(hist, hist_name)
+    output_file.Close()
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Skim tree.")
+    parser.add_argument(
+        "--input",
+        required=True,
+        type=str,
+        help="input root file or txt file with a list of files",
+    )
+    parser.add_argument("--output", required=True, type=str, help="output root file")
+    parser.add_argument(
+        "--input-tree", required=False, type=str, default=None, help="input tree name"
+    )
+    parser.add_argument(
+        "--output-tree", required=False, type=str, default=None, help="output tree"
+    )
+    parser.add_argument(
+        "--other-trees", required=False, default=None, help="other trees to copy"
+    )
+    parser.add_argument(
+        "--hists", required=False, default=None, help="histograms to copy"
+    )
+    parser.add_argument(
+        "--sel", required=False, type=str, default=None, help="selection"
+    )
+    parser.add_argument("--invert-sel", action="store_true", help="Invert selection.")
+    parser.add_argument(
+        "--ignore-absent",
+        action="store_true",
+        help="Ignore file if target tree or hist is absent.",
+    )
+    parser.add_argument(
+        "--skip-empty", action="store_true", help="Skip skip trees with 0 entries."
+    )
+    parser.add_argument(
+        "--column-filters",
+        required=False,
+        default=None,
+        type=str,
+        help="""Comma separated statements to keep and drop columns based on exact names or regex patterns.
+                              By default, all columns will be included""",
+    )
+    parser.add_argument(
+        "--input-prefix",
+        required=False,
+        type=str,
+        default="",
+        help="prefix to be added to input each input file",
+    )
+    parser.add_argument(
+        "--processing-module",
+        required=False,
+        type=str,
+        default=None,
+        help="Python module used to process DataFrame. Should be in form file:method",
+    )
+    parser.add_argument(
+        "--processing-arguments",
+        nargs="*",
+        required=False,
+        type=str,
+        default=[],
+        help="Argument to pass to processing module.",
+    )
+    parser.add_argument(
+        "--config",
+        required=False,
+        type=str,
+        default=None,
+        help="Configuration with the skim setup.",
+    )
+    parser.add_argument(
+        "--setup",
+        required=False,
+        type=str,
+        default=None,
+        help="Name of the setup descriptor in the configuration file.",
+    )
+    parser.add_argument(
+        "--comp-algo",
+        required=False,
+        type=str,
+        default="LZMA",
+        help="compression algorithm",
+    )
+    parser.add_argument(
+        "--comp-level", required=False, type=int, default=9, help="compression level"
+    )
+    parser.add_argument(
+        "--n-threads", required=False, type=int, default=None, help="number of threads"
+    )
+    parser.add_argument(
+        "--input-range",
+        required=False,
+        type=str,
+        default=None,
+        help="read only entries in range begin:end (before any selection)",
+    )
+    parser.add_argument(
+        "--output-range",
+        required=False,
+        type=str,
+        default=None,
+        help="write only entries in range begin:end (after all selections)",
+    )
+    parser.add_argument(
+        "--update-output",
+        action="store_true",
+        help="Update output file instead of overriding it.",
+    )
+    parser.add_argument(
+        "--verbose", required=False, type=int, default=3, help="verbosity level"
+    )
+    args = parser.parse_args()
+
+    all_inputs = []
+    if args.input.endswith(".root"):
+        all_inputs.append(args.input_prefix + args.input)
+    elif args.input.endswith(".txt"):
+        with open(args.input, "r") as input_list:
+            for name in input_list.readlines():
+                name = name.strip()
+                if len(name) > 0 and name[0] != "#":
+                    all_inputs.append(args.input_prefix + name)
+    elif os.path.isdir(args.input):
+        for f in os.listdir(args.input):
+            if not f.endswith(".root"):
+                continue
+            file_name = os.path.join(args.input, f)
+            all_inputs.append(file_name)
+    else:
+        raise RuntimeError("Input format is not supported.")
+    if args.verbose > 1:
+        print("Input files:\n" + "\n\t".join(all_inputs))
+
+    processing_module = None
+    processing_function = None
+    processing_arguments = None
+
+    if args.config:
+        for arg_name in [
+            "input_tree",
+            "output_tree",
+            "other_trees",
+            "hists",
+            "sel",
+            "invert_sel",
+            "column_filters",
+            "processing_module",
+        ]:
+            value = getattr(args, arg_name)
+            if value:
+                raise RuntimeError(
+                    f"--config and --{arg_name} can not be specified together."
+                )
+        import yaml
+
+        with open(args.config, "r") as f:
+            skim_config = yaml.safe_load(f)
+        if not isinstance(skim_config, dict) or len(skim_config) == 0:
+            raise RuntimeError("Config file is empty or has invalid format.")
+        if args.setup:
+            if args.setup not in skim_config:
+                raise RuntimeError(
+                    f"Setup '{args.setup}' is not found in the config file."
+                )
+            setup = skim_config[args.setup]
+        else:
+            if len(skim_config) > 1:
+                raise RuntimeError(
+                    "Multiple setups are found in the config file, but setup name is not specified."
+                )
+            setup = list(skim_config.values())[0]
+        setup_ref = setup
+        while "base" in setup_ref:
+            base_setup = skim_config[setup_ref["base"]]
+            for key in base_setup:
+                if key not in setup:
+                    setup[key] = base_setup[key]
+            setup_ref = base_setup
+
+        input_tree = setup["input_tree"]
+        output_tree = setup.get("output_tree", input_tree)
+        input_trees = [input_tree]
+        output_trees = [output_tree]
+        other_trees = setup.get("other_trees", [])
+        hists = setup.get("hists", [])
+        sel = setup.get("sel", None)
+        sel_ref = setup.get("sel_ref", None)
+        if sel and sel_ref:
+            raise RuntimeError("Both 'sel' and 'sel_ref' are specified.")
+        if sel_ref:
+            sel = skim_config[sel_ref]
+        invert_sel = setup.get("invert_sel", False)
+        column_filters = setup.get("column_filters", [])
+        if "processing_module" in setup:
+            processing_module_entry = setup["processing_module"]["file"]
+            config_path = os.path.dirname(args.config)
+            if type(processing_module_entry) is str:
+                processing_module_entry = [processing_module_entry]
+            for file in processing_module_entry:
+                if file.startswith("."):
+                    file = os.path.join(config_path, file)
+                if os.path.exists(file):
+                    processing_module = file
+                    break
+            if processing_module is None:
+                raise RuntimeError(
+                    f"Processing module file is not found in [ {', '.join(processing_module_entry)} ]."
+                )
+            processing_function = setup["processing_module"]["function"]
+            processing_arguments = setup["processing_module"].get("arguments", [])
+    else:
+        if args.setup:
+            raise RuntimeError("Setup name is specified, but config file is not.")
+        if not args.input_tree:
+            raise RuntimeError("Input tree is not specified.")
+        input_trees = args.input_tree.split(",")
+        if len(input_trees) > 1:
+            if args.output_tree:
+                raise RuntimeError(
+                    "Output tree renaming is not supported when multiple input trees are provided."
+                )
+            output_trees = input_trees
+        else:
+            output_trees = [args.output_tree if args.output_tree else args.input_tree]
+        sel = args.sel
+        invert_sel = args.invert_sel
+
+        def get_list(arg):
+            arg_value = getattr(args, arg)
+            values = []
+            if arg_value:
+                for v in arg_value.split(","):
+                    v = v.strip()
+                    if len(v) > 0:
+                        values.append(v)
+            return values
+
+        other_trees = get_list("other_trees")
+        hists = get_list("hists")
+        column_filters = get_list("column_filters")
+        if args.processing_module:
+            processing_module, processing_function = args.processing_module.split(":")
+            processing_arguments = args.processing_arguments
+
+    input_range = (
+        [int(x) for x in args.input_range.split(":")] if args.input_range else None
+    )
+    output_range = (
+        [int(x) for x in args.output_range.split(":")] if args.output_range else None
+    )
+
+    if args.n_threads is None:
+        if args.input_range is not None or args.output_range is not None:
+            args.n_threads = 1
+        else:
+            args.n_threads = 4
+    if args.n_threads > 1:
+        if args.verbose > 0:
+            print(f"Using {args.n_threads} threads.")
+        ROOT.ROOT.EnableImplicitMT(args.n_threads)
+
+    inputs = select_inputs(
+        all_inputs,
+        input_trees + other_trees + hists,
+        args.ignore_absent,
+        args.skip_empty,
+        args.verbose,
+    )
+
+    opt = ROOT.RDF.RSnapshotOptions()
+    opt.fCompressionAlgorithm = getattr(ROOT.ROOT, "k" + args.comp_algo)
+    opt.fCompressionLevel = args.comp_level
+    if args.update_output:
+        opt.fMode = "UPDATE"
+
+    for input_idx in range(len(input_trees)):
+        input_tree = input_trees[input_idx]
+        output_tree = output_trees[input_idx]
+        print(f"Processing {input_tree} -> {output_tree}...")
+        skim_tree(
+            inputs=inputs[input_tree],
+            input_tree=input_tree,
+            output=args.output,
+            output_tree=output_tree,
+            input_range=input_range,
+            output_range=output_range,
+            column_filters=column_filters,
+            sel=sel,
+            invert_sel=invert_sel,
+            processing_module=processing_module,
+            processing_function=processing_function,
+            processing_arguments=processing_arguments,
+            snapshot_options=opt,
+            verbose=args.verbose,
+        )
+        opt.fMode = "UPDATE"
+
+    for tree_name in other_trees:
+        copy_tree(
+            inputs=inputs[tree_name],
+            tree_name=tree_name,
+            output=args.output,
+            snapshot_options=opt,
+            verbose=args.verbose,
+        )
+
+    if len(hists) > 0:
+        copy_histograms(
+            all_inputs=all_inputs,
+            inputs=inputs,
+            hists=hists,
+            output=args.output,
+            snapshot_options=opt,
+            verbose=args.verbose,
+        )
+
+    if processing_module:
+        module = processing_modules.get(processing_module)
+        if module and hasattr(module, "OnSkimFinish"):
+            if args.verbose > 0:
+                print(f"Running {processing_module}:OnSkimFinish() ...")
+            module.OnSkimFinish()
+
+    if args.verbose > 0:
+        print("Skim successfully finished.")

--- a/RunKit/xsdb_search.py
+++ b/RunKit/xsdb_search.py
@@ -1,0 +1,57 @@
+# based on https://github.com/cms-sw/xsecdb/blob/master/scripts/xsdb_search.py
+
+import io
+import json
+import os
+import pycurl
+import sys
+
+if __name__ == "__main__":
+    file_dir = os.path.dirname(os.path.abspath(__file__))
+    sys.path.append(os.path.dirname(file_dir))
+    __package__ = "RunKit"
+
+from .run_tools import ps_call
+
+
+def search_xsdb(query_dict):
+    base_url = "https://cms-gen-dev.cern.ch/xsdb"
+    api_url = base_url + "/api"
+    query = {
+        "search": query_dict,
+        "pagination": {"pageSize": 0, "currentPage": 0},
+        "orderBy": {},
+    }
+    query_str = json.dumps(query)
+    home = os.environ["HOME"]
+    cookie = os.path.join(home, "private/xsdbdev-cookie.txt")
+    ps_call(
+        ["cern-get-sso-cookie", "-u", base_url, "--krb", "-r", "-o", cookie],
+        env={"KRB5CCNAME": os.environ["KRB5CCNAME"]},
+    )
+
+    bytes_io = io.BytesIO()
+    c = pycurl.Curl()
+    c.setopt(pycurl.FOLLOWLOCATION, 1)
+    c.setopt(pycurl.COOKIEJAR, cookie)
+    c.setopt(pycurl.COOKIEFILE, cookie)
+    c.setopt(
+        pycurl.HTTPHEADER, ["Content-Type:application/json", "Accept:application/json"]
+    )
+    c.setopt(pycurl.VERBOSE, 0)
+    c.setopt(pycurl.URL, api_url + "/search")
+    c.setopt(pycurl.WRITEFUNCTION, bytes_io.write)
+    c.setopt(pycurl.POST, 1)
+    c.setopt(pycurl.POSTFIELDS, query_str)
+    c.perform()
+
+    out = bytes_io.getvalue().decode("utf-8")
+    return json.loads(out)
+
+
+if __name__ == "__main__":
+    query_dict = {}
+    for line in sys.argv[1:]:
+        key, val = line.split("=")
+        query_dict[key] = val
+    print(json.dumps(search_xsdb(query_dict), indent=2))

--- a/config/law.cfg
+++ b/config/law.cfg
@@ -2,7 +2,6 @@
 AnaProd.tasks
 Analysis.tasks
 RunKit.grid_helper_tasks
-RunKit.crabLaw
 inference.dhi.tasks
 test.hello_world_task
 

--- a/run_tools/law_customizations.py
+++ b/run_tools/law_customizations.py
@@ -10,7 +10,7 @@ import subprocess
 import tempfile
 
 from FLAF.RunKit.run_tools import natural_sort
-from FLAF.RunKit.crabLaw import update_kinit
+from FLAF.RunKit.kinit import update_kinit
 from FLAF.RunKit.law_wlcg import WLCGFileSystem, WLCGFileTarget, WLCGDirectoryTarget
 from FLAF.Common.Setup import Setup
 


### PR DESCRIPTION
Fix for [#114](https://github.com/cms-flaf/FLAF/issues/114): Integrate RunKit code into the main repository

## Root cause

`RunKit` was an external git submodule (`git@github.com:kandrosov/RunKit.git`) pinned
in `FLAF/.gitmodules`. It bundles a large, general-purpose toolkit (CRAB / NanoAOD
production, lumi tools, file inspectors, mkdocs site, …), but FLAF and the analyses
only ever import a small subset of it. The submodule added an external dependency and
extra checkout/recursion steps for code that is effectively part of FLAF.

## Solution

Replaced the submodule with a vendored `FLAF/RunKit/` directory. The `.gitmodules`
entry was dropped (only `PlotKit` remains). Because everything is already imported as
`FLAF.RunKit.*`, the directory simply stops being a submodule — no import paths changed
for the kept modules.

**Kept (import closure actually used by FLAF + the analyses):** `run_tools`, `envToJson`,
`law_wlcg`, `grid_tools`, `law_das`, `law_gfal`, `pathCacheClient`, `includeCMSSWlibs`,
`grid_helper_tasks`.

**Refactored out the CRAB machinery.** FLAF only needed three kerberos keep-alive helpers
(`cond`, `update_kinit`, `update_kinit_thread`) from `crabLaw.py`. These were extracted
into a small new module `RunKit/kinit.py` (depends only on `run_tools`). That let us drop
`crabLaw.py`, `crabTask.py`, `crabTaskStatus.py`, and the now-orphaned `law_customizations.py`
(RunKit's `HTCondorWorkflow`, used only by `crabLaw`) and `getFileRunLumi.py` (used only by
`crabTask`). The `RunKit.crabLaw` law module — which registered the unused `ProdTask` /
`LawTaskManager` CRAB-production tasks — was removed from `config/law.cfg`.

**Added back a few standalone tools** that are worth shipping with FLAF (per review):
`inspectNanoFile.py`, `pathCacheServer.py` (+ `pathCacheServerCfg.yaml`), `skim_tree.py`,
`xsdb_search.py`. None pull in any removed module (only `run_tools`).

**`.gitignore`:** RunKit's dedicated `.gitignore` was removed; its still-relevant runtime
artefacts were migrated into the top-level `FLAF/.gitignore` (`/RunKit/.dasmaps`,
`/RunKit/.gfal_copy_safe_tmp`; `__pycache__` and `/site` were already covered there).

All kept/added `.py` files were run through `black` to satisfy the formatting CI.

## Files changed (FLAF)

- `.gitmodules` — removed the `[submodule "RunKit"]` entry.
- `RunKit/` — converted from a submodule gitlink to a regular directory; pruned to the
  used closure + `kinit.py` + the 4 standalone tools; CRAB machinery removed.
- `RunKit/kinit.py` — new: the three kinit helpers extracted from `crabLaw`.
- `config/law.cfg` — removed `RunKit.crabLaw`.
- `Common/Utilities.py`, `run_tools/law_customizations.py` — import kinit helpers from
  `FLAF.RunKit.kinit` instead of `FLAF.RunKit.crabLaw`.
- `.gitignore` — migrated RunKit runtime-artefact ignores.
- `.github/copilot-instructions.md` — RunKit documented as vendored, not a submodule.

## Coordinated changes in dependent repos

The analyses imported the kinit helpers from `crabLaw`, so they move to `FLAF.RunKit.kinit`
together with the FLAF pin advance (branch `issue-114-integrate-runkit` in each):

- **HH_bbWW** — 5 `Studies/**/*Condor*.py` / `DNN_Class.py` imports → `FLAF.RunKit.kinit`;
  `config/law.cfg` drops `FLAF.RunKit.crabLaw`.
- **HH_bbtautau** — `config/law.cfg` drops `FLAF.RunKit.crabLaw`.
- **H_mumu** — `config/law.cfg` drops the stale commented `#FLAF.RunKit.crabLaw`.

These must merge together with the FLAF change (their FLAF submodule pin advance), since
`crabLaw` disappears from FLAF.

## Testing

- Imported all kept modules as `FLAF.RunKit.<mod>` in the flaf_env (FLAF_all on
  `PYTHONPATH`): all resolve; `FLAF.Common.Utilities` imports cleanly via `kinit`.
- Verified removed modules (`crabLaw`, `crabTask`, `crabTaskStatus`, `law_customizations`,
  `getFileRunLumi`) are absent; `xsdb_search.py` compiles (its only missing dep, `pycurl`,
  is a runtime-only dep of that standalone tool, unchanged by this work).
- `black --check RunKit/*.py` and the changed `Studies` files pass; `yamllint`
  `pathCacheServerCfg.yaml` passes.
- `git submodule status` shows only `PlotKit`; no `crabLaw` references remain in any repo.