### PR TITLE
Move histTupleFlavor handling to Setup

### DIFF
--- a/Analysis/HistTupleProducer.py
+++ b/Analysis/HistTupleProducer.py
@@ -81,7 +81,8 @@ def createHistTuple(
     histTupleDef.analysis_setup(setup)
     isData = dataset_name == "data"
 
-    variables = setup.histTuple_plot_vars
+    binned_variables = setup.histTuple_plot_vars
+    fullres_variables = setup.histTuple_fullres_vars
 
     norm_uncertainties = set()
     if setup.global_params["compute_rel_weights"]:
@@ -94,7 +95,7 @@ def createHistTuple(
 
     print("Defining binnings for variables")
     flatten_vars = set()
-    for var in variables:
+    for var in binned_variables:
         if isinstance(var, dict) and "vars" in var:
             for v in var["vars"]:
                 flatten_vars.add(v)
@@ -140,6 +141,8 @@ def createHistTuple(
                 )
 
             dfw = histTupleDef.GetDfw(df, setup, dataset_name)
+            for var in fullres_variables:
+                dfw.colToSave.append(var)
 
             selection_tags = setup.global_params.get("histTuple_selectors", [])
             selection_flags = []

--- a/Analysis/HistTupleProducer.py
+++ b/Analysis/HistTupleProducer.py
@@ -81,10 +81,7 @@ def createHistTuple(
     histTupleDef.analysis_setup(setup)
     isData = dataset_name == "data"
 
-    if type(setup.global_params["variables"]) == list:
-        variables = setup.global_params["variables"]
-    elif type(setup.global_params["variables"]) == dict:
-        variables = setup.global_params["variables"].keys()
+    variables = setup.histTuple_plot_vars
 
     norm_uncertainties = set()
     if setup.global_params["compute_rel_weights"]:

--- a/Analysis/tasks.py
+++ b/Analysis/tasks.py
@@ -97,7 +97,7 @@ class HistTupleProducerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
             var_produced_by = self.setup.var_producer_map
 
             flatten_vars = set()
-            for var in self.global_params["variables"]:
+            for var in self.setup.histTuple_vars:
                 if isinstance(var, dict) and "vars" in var:
                     for v in var["vars"]:
                         flatten_vars.add(v)
@@ -286,7 +286,7 @@ class HistTupleProducerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
         datasets_to_consider.append("data")
 
         flatten_vars = set()
-        for var in self.global_params["variables"]:
+        for var in self.setup.histTuple_vars:
             if isinstance(var, dict) and "vars" in var:
                 for v in var["vars"]:
                     flatten_vars.add(v)
@@ -519,7 +519,7 @@ class HistFromNtupleProducerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
 
     @property
     def active_variables(self):
-        all_vars = _dedup_variables(self.global_params["variables"])
+        all_vars = _dedup_variables(self.setup.histTuple_plot_vars)
         if not self.variables:
             return all_vars
         selected = {v.strip() for v in self.variables.split(",") if v.strip()}
@@ -751,7 +751,7 @@ class HistMergerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
 
     @property
     def active_variables(self):
-        all_vars = _dedup_variables(self.global_params["variables"])
+        all_vars = _dedup_variables(self.setup.histTuple_plot_vars)
         if not self.variables:
             return all_vars
         selected = {v.strip() for v in self.variables.split(",") if v.strip()}
@@ -1275,7 +1275,7 @@ class HistPlotTask(Task, HTCondorWorkflow, law.LocalWorkflow):
 
     @property
     def active_variables(self):
-        all_vars = _dedup_variables(self.global_params["variables"])
+        all_vars = _dedup_variables(self.setup.histTuple_plot_vars)
         if not self.variables:
             return all_vars
         selected = {v.strip() for v in self.variables.split(",") if v.strip()}
@@ -1364,7 +1364,7 @@ class HistPlotTask(Task, HTCondorWorkflow, law.LocalWorkflow):
             customisations=self.customisations,
         ).create_branch_map()
         var_dict = {}
-        for var in self.global_params["variables"]:
+        for var in self.setup.histTuple_plot_vars:
             var_name = var if isinstance(var, str) else var["name"]
             var_dict[var_name] = var
         for k, (_, (var, _, _)) in enumerate(merge_map.items()):

--- a/Common/Setup.py
+++ b/Common/Setup.py
@@ -363,19 +363,11 @@ class Setup:
         histTuple_plot_vars = self.global_params["histTuple_flavors"][
             self.histTuple_flavor
         ]["variables"]
-        self.histTuple_plot_vars = set(
-            histTuple_plot_vars
-            if isinstance(histTuple_plot_vars, list)
-            else histTuple_plot_vars.keys()
-        )
+        self.histTuple_plot_vars = set([ x["name"] for x in histTuple_plot_vars if isinstance(x, dict) else x ])
         histTuple_fullres_vars = self.global_params["histTuple_flavors"][
             self.histTuple_flavor
         ]["fullResolution_variables"]
-        self.histTuple_fullres_vars = set(
-            histTuple_plot_vars
-            if isinstance(histTuple_fullres_vars, list)
-            else histTuple_fullres_vars.keys()
-        )
+        self.histTuple_fullres_vars = set([ x["name"] for x in histTuple_fullres_vars if isinstance(x, dict) else x ])
         self.histTuple_vars = (
             self.histTuple_plot_vars | self.histTuple_fullres_vars
         )  # Keep union for the simple tasks-dependency loading

--- a/Common/Setup.py
+++ b/Common/Setup.py
@@ -360,13 +360,13 @@ class Setup:
 
         self.histTuple_flavor = self.global_params["histTuple_flavor"]
         print(f"Using histTuple flavor {self.histTuple_flavor}")
+        histTuple_plot_vars = self.global_params["histTuple_flavors"][self.histTuple_flavor]["variables"]
         self.histTuple_plot_vars = set(
-            self.global_params["histTuple_flavors"][self.histTuple_flavor]["variables"]
+            histTuple_plot_vars if isinstance(histTuple_plot_vars, list) else histTuple_plot_vars.keys()
         )
+        histTuple_fullres_vars = self.global_params["histTuple_flavors"][self.histTuple_flavor]["fullResolution_variables"]
         self.histTuple_fullres_vars = set(
-            self.global_params["histTuple_flavors"][self.histTuple_flavor][
-                "fullResolution_variables"
-            ]
+            histTuple_plot_vars if isinstance(histTuple_fullres_vars, list) else histTuple_fullres_vars.keys()
         )
         self.histTuple_vars = (
             self.histTuple_plot_vars | self.histTuple_fullres_vars

--- a/Common/Setup.py
+++ b/Common/Setup.py
@@ -363,11 +363,11 @@ class Setup:
         histTuple_plot_vars = self.global_params["histTuple_flavors"][
             self.histTuple_flavor
         ]["variables"]
-        self.histTuple_plot_vars = set([ x["name"] for x in histTuple_plot_vars if isinstance(x, dict) else x ])
+        self.histTuple_plot_vars = set([ x["name"] if isinstance(x, dict) else x for x in histTuple_plot_vars ])
         histTuple_fullres_vars = self.global_params["histTuple_flavors"][
             self.histTuple_flavor
         ]["fullResolution_variables"]
-        self.histTuple_fullres_vars = set([ x["name"] for x in histTuple_fullres_vars if isinstance(x, dict) else x ])
+        self.histTuple_fullres_vars = set([ x["name"] if isinstance(x, dict) else x for x in histTuple_fullres_vars ])
         self.histTuple_vars = (
             self.histTuple_plot_vars | self.histTuple_fullres_vars
         )  # Keep union for the simple tasks-dependency loading

--- a/Common/Setup.py
+++ b/Common/Setup.py
@@ -358,6 +358,20 @@ class Setup:
             else:
                 processes[key] = item
 
+        self.histTuple_flavor = self.global_params["histTuple_flavor"]
+        print(f"Using histTuple flavor {self.histTuple_flavor}")
+        self.histTuple_plot_vars = set(
+            self.global_params["histTuple_flavors"][self.histTuple_flavor]["variables"]
+        )
+        self.histTuple_fullres_vars = set(
+            self.global_params["histTuple_flavors"][self.histTuple_flavor][
+                "fullResolution_variables"
+            ]
+        )
+        self.histTuple_vars = (
+            self.histTuple_plot_vars | self.histTuple_fullres_vars
+        )  # Keep union for the simple tasks-dependency loading
+
         def collect_base_processes(p_name, parent_name=None):
             if p_name not in processes:
                 if parent_name is not None:

--- a/Common/Setup.py
+++ b/Common/Setup.py
@@ -362,11 +362,15 @@ class Setup:
         print(f"Using histTuple flavor {self.histTuple_flavor}")
         histTuple_plot_vars = self.global_params["histTuple_flavors"][self.histTuple_flavor]["variables"]
         self.histTuple_plot_vars = set(
-            histTuple_plot_vars if isinstance(histTuple_plot_vars, list) else histTuple_plot_vars.keys()
+            histTuple_plot_vars
+            if isinstance(histTuple_plot_vars, list)
+            else histTuple_plot_vars.keys()
         )
         histTuple_fullres_vars = self.global_params["histTuple_flavors"][self.histTuple_flavor]["fullResolution_variables"]
         self.histTuple_fullres_vars = set(
-            histTuple_plot_vars if isinstance(histTuple_fullres_vars, list) else histTuple_fullres_vars.keys()
+            histTuple_plot_vars
+            if isinstance(histTuple_fullres_vars, list)
+            else histTuple_fullres_vars.keys()
         )
         self.histTuple_vars = (
             self.histTuple_plot_vars | self.histTuple_fullres_vars

--- a/Common/Setup.py
+++ b/Common/Setup.py
@@ -360,13 +360,17 @@ class Setup:
 
         self.histTuple_flavor = self.global_params["histTuple_flavor"]
         print(f"Using histTuple flavor {self.histTuple_flavor}")
-        histTuple_plot_vars = self.global_params["histTuple_flavors"][self.histTuple_flavor]["variables"]
+        histTuple_plot_vars = self.global_params["histTuple_flavors"][
+            self.histTuple_flavor
+        ]["variables"]
         self.histTuple_plot_vars = set(
             histTuple_plot_vars
             if isinstance(histTuple_plot_vars, list)
             else histTuple_plot_vars.keys()
         )
-        histTuple_fullres_vars = self.global_params["histTuple_flavors"][self.histTuple_flavor]["fullResolution_variables"]
+        histTuple_fullres_vars = self.global_params["histTuple_flavors"][
+            self.histTuple_flavor
+        ]["fullResolution_variables"]
         self.histTuple_fullres_vars = set(
             histTuple_plot_vars
             if isinstance(histTuple_fullres_vars, list)

--- a/Common/Setup.py
+++ b/Common/Setup.py
@@ -380,7 +380,9 @@ class Setup:
                     seen_hashable.add(item)
                     unique_list.append(item)
                     
-        self.histTuple_vars = unique_list  # Keep union for the simple tasks-dependency loading
+        self.histTuple_vars = (
+            unique_list  # Keep union for the simple tasks-dependency loading
+        )
 
         def collect_base_processes(p_name, parent_name=None):
             if p_name not in processes:

--- a/Common/Setup.py
+++ b/Common/Setup.py
@@ -367,13 +367,29 @@ class Setup:
             self.histTuple_flavor
         ]["fullResolution_variables"]
 
-        var_dict = {}
-        for var in self.histTuple_plot_vars + self.histTuple_fullres_vars:
+        # Safety check that the fullres or the plotvars do not have duplicates
+        plotvar_dict = {}
+        for var in self.histTuple_plot_vars:
             var_name = var["name"] if isinstance(var, dict) else var
-            if var_name in var_dict:
-                raise RuntimeError(f"Duplicated variable name {var_name}")
-            var_dict[var_name] = var
-        self.histTuple_vars = list(var_dict.values())
+            if var_name in plotvar_dict:
+                raise RuntimeError(f"Duplicated plot variable name {var_name}")
+            plotvar_dict[var_name] = var
+
+        fullresvar_dict = {}
+        for var in self.histTuple_plot_vars:
+            var_name = var["name"] if isinstance(var, dict) else var
+            if var_name in fullresvar_dict:
+                raise RuntimeError(
+                    f"Duplicated full resolution variable name {var_name}"
+                )
+            fullresvar_dict[var_name] = var
+
+        # Now a merged list removing the duplicates
+        var_set = set()
+        for var in list(plotvar_dict.values()) + list(fullresvar_dict.values()):
+            var_name = var["name"] if isinstance(var, dict) else var
+            var_set.add(var)
+        self.histTuple_vars = list(var_set)
 
         def collect_base_processes(p_name, parent_name=None):
             if p_name not in processes:

--- a/Common/Setup.py
+++ b/Common/Setup.py
@@ -367,9 +367,9 @@ class Setup:
             self.histTuple_flavor
         ]["fullResolution_variables"]
 
-        unique_list = [ ]
+        unique_list = []
         seen_hashable = set()
-        seen_unhashable = [ ]
+        seen_unhashable = []
         for var in self.histTuple_plot_vars + self.histTuple_fullres_vars:
             if isinstance(var, dict):
                 if var not in seen_unhashable:
@@ -379,7 +379,7 @@ class Setup:
                 if var not in seen_hashable:
                     seen_hashable.add(item)
                     unique_list.append(item)
-                    
+
         self.histTuple_vars = (
             unique_list  # Keep union for the simple tasks-dependency loading
         )

--- a/Common/Setup.py
+++ b/Common/Setup.py
@@ -388,7 +388,7 @@ class Setup:
         var_set = set()
         for var in list(plotvar_dict.values()) + list(fullresvar_dict.values()):
             var_name = var["name"] if isinstance(var, dict) else var
-            var_set.add(var)
+            var_set.add(var_name)
         self.histTuple_vars = list(var_set)
 
         def collect_base_processes(p_name, parent_name=None):

--- a/Common/Setup.py
+++ b/Common/Setup.py
@@ -364,13 +364,13 @@ class Setup:
             self.histTuple_flavor
         ]["variables"]
         self.histTuple_plot_vars = set(
-            [ x["name"] if isinstance(x, dict) else x for x in histTuple_plot_vars ]
+            [x["name"] if isinstance(x, dict) else x for x in histTuple_plot_vars]
         )
         histTuple_fullres_vars = self.global_params["histTuple_flavors"][
             self.histTuple_flavor
         ]["fullResolution_variables"]
         self.histTuple_fullres_vars = set(
-            [ x["name"] if isinstance(x, dict) else x for x in histTuple_fullres_vars ]
+            [x["name"] if isinstance(x, dict) else x for x in histTuple_fullres_vars]
         )
         self.histTuple_vars = (
             self.histTuple_plot_vars | self.histTuple_fullres_vars

--- a/Common/Setup.py
+++ b/Common/Setup.py
@@ -380,9 +380,7 @@ class Setup:
                     seen_hashable.add(item)
                     unique_list.append(item)
                     
-        self.histTuple_vars = (
-            self.histTuple_plot_vars | self.histTuple_fullres_vars
-        )  # Keep union for the simple tasks-dependency loading
+        self.histTuple_vars = unique_list  # Keep union for the simple tasks-dependency loading
 
         def collect_base_processes(p_name, parent_name=None):
             if p_name not in processes:

--- a/Common/Setup.py
+++ b/Common/Setup.py
@@ -363,11 +363,15 @@ class Setup:
         histTuple_plot_vars = self.global_params["histTuple_flavors"][
             self.histTuple_flavor
         ]["variables"]
-        self.histTuple_plot_vars = set([ x["name"] if isinstance(x, dict) else x for x in histTuple_plot_vars ])
+        self.histTuple_plot_vars = set(
+            [ x["name"] if isinstance(x, dict) else x for x in histTuple_plot_vars ]
+        )
         histTuple_fullres_vars = self.global_params["histTuple_flavors"][
             self.histTuple_flavor
         ]["fullResolution_variables"]
-        self.histTuple_fullres_vars = set([ x["name"] if isinstance(x, dict) else x for x in histTuple_fullres_vars ])
+        self.histTuple_fullres_vars = set(
+            [ x["name"] if isinstance(x, dict) else x for x in histTuple_fullres_vars ]
+        )
         self.histTuple_vars = (
             self.histTuple_plot_vars | self.histTuple_fullres_vars
         )  # Keep union for the simple tasks-dependency loading

--- a/Common/Setup.py
+++ b/Common/Setup.py
@@ -367,22 +367,13 @@ class Setup:
             self.histTuple_flavor
         ]["fullResolution_variables"]
 
-        unique_list = []
-        seen_hashable = set()
-        seen_unhashable = []
+        var_dict = {}
         for var in self.histTuple_plot_vars + self.histTuple_fullres_vars:
-            if isinstance(var, dict):
-                if var not in seen_unhashable:
-                    seen_unhashable.append(var)
-                    unique_list.append(var)
-            else:
-                if var not in seen_hashable:
-                    seen_hashable.add(var)
-                    unique_list.append(var)
-
-        self.histTuple_vars = (
-            unique_list  # Keep union for the simple tasks-dependency loading
-        )
+            var_name = var["name"] if isinstance(var, dict) else var
+            if var_name in var_dict:
+                raise RuntimeError(f"Duplicated variable name {var_name}")
+            var_dict[var_name] = var
+        self.histTuple_vars = list(var_dict.values())
 
         def collect_base_processes(p_name, parent_name=None):
             if p_name not in processes:

--- a/Common/Setup.py
+++ b/Common/Setup.py
@@ -360,18 +360,26 @@ class Setup:
 
         self.histTuple_flavor = self.global_params["histTuple_flavor"]
         print(f"Using histTuple flavor {self.histTuple_flavor}")
-        histTuple_plot_vars = self.global_params["histTuple_flavors"][
+        self.histTuple_plot_vars = self.global_params["histTuple_flavors"][
             self.histTuple_flavor
         ]["variables"]
-        self.histTuple_plot_vars = set(
-            [x["name"] if isinstance(x, dict) else x for x in histTuple_plot_vars]
-        )
-        histTuple_fullres_vars = self.global_params["histTuple_flavors"][
+        self.histTuple_fullres_vars = self.global_params["histTuple_flavors"][
             self.histTuple_flavor
         ]["fullResolution_variables"]
-        self.histTuple_fullres_vars = set(
-            [x["name"] if isinstance(x, dict) else x for x in histTuple_fullres_vars]
-        )
+
+        unique_list = [ ]
+        seen_hashable = set()
+        seen_unhashable = [ ]
+        for var in self.histTuple_plot_vars + self.histTuple_fullres_vars:
+            if isinstance(var, dict):
+                if var not in seen_unhashable:
+                    seen_unhashable.append(var)
+                    unique_list.append(var)
+            else:
+                if var not in seen_hashable:
+                    seen_hashable.add(item)
+                    unique_list.append(item)
+                    
         self.histTuple_vars = (
             self.histTuple_plot_vars | self.histTuple_fullres_vars
         )  # Keep union for the simple tasks-dependency loading

--- a/Common/Setup.py
+++ b/Common/Setup.py
@@ -377,8 +377,8 @@ class Setup:
                     unique_list.append(var)
             else:
                 if var not in seen_hashable:
-                    seen_hashable.add(item)
-                    unique_list.append(item)
+                    seen_hashable.add(var)
+                    unique_list.append(var)
 
         self.histTuple_vars = (
             unique_list  # Keep union for the simple tasks-dependency loading


### PR DESCRIPTION
Moving the histTuple_flavor logic into the Setup class.

histTuple_flavor was a key used in the global.yaml that can point to different histTuple setups. This contains 2 parts:
"variables" -- list of variables to plot into histograms
"fullResolution_variables" -- list of variables to save at full resolution (NOT PLOT)

Previously, through some quirks, law tasks were created using the default variables list always, even when histTuple_flavor was set to something else (DNN_training in bbWW example). This created weird dependency and branch creation.

This new method is set to instead handle both variable lists through Setup, creating ```setup.histTuple_plot_vars``` and ```setup.histTuple_fullres_vars```. Through these and the union ```setup.histTuple_vars```, the law tasks are correctly created now.

The side effect is now all ```global.yaml``` need to move their default ```variables``` and old named ```histTuple_fullResolution_variables``` into a ```default``` key of their ```histTuple_flavors``` dict.