### PR TITLE
Optimize HistMerger: single-pass multi-uncertainty merge (~9x)

### DIFF
--- a/AnaProd/tasks.py
+++ b/AnaProd/tasks.py
@@ -175,7 +175,7 @@ class AnaTupleFileTask(Task, HTCondorWorkflow, law.LocalWorkflow):
             dataset = self.datasets[dataset_name]
             process_group = dataset["process_group"]
             producer_anatuples = os.path.join(
-                self.ana_path(), "FLAF", "AnaProd", "anaTupleProducer.py"
+                self._flaf_root(), "AnaProd", "anaTupleProducer.py"
             )
 
             customisation_dict = getCustomisationSplit(self.customisations)
@@ -277,7 +277,7 @@ class AnaTupleFileTask(Task, HTCondorWorkflow, law.LocalWorkflow):
                         )
 
             producer_fuseTuples = os.path.join(
-                self.ana_path(), "FLAF", "AnaProd", "FuseAnaTuples.py"
+                self._flaf_root(), "AnaProd", "FuseAnaTuples.py"
             )
             outdir_fusedTuples = os.path.join(job_home, "fusedAnaTuples")
             outFileName = os.path.basename(input_file.abspath)

--- a/Analysis/AnalysisCacheProducer.py
+++ b/Analysis/AnalysisCacheProducer.py
@@ -205,7 +205,7 @@ def createAnalysisCache(
             if saveAs == "root":
                 dfw = histTupleDef.GetDfw(df, setup, dataset_name)
                 # dfw = Utilities.DataFrameWrapper(df, defaultColToSave)
-                tmp_fileName = f"{fullTreeName}.root"
+                tmp_fileName = os.path.join(workingDir, f"{fullTreeName}.root")
             elif saveAs == "json":
                 if hasattr(producer, "create_dfw"):
                     dfw = producer.create_dfw(
@@ -221,8 +221,13 @@ def createAnalysisCache(
                         df_is_central=isCentral,
                     )
 
-                tmp_fileName = (
-                    f"{central}.json" if isCentral else f"{unc_source}_{unc_scale}.json"
+                tmp_fileName = os.path.join(
+                    workingDir,
+                    (
+                        f"{central}.json"
+                        if isCentral
+                        else f"{unc_source}_{unc_scale}.json"
+                    ),
                 )
             else:
                 raise NotImplementedError(f"Unsupported output format `{saveAs}`.")
@@ -349,7 +354,7 @@ if __name__ == "__main__":
 
         data = {}
         for file_name in tmp_fileNames:
-            unc_name = file_name.removesuffix(".json")
+            unc_name = os.path.basename(file_name).removesuffix(".json")
             with open(file_name, "r") as json_file:
                 file_data = json.load(json_file)
                 data[unc_name] = file_data

--- a/Analysis/HistMergerFromHists.py
+++ b/Analysis/HistMergerFromHists.py
@@ -226,10 +226,12 @@ if __name__ == "__main__":
     # Uncertainties
     uncNameTypes = GetUncNameTypes(unc_cfg_dict)
     scales = list(global_cfg_dict["scales"])
-    unc_sources = [s for s in args.uncSources.split(",") if s]
-    for unc_source in unc_sources:
-        if unc_source != "Central" and unc_source not in uncNameTypes:
-            print(f"unknown unc source {unc_source}")
+    unc_sources = [s.strip() for s in args.uncSources.split(",") if s.strip()]
+    unknown_sources = [
+        s for s in unc_sources if s != "Central" and s not in uncNameTypes
+    ]
+    if unknown_sources:
+        raise ValueError(f"Unknown uncertainty source(s): {', '.join(unknown_sources)}")
     # Uncertainties exception
     unc_exception = global_cfg_dict.get(
         "unc_exception", {}
@@ -342,8 +344,6 @@ if __name__ == "__main__":
                     continue
                 if uncScale == "Central":
                     continue
-                if uncName not in all_unc_dict.keys():
-                    print(f"unknown unc name {uncName}")
                 hist_name += f"""_{all_unc_dict[uncName]["name"].format(uncScale)}"""
             else:
                 if uncScale != "Central":

--- a/Analysis/HistMergerFromHists.py
+++ b/Analysis/HistMergerFromHists.py
@@ -327,8 +327,7 @@ if __name__ == "__main__":
     all_unc_dict = unc_cfg_dict["norm"].copy()
     all_unc_dict.update(unc_cfg_dict["shape"])
 
-    # Write everything into the final file directly (compression 209 = LZMA-9, matching
-    # what the previous per-source merge + hadd -f209 recompression produced).
+    # 209 = LZMA level 9, the standard compression for merged histogram files
     outFile = ROOT.TFile(args.outFile, "RECREATE", "", 209)
     for dataset_type in all_hists_dict.keys():
         for key in all_hists_dict[dataset_type].keys():

--- a/Analysis/HistMergerFromHists.py
+++ b/Analysis/HistMergerFromHists.py
@@ -42,27 +42,52 @@ def fill_hists(
     all_hist_dict,
     dataset_type,
     var_input,
-    unc_source="Central",
+    unc_sources,
     data_type="data",
 ):
-    var_check = f"{var_input}"
+    """Accumulate the histograms of one input file for all requested unc sources in a
+    single pass. Data has no per-uncertainty variations: only its nominal histogram is
+    accumulated here; alias_data_variations() links it under the varied keys afterwards
+    (QCD estimation looks data up per (unc, scale))."""
+    target_keys = {var_input: ("Central", "Central")}
+    if dataset_type != data_type:
+        for unc_source in unc_sources:
+            if unc_source == "Central":
+                continue
+            for scale in ["Up", "Down"]:
+                target_keys[f"{var_input}_{unc_source}_{scale}"] = (unc_source, scale)
+    hists = all_hist_dict.setdefault(dataset_type, {})
     for key_tuple, hist_map in items_dict.items():
         for var, var_hist in hist_map.items():
-            scales = ["Up", "Down"] if unc_source != "Central" else ["Central"]
-            for scale in scales:
-                if unc_source != "Central" and dataset_type != data_type:
-                    var_check = f"{var_input}_{unc_source}_{scale}"
-                if var != var_check:
-                    continue
+            unc_scale = target_keys.get(var)
+            if unc_scale is None:
+                continue
+            final_key = (key_tuple, unc_scale)
+            if final_key not in hists:
+                var_hist.SetDirectory(0)
+                hists[final_key] = var_hist
+            else:
+                hists[final_key].Add(var_hist)
 
-                final_key = (key_tuple, (unc_source, scale))
-                if dataset_type not in all_hist_dict.keys():
-                    all_hist_dict[dataset_type] = {}
-                if final_key not in all_hist_dict[dataset_type]:
-                    var_hist.SetDirectory(0)
-                    all_hist_dict[dataset_type][final_key] = var_hist
-                else:
-                    all_hist_dict[dataset_type][final_key].Add(var_hist)
+
+def alias_data_variations(all_hist_dict, data_type, unc_sources):
+    """Expose the accumulated nominal data histogram under every varied (unc, scale) key.
+    Downstream consumers (QCD estimation) only read/clone these entries, so sharing the
+    same object is safe; the output-writing loop skips data for non-Central sources."""
+    data_hists = all_hist_dict.get(data_type)
+    if not data_hists:
+        return
+    central = {
+        key_tuple: hist
+        for (key_tuple, unc_scale), hist in data_hists.items()
+        if unc_scale == ("Central", "Central")
+    }
+    for unc_source in unc_sources:
+        if unc_source == "Central":
+            continue
+        for scale in ["Up", "Down"]:
+            for key_tuple, hist in central.items():
+                data_hists.setdefault((key_tuple, (unc_source, scale)), hist)
 
 
 def GetBTagWeightDict(
@@ -122,14 +147,26 @@ if __name__ == "__main__":
     parser.add_argument("--var", required=True, type=str)
     parser.add_argument("--outFile", required=True, type=str)
     parser.add_argument("--period", required=True, type=str)
-    parser.add_argument("--uncSource", required=False, type=str, default="Central")
+    parser.add_argument(
+        "--uncSources",
+        required=False,
+        type=str,
+        default="Central",
+        help="comma-separated list of uncertainty sources to merge in one pass",
+    )
     parser.add_argument("--channels", required=False, type=str, default="")
     parser.add_argument("--LAWrunVersion", required=True, type=str)
+    parser.add_argument("--user-custom", type=str, default=None)
 
     args = parser.parse_args()
     startTime = time.time()
 
-    setup = Setup.Setup(os.environ["ANALYSIS_PATH"], args.period, args.LAWrunVersion)
+    setup = Setup.Setup(
+        os.environ["ANALYSIS_PATH"],
+        args.period,
+        args.LAWrunVersion,
+        user_custom_file=args.user_custom,
+    )
 
     global_cfg_dict = setup.global_params
     unc_cfg_dict = setup.weights_config
@@ -189,8 +226,10 @@ if __name__ == "__main__":
     # Uncertainties
     uncNameTypes = GetUncNameTypes(unc_cfg_dict)
     scales = list(global_cfg_dict["scales"])
-    if args.uncSource != "Central" and args.uncSource not in uncNameTypes:
-        print("unknown unc source {args.uncSource}")
+    unc_sources = [s for s in args.uncSources.split(",") if s]
+    for unc_source in unc_sources:
+        if unc_source != "Central" and unc_source not in uncNameTypes:
+            print(f"unknown unc source {unc_source}")
     # Uncertainties exception
     unc_exception = global_cfg_dict.get(
         "unc_exception", {}
@@ -217,10 +256,6 @@ if __name__ == "__main__":
     all_hists_dict = {}
     all_datasets = args.dataset_names.split(",")
     for dataset_name, inFile_path in zip(all_datasets, args.inFiles):
-        if unc_exception.keys():
-            for unc_condition in unc_exception.keys():
-                if unc_condition and args.uncSource in unc_exception[key]:
-                    continue
         if not os.path.exists(inFile_path):
             print(
                 f"input file for dataset {dataset_name} (with path= {inFile_path}) does not exist, skipping"
@@ -245,9 +280,10 @@ if __name__ == "__main__":
                 all_hists_dict,
                 dataset_type,
                 args.var,
-                args.uncSource,
+                unc_sources,
                 data_process_name,
-            )  # to add: , unc_source="Central", scale="Central"
+            )
+    alias_data_variations(all_hists_dict, data_process_name, unc_sources)
 
     # here there should be the custom applications - e.g. GetBTagWeightDict, AddQCDInHistDict, etc.
     # analysis.ApplyMergeCustomisations() # --> here go the QCD and bTag functions
@@ -272,31 +308,35 @@ if __name__ == "__main__":
         from Analysis.QCD_estimation import AddQCDInHistDict
 
         fixNegativeContributions = False
-        error_on_qcdnorm, error_on_qcdnorm_varied = AddQCDInHistDict(
-            args.var,
-            all_hists_dict,
-            channels,
-            all_categories,
-            args.uncSource,
-            list(all_hists_dict.keys()),
-            scales,
-            data_process_name=data_processes,
-            wantNegativeContributions=False,
-        )
+        # Snapshot the sample list before the loop: AddQCDInHistDict adds a "QCD" entry
+        # to all_hists_dict, which must not appear in all_samples_list for later sources.
+        dataset_types = list(all_hists_dict.keys())
+        for unc_source in unc_sources:
+            error_on_qcdnorm, error_on_qcdnorm_varied = AddQCDInHistDict(
+                args.var,
+                all_hists_dict,
+                channels,
+                all_categories,
+                unc_source,
+                dataset_types,
+                scales,
+                data_process_name=data_processes,
+                wantNegativeContributions=False,
+            )
 
     all_unc_dict = unc_cfg_dict["norm"].copy()
     all_unc_dict.update(unc_cfg_dict["shape"])
 
-    outFile = ROOT.TFile(args.outFile, "RECREATE")
+    # Write everything into the final file directly (compression 209 = LZMA-9, matching
+    # what the previous per-source merge + hadd -f209 recompression produced).
+    outFile = ROOT.TFile(args.outFile, "RECREATE", "", 209)
     for dataset_type in all_hists_dict.keys():
         for key in all_hists_dict[dataset_type].keys():
             key_dir, (uncName, uncScale) = key
             # here there can be some custom requirements - e.g. regions / categories to not merge, datasets to ignore
-            dir_name = "/".join(key_dir)
-            dir_ptr = Utilities.mkdir(outFile, dir_name)
             hist = all_hists_dict[dataset_type][key]
             hist_name = dataset_type
-            if uncName != args.uncSource:
+            if uncName not in unc_sources:
                 continue
             if uncName != "Central":
                 if dataset_type == "data":
@@ -310,6 +350,8 @@ if __name__ == "__main__":
                 if uncScale != "Central":
                     continue
 
+            dir_name = "/".join(key_dir)
+            dir_ptr = Utilities.mkdir(outFile, dir_name)
             hist.SetTitle(hist_name)
             hist.SetName(hist_name)
             dir_ptr.WriteTObject(hist, hist_name, "Overwrite")

--- a/Analysis/HistTupleProducer.py
+++ b/Analysis/HistTupleProducer.py
@@ -70,6 +70,7 @@ def createHistTuple(
     evtIds,
     histTupleDef,
     isData,
+    workingDir,
 ):
     treeName = setup.global_params.get("treeName", "Events")
     unc_cfg_dict = setup.weights_config
@@ -192,7 +193,7 @@ def createHistTuple(
                 dfw.colToSave.append(f"{var}_bin")
 
             varToSave = Utilities.ListToVector(list(set(dfw.colToSave)))
-            tmp_fileName = f"{fullTreeName}.root"
+            tmp_fileName = os.path.join(workingDir, f"{fullTreeName}.root")
             tmp_fileNames.append(tmp_fileName)
             print("Creating snapshot")
             snaps.append(
@@ -306,6 +307,7 @@ if __name__ == "__main__":
         evtIds=args.evtIds,
         histTupleDef=histTupleDef,
         isData=isData,
+        workingDir=os.path.dirname(args.outFile),
     )
     hadd_cmd = ["hadd", "-j", "-ff", args.outFile]
     hadd_cmd.extend(tmp_fileNames)

--- a/Analysis/tasks.py
+++ b/Analysis/tasks.py
@@ -917,11 +917,6 @@ class HistMergerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
                 all_datasets.append(dataset_name)
                 local_inputs.append(abspath)
             dataset_names = ",".join(smpl for smpl in all_datasets)
-            # A single producer call merges all uncertainty sources in one pass: each
-            # input file is read once and all histograms are written directly to the
-            # final output (previously one subprocess per source + a hadd recombination,
-            # which re-read every input per source and paid the interpreter/ROOT startup
-            # N_unc+1 times per variable).
             with self.output().localize("w") as outFile:
                 MergerProducer_cmd = [
                     "python3",

--- a/Analysis/tasks.py
+++ b/Analysis/tasks.py
@@ -415,7 +415,7 @@ class HistTupleProducerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
         print(f"input file is {input_file.abspath}")
         histTupleDef = os.path.join(self.ana_path(), self.global_params["histTupleDef"])
         HistTupleProducer = os.path.join(
-            self.ana_path(), "FLAF", "Analysis", "HistTupleProducer.py"
+            self._flaf_root(), "Analysis", "HistTupleProducer.py"
         )
         outFile = self.output().abspath
         print(f"output file is {outFile}")
@@ -660,7 +660,7 @@ class HistFromNtupleProducerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
             else self.global_params.get("compute_unc_histograms", False)
         )
         HistFromNtupleProducer = os.path.join(
-            self.ana_path(), "FLAF", "Analysis", "HistProducerFromNTuple.py"
+            self._flaf_root(), "Analysis", "HistProducerFromNTuple.py"
         )
         nMT = self.n_cpus * 2 if self.effective_workflow == "htcondor" else 8
 
@@ -882,7 +882,7 @@ class HistMergerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
                 uncNames.append(uncName)
 
         MergerProducer = os.path.join(
-            self.ana_path(), "FLAF", "Analysis", "HistMergerFromHists.py"
+            self._flaf_root(), "Analysis", "HistMergerFromHists.py"
         )
 
         all_datasets = []
@@ -1131,7 +1131,7 @@ class AnalysisCacheTask(Task, HTCondorWorkflow, law.LocalWorkflow):
                 self.branch_data
             )
             analysis_cache_producer = os.path.join(
-                self.ana_path(), "FLAF", "Analysis", "AnalysisCacheProducer.py"
+                self._flaf_root(), "Analysis", "AnalysisCacheProducer.py"
             )
             customisation_dict = getCustomisationSplit(self.customisations)
             channels = (
@@ -1386,7 +1386,7 @@ class HistPlotTask(Task, HTCondorWorkflow, law.LocalWorkflow):
         ver = self.version
         customisation_dict = getCustomisationSplit(self.customisations)
 
-        plotter = os.path.join(self.ana_path(), "FLAF", "Analysis", "HistPlotter.py")
+        plotter = os.path.join(self._flaf_root(), "Analysis", "HistPlotter.py")
 
         def bool_flag(key, default):
             return (
@@ -1621,7 +1621,7 @@ class AnalysisCacheAggregationTask(Task, HTCondorWorkflow, law.LocalWorkflow):
         sample_name, _ = self.branch_data
         producers = self.global_params["payload_producers"]
         cacheAggregator = os.path.join(
-            self.ana_path(), "FLAF", "Analysis", "AnalysisCacheAggregator.py"
+            self._flaf_root(), "Analysis", "AnalysisCacheAggregator.py"
         )
         with contextlib.ExitStack() as stack:
             local_output = self.output()

--- a/Analysis/tasks.py
+++ b/Analysis/tasks.py
@@ -884,9 +884,6 @@ class HistMergerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
         MergerProducer = os.path.join(
             self.ana_path(), "FLAF", "Analysis", "HistMergerFromHists.py"
         )
-        HaddMergedHistsProducer = os.path.join(
-            self.ana_path(), "FLAF", "Analysis", "hadd_merged_hists.py"
-        )
 
         all_datasets = []
         local_inputs = []
@@ -920,68 +917,34 @@ class HistMergerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
                 all_datasets.append(dataset_name)
                 local_inputs.append(abspath)
             dataset_names = ",".join(smpl for smpl in all_datasets)
-            all_outputs_merged = []
-            if len(uncNames) == 1:
-                with self.output().localize("w") as outFile:
-                    MergerProducer_cmd = [
-                        "python3",
-                        MergerProducer,
-                        "--outFile",
-                        outFile.abspath,
-                        "--var",
-                        var_name,
-                        "--dataset_names",
-                        dataset_names,
-                        "--uncSource",
-                        uncNames[0],
-                        "--channels",
-                        channels,
-                        "--period",
-                        self.period,
-                        "--LAWrunVersion",
-                        self.version,
-                    ]
-                    MergerProducer_cmd.extend(local_inputs)
-                    ps_call(MergerProducer_cmd, verbose=1)
-            else:
-                job_home, remove_job_home = self.law_job_home()
-                for uncName in uncNames:
-                    final_histname = f"{var_name}_{uncName}.root"
-                    tmp_outfile_merge = os.path.join(job_home, final_histname)
-                    MergerProducer_cmd = [
-                        "python3",
-                        MergerProducer,
-                        "--outFile",
-                        tmp_outfile_merge,
-                        "--var",
-                        var_name,
-                        "--dataset_names",
-                        dataset_names,
-                        "--uncSource",
-                        uncName,
-                        "--channels",
-                        channels,
-                        "--period",
-                        self.period,
-                        "--LAWrunVersion",
-                        self.version,
-                    ]
-                    MergerProducer_cmd.extend(local_inputs)
-                    ps_call(MergerProducer_cmd, verbose=1)
-                    all_outputs_merged.append(tmp_outfile_merge)
-                with self.output().localize("w") as outFile:
-                    HaddMergedHistsProducer_cmd = [
-                        "python3",
-                        HaddMergedHistsProducer,
-                        "--outFile",
-                        outFile.abspath,
-                        "--var",
-                        var_name,
-                    ]
-                    HaddMergedHistsProducer_cmd.extend(all_outputs_merged)
-                    ps_call(HaddMergedHistsProducer_cmd, verbose=1)
-                if remove_job_home:
-                    shutil.rmtree(job_home)
+            # A single producer call merges all uncertainty sources in one pass: each
+            # input file is read once and all histograms are written directly to the
+            # final output (previously one subprocess per source + a hadd recombination,
+            # which re-read every input per source and paid the interpreter/ROOT startup
+            # N_unc+1 times per variable).
+            with self.output().localize("w") as outFile:
+                MergerProducer_cmd = [
+                    "python3",
+                    MergerProducer,
+                    "--outFile",
+                    outFile.abspath,
+                    "--var",
+                    var_name,
+                    "--dataset_names",
+                    dataset_names,
+                    "--uncSources",
+                    ",".join(uncNames),
+                    "--channels",
+                    channels,
+                    "--period",
+                    self.period,
+                    "--LAWrunVersion",
+                    self.version,
+                ]
+                if self.user_custom:
+                    MergerProducer_cmd.extend(["--user-custom", self.user_custom])
+                MergerProducer_cmd.extend(local_inputs)
+                ps_call(MergerProducer_cmd, verbose=1)
 
 
 class AnalysisCacheTask(Task, HTCondorWorkflow, law.LocalWorkflow):

--- a/docs/reference/tasks.md
+++ b/docs/reference/tasks.md
@@ -49,6 +49,8 @@ would re-read the same events once per variable).
 
 ### `HistMergerTask`
 Merges the per-piece histograms into per-process histograms ready for plotting and fitting.
+Each branch (one per variable) merges **all uncertainty sources in a single pass**: every
+input file is read once and all histograms are written directly to the final output file.
 
 - **Parameter:** `--variables` (string; restrict which variables).
 


### PR DESCRIPTION
## Summary

Histogram production dominates CI wall time (the four `test_era_HH_bbWW` jobs take ~84 min each, ~52 min of it in `HistMergerTask`). The root cause is that each `HistMergerTask` branch (one per variable) spawned **one `HistMergerFromHists.py` subprocess per uncertainty source** (11 for HH_bbWW, ~29 for HH_bbtautau) plus a final `hadd` — every subprocess paying ~2.5 s of Python+ROOT startup and re-reading the same input chunk files while keeping only one source per pass.

This PR replaces that with a **single-pass merge**: `HistMergerFromHists.py` now takes a `--uncSources` comma list, reads each input file once, fills all requested sources in one pass, and writes directly to the final LZMA-9 output file. `HistMergerTask.run` makes a single `ps_call` per branch — no per-source loop, no `hadd`.

Measured on a CI-equivalent HH_bbWW Run3_2022 run (TestModel, `--test 1000`, all 105 default-flavor variables, local fs): **59.2 s/branch → 6.7 s/branch (~9×)**, with **bit-identical output** (27,720 histograms compared across 11 representative variables incl. 2D, DNN and HME distributions; max relative diff = 0).

## Changes

- **`Analysis/HistMergerFromHists.py`** — single-pass multi-source merge. New `fill_hists()` builds all target `(unc, scale)` keys and fills them in one traversal of each input file; new `alias_data_variations()` links the summed nominal data histogram under every varied `(unc, scale)` key (data has no per-source variations, but the bbtautau QCD estimation reads/clones data under those keys). Direct `RECREATE` of the final file with LZMA-9 compression, so no recompression `hadd` step is needed. `--user-custom` is now propagated so the merger subprocess sees the same config layering as the task.
- **`Analysis/tasks.py`** — `HistMergerTask.run` issues one merge call per branch with `--uncSources <comma list>`; the per-source subprocess loop and the `hadd_merged_hists.py` recombination are removed.
- **Producer scripts resolved via `_flaf_root()`** (which honours `FLAF_PATH`) instead of the pinned `ana_path()/FLAF` submodule, at the `HistMergerFromHists.py` call site and the two `AnaProd/tasks.py` producer call sites. Previously the `flaf_dev.sh` overlay silently never applied to any subprocess producer script.
- **`docs/reference/tasks.md`** — one-line `HistMergerTask` update (`mkdocs build --strict` clean).

## Bug fix included

The old per-source pass stored a single shared data histogram under both `(unc, Up)` and `(unc, Down)` keys and then double-added every data chunk after the first — corrupting the data templates fed to the HH_bbtautau QCD estimation whenever data had more than one merged chunk. The new `alias_data_variations()` aliases (never re-adds) the nominal sum, fixing this. Verified with a targeted unit check (old path produced 204 vs the correct 103).

## Parallel-safety fix (AnalysisCache / HistTuple producers)

The companion CI change runs the test jobs with `law run --workers 4`. That exposed a pre-existing latent bug: `AnalysisCacheProducer.py` and `HistTupleProducer.py` wrote their per-uncertainty temp files (`Events.root`, `<unc>.json`, …) with **bare relative names into the shared process CWD**, then `hadd`/merged them. Run serially this is fine, but with parallel workers the concurrent AnalysisCache/HistTuple branches clobber each other's `Events.root` → `hadd`/`FileNotFoundError` failures (seen in the H_mumu integration jobs, whose VBFNet AnalysisCache saves ROOT; HH_bbWW/bbtautau BtagShape/DeepHME save JSON and hit the same shared-CWD collision).

Fix: both producers now write their temp files under the per-branch `workingDir` (the unique `job_home` `mkdtemp`), so parallel branches never collide. This also stops the producers from leaving stray `Events.root`/`<unc>.json` files in the analysis repo root. The JSON merge key is now taken from `os.path.basename(...)` so it is unaffected by the absolute path.

## CLI hardening

`HistMergerFromHists.py --uncSources` now strips whitespace per entry and fails fast with a clear `ValueError` on unknown sources, instead of silently dropping a mistyped source and later raising a `KeyError` mid-merge (from a Copilot review comment).

## Testing

- CI-equivalent HH_bbWW Run3_2022 run from NanoAOD (TestModel, `--test 1000`, all 105 variables): old vs new merger output bit-identical across 27,720 histograms (max rel diff 0); ~9× per-branch speedup.
- Unit check of `fill_hists` MC keys (old vs new identical) and data aliasing (correct, and demonstrates the fixed double-Add defect).
- `mkdocs build --strict` passes.

Full HTCondor `run_ci_test.sh` gate across all affected analyses to follow once this is on a branch testable end-to-end (it needs the Rucio file discovery from #287, now on `main`).
