### PR TITLE
Fix QCD Shape unc, calulated at hist merge step, not event wise Unc, so added data-driven flag so that it do not crash before hist-Merge

### DIFF
--- a/Analysis/AnalysisCacheProducer.py
+++ b/Analysis/AnalysisCacheProducer.py
@@ -159,7 +159,10 @@ def createAnalysisCache(
     Utilities.InitializeCorrections(setup, dataset_name, stage="AnalysisCache")
     scale_uncertainties = set()
     if setup.global_params["compute_unc_variations"]:
-        scale_uncertainties.update(unc_cfg_dict["shape"].keys())
+        for unc_name, unc_params in unc_cfg_dict["shape"].items():
+            if isinstance(unc_params, dict) and unc_params.get("data_driven", False):
+                continue
+            scale_uncertainties.add(unc_name)
     print("Scale uncertainties to consider:", scale_uncertainties)
 
     producer_config = setup.global_params["payload_producers"][producer_to_run]

--- a/Analysis/HistMergerFromHists.py
+++ b/Analysis/HistMergerFromHists.py
@@ -45,17 +45,18 @@ def fill_hists(
     unc_source="Central",
     data_type="data",
 ):
+    load_source = "Central" if unc_source == "QCDScale" else unc_source
     var_check = f"{var_input}"
     for key_tuple, hist_map in items_dict.items():
         for var, var_hist in hist_map.items():
-            scales = ["Up", "Down"] if unc_source != "Central" else ["Central"]
+            scales = ["Up", "Down"] if load_source != "Central" else ["Central"]
             for scale in scales:
-                if unc_source != "Central" and dataset_type != data_type:
-                    var_check = f"{var_input}_{unc_source}_{scale}"
+                if load_source != "Central" and dataset_type != data_type:
+                    var_check = f"{var_input}_{load_source}_{scale}"
                 if var != var_check:
                     continue
 
-                final_key = (key_tuple, (unc_source, scale))
+                final_key = (key_tuple, (load_source, scale))
                 if dataset_type not in all_hist_dict.keys():
                     all_hist_dict[dataset_type] = {}
                 if final_key not in all_hist_dict[dataset_type]:

--- a/Analysis/HistProducerFromNTuple.py
+++ b/Analysis/HistProducerFromNTuple.py
@@ -250,7 +250,10 @@ if __name__ == "__main__":
             uncs_to_compute.update(
                 {
                     key: setup.global_params["scales"]
-                    for key in unc_cfg_dict["shape"].keys()
+                    for key, params in unc_cfg_dict["shape"].items()
+                    if not (
+                        isinstance(params, dict) and params.get("data_driven", False)
+                    )
                 }
             )
     print(uncs_to_compute)

--- a/Analysis/HistTupleProducer.py
+++ b/Analysis/HistTupleProducer.py
@@ -92,7 +92,10 @@ def createHistTuple(
     print("Norm uncertainties to consider:", norm_uncertainties)
     scale_uncertainties = set()
     if setup.global_params["compute_unc_variations"]:
-        scale_uncertainties.update(unc_cfg_dict["shape"].keys())
+        for unc_name, unc_params in unc_cfg_dict["shape"].items():
+            if isinstance(unc_params, dict) and unc_params.get("data_driven", False):
+                continue
+            scale_uncertainties.add(unc_name)
     print("Scale uncertainties to consider:", scale_uncertainties)
 
     print("Defining binnings for variables")


### PR DESCRIPTION
Title: Exclude data-driven shape uncertainties from per-event tree processing (fixes QCDScale crash)

Description:

**Problem**
QCDScale is a data-driven shape uncertainty for the HH→bbττ QCD ABCD estimate: its Up/Down templates are built after histogramming, from the OS_AntiIso/SS_Iso/SS_AntiIso sideband regions — there is no per-event weight variation and no corresponding Events__QCDScale__Up/Down tree in the anaTuple.

However, every stage that consumes `unc_cfg_dict["shape"]` assumed the opposite: that each key in that section names a real tree-level systematic requiring an `Events__<unc>__<scale>` tree. Adding QCDScale there (to give it a datacard nuisance name) made three independent stages try to load a tree that was never produced, crashing with:

```
RuntimeError: ERROR: tree Events__QCDScale__Up not found in file ...
KeyError: 'Events__QCDScale__Up'
at HistTupleProducerTask, HistFromNtupleProducerTask, and (latent, not yet hit in production but same code path) AnalysisCacheProducer.
```
**Fix**
Introduce a `data_driven: true` flag on a shape entry (set in the main repo's `weights.yaml` for QCDScale) and skip flagged entries wherever a stage builds its list of per-event/tree-level uncertainties to process:

`Analysis/HistTupleProducer.py (createHistTuple)`: `scale_uncertainties` now skips `data_driven` entries.
`Analysis/AnalysisCacheProducer.py (createAnalysisCache)`: same skip (same bug pattern; would have crashed identically once this stage runs with unc variations enabled).
`Analysis/HistProducerFromNTuple.py`: `uncs_to_compute` now skips `data_driven` entries, so it neither looks up a `Events__QCDScale__*` tree nor produces` {var}_QCDScale_{scale}`-named histograms.

The  `Analysis/HistMergerFromHists.py`'s `fill_hists`, which needed the opposite treatment (see [HH_bbtautau PR 74](https://github.com/cms-flaf/HH_bbtautau/pull/74) ), and `tasks.py`'s `HistMergerTask.uncNames` construction, which correctly still includes `QCDScale` unfiltered — the merge stage is exactly where this data-driven uncertainty is supposed to be built and consumed.