### PR TITLE
Replace PlotKit submodule with redesigned pure-Python PlotKit (#171)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "PlotKit"]
 	path = PlotKit
-	url = git@github.com:kandrosov/PlotKit.git
+	url = git@github.com:cms-flaf/PlotKit.git

--- a/docs/ci/integration-pipeline.md
+++ b/docs/ci/integration-pipeline.md
@@ -29,9 +29,12 @@ Repos with the trigger enabled: HH_bbtautau, HH_bbWW, H_mumu, FLAF, Corrections,
     ```text
     @cms-flaf-bot please test
     - https://github.com/cms-flaf/FLAF/pull/272
+    - https://github.com/cms-flaf/PlotKit/pull/2
     ```
     Shorthands include `- <repo>_version=PR_<n>`, a `…/pull/<n>` URL, a `…/tree/<branch>` URL, and
-    `- gitlab_branch=<branch>` to run a non-default `flaf_integration` branch.
+    `- gitlab_branch=<branch>` to run a non-default `flaf_integration` branch. `PlotKit_version`
+    pins the `FLAF/PlotKit` sub-sub-module, which is switched after `FLAF` (so it overrides whatever
+    commit the requested `FLAF` pins).
 
 ## `integration_cfg.yaml`
 
@@ -73,7 +76,9 @@ The shared trigger logic distinguishes:
 
 - **root packages** — repos with an `_active` variable (the analyses: HH_bbtautau, HH_bbWW,
   H_mumu);
-- **packages** — repos with a `_version` but no `_active` (FLAF, Corrections, StatInference).
+- **packages** — repos with a `_version` but no `_active` (FLAF, PlotKit, Corrections,
+  StatInference). `PlotKit` is a sub-sub-module (`FLAF/PlotKit`); the build switches it after
+  `FLAF`.
 
 Both may trigger the pipeline; the distinction matters only when editing the trigger logic.
 

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -27,7 +27,7 @@ tools with it. For example, HH→bb̄ττ looks like this:
 ```text
 HH_bbtautau/                  ← the analysis repository (you clone this)
 ├── FLAF/                     ← shared framework (submodule)
-│   ├── PlotKit/              ← plotting helpers (submodule of FLAF)
+│   ├── PlotKit/              ← plotting toolkit: matplotlib/mplhep (+ROOT/cmsstyle); submodule
 │   └── RunKit/               ← workflow utilities (vendored directory, not a submodule)
 ├── Corrections/              ← shared corrections (submodule)
 ├── StatInference/            ← shared stat tooling (submodule; HH analyses only)

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -85,7 +85,10 @@ Framework and CMS-computing vocabulary, in plain terms. For the quick on-ramp ve
   testing set; production uses the full model. Defined in `phys_models.yaml`.
 
 **PlotKit**
-: FLAF's plotting-helpers submodule.
+: FLAF's plotting toolkit (a submodule of FLAF, [cms-flaf/PlotKit](https://github.com/cms-flaf/PlotKit)).
+  Renders the stacked CMS plots with **matplotlib + mplhep** by default (no ROOT required) and can
+  optionally render through **ROOT + cmsstyle**. It reads the analysis `config/plot/*.yaml` files and
+  can also run standalone (`python -m PlotKit.cli`).
 
 **Process**
 : A physics object built from one or more datasets (e.g. "TT", "DY", "signal") — what you plot and

--- a/docs/reference/tasks.md
+++ b/docs/reference/tasks.md
@@ -67,9 +67,15 @@ consume.
 - **Parameter:** `--producer-to-aggregate`.
 
 ### `HistPlotTask`
-Produces the final **plots**. **Branches over variables** (one branch per variable).
+Produces the final **plots** via the [PlotKit](https://github.com/cms-flaf/PlotKit) submodule
+(matplotlib + mplhep by default; optional ROOT + cmsstyle). **Branches over variables** (one branch
+per variable).
 
 - **Parameter:** `--variables` (string; restrict which variables).
+
+Plot styling comes from the analysis `config/plot/*.yaml` files (`cms_stacked.yaml`,
+`histograms.yaml`, `<era>.yaml`) — unchanged from the legacy renderer. PlotKit can also render
+outside FLAF; see its README for the standalone `python -m PlotKit.cli` entry point.
 
 ## Statistical-inference tasks
 

--- a/docs/reference/tasks.md
+++ b/docs/reference/tasks.md
@@ -74,8 +74,11 @@ per variable).
 - **Parameter:** `--variables` (string; restrict which variables).
 
 Plot styling comes from the analysis `config/plot/*.yaml` files (`cms_stacked.yaml`,
-`histograms.yaml`, `<era>.yaml`) — unchanged from the legacy renderer. PlotKit can also render
-outside FLAF; see its README for the standalone `python -m PlotKit.cli` entry point.
+`histograms.yaml`, `<era>.yaml`) — unchanged from the legacy renderer. Signal overlays are scaled by
+`signal_plot_scale` in `global.yaml`: a fixed factor (e.g. `100`) **or** `bkg` to normalise each
+signal's integral to the summed background (shape comparison; the legend then reads
+`… (norm. to bkg)`). PlotKit can also render outside FLAF; see its README for the standalone
+`python -m PlotKit.cli` entry point.
 
 ## Statistical-inference tasks
 

--- a/run_tools/mk_flaf_env.sh
+++ b/run_tools/mk_flaf_env.sh
@@ -34,6 +34,7 @@ install() {
     run_cmd pip install bayesian-optimization
     run_cmd pip install yamllint
     run_cmd pip install black
+    run_cmd pip install cmsstyle  # optional PlotKit backend (ROOT/cmsstyle); mplhep comes from LCG
 }
 
 install_gh_cli() {


### PR DESCRIPTION
## Summary

Replaces the legacy `kandrosov/PlotKit` submodule with the redesigned, pure-Python
[cms-flaf/PlotKit](https://github.com/cms-flaf/PlotKit) (merged in cms-flaf/PlotKit#1) — matplotlib +
mplhep by default, optional ROOT + cmsstyle. The swap is **transparent**: `Analysis/HistPlotter.py` is
unchanged and the analysis `config/plot/*.yaml` files keep their format, so only the submodule (URL +
pointer) and the env change. Fixes #171.

## Changes

- `.gitmodules`: PlotKit URL `kandrosov/PlotKit` → `cms-flaf/PlotKit`; submodule pointer advanced to
  the merged `main`.
- `run_tools/mk_flaf_env.sh`: `pip install cmsstyle` (optional ROOT backend; lazy-imported, so nothing
  breaks before the next env rebuild — mplhep already comes from LCG).
- `docs/`: glossary, architecture and the `HistPlotTask` reference updated to describe the new PlotKit
  (mplhep/cmsstyle, standalone `python -m PlotKit.cli`, and the `signal_plot_scale: bkg` option).
  `mkdocs build --strict` passes.
- `Analysis/HistPlotter.py`: **unchanged** — the preserved legacy `Plotter` API makes the swap
  transparent.

## Testing

- Verified end-to-end on real **HH_bbWW `all_plots` histograms (Run3_2023)**: the HistPlotTask
  plotting path (`HistPlotter.py` → PlotKit) renders faithful stacked plots (CMS/lumi/channel/
  category/region labels, `divide_by_bin_width`, stacked backgrounds + bkg-uncertainty band + scaled
  signals + data + Obs/Bkg ratio), through both the mplhep and cmsstyle backends.
- PlotKit's own suite is 16/16; `mkdocs build --strict` passes.

## Companion PR

- **HH_bbWW**: switches `config/global.yaml` to `signal_plot_scale: bkg` (normalise each signal to the
  summed background — a new PlotKit capability).
