### PR TITLE
Fix #280: resolve compute_unc_histograms from the histTuple flavor

### DIFF
--- a/Analysis/tasks.py
+++ b/Analysis/tasks.py
@@ -422,7 +422,7 @@ class HistTupleProducerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
         compute_unc_histograms = (
             customisation_dict.get("compute_unc_histograms") == "True"
             if "compute_unc_histograms" in customisation_dict
-            else self.global_params.get("compute_unc_histograms", False)
+            else self.setup.compute_unc_histograms
         )
         job_home, remove_job_home = self.law_job_home()
         with contextlib.ExitStack() as stack:
@@ -657,7 +657,7 @@ class HistFromNtupleProducerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
         compute_unc_histograms = (
             customisation_dict["compute_unc_histograms"] == "True"
             if "compute_unc_histograms" in customisation_dict.keys()
-            else self.global_params.get("compute_unc_histograms", False)
+            else self.setup.compute_unc_histograms
         )
         HistFromNtupleProducer = os.path.join(
             self._flaf_root(), "Analysis", "HistProducerFromNTuple.py"
@@ -871,7 +871,7 @@ class HistMergerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
         compute_unc_histograms = (
             customisation_dict["compute_unc_histograms"] == "True"
             if "compute_unc_histograms" in customisation_dict.keys()
-            else self.global_params.get("compute_unc_histograms", False)
+            else self.setup.compute_unc_histograms
         )
         if compute_unc_histograms:
             for uncName in list(unc_cfg_dict["norm"].keys()) + list(
@@ -1405,7 +1405,11 @@ class HistPlotTask(Task, HTCondorWorkflow, law.LocalWorkflow):
         )
         # Same resolution as in HistMergerTask: it decides whether the merged file holds the
         # up/down variations that the full-uncertainty band and ratio panel are built from.
-        compute_unc_histograms = bool_flag("compute_unc_histograms", False)
+        compute_unc_histograms = (
+            customisation_dict["compute_unc_histograms"] == "True"
+            if "compute_unc_histograms" in customisation_dict
+            else self.setup.compute_unc_histograms
+        )
 
         with self.input().localize("r") as local_input:
             infile = local_input.abspath

--- a/Common/Setup.py
+++ b/Common/Setup.py
@@ -367,6 +367,17 @@ class Setup:
             self.histTuple_flavor
         ]["fullResolution_variables"]
 
+        # Whether up/down-variation histograms are produced. The histTuple flavor usually
+        # dictates this (uncertainties are only needed for the limit-setting shape variable),
+        # so read it from the flavor config first, falling back to the global/user_custom
+        # value for back-compatibility.
+        self.compute_unc_histograms = self.global_params["histTuple_flavors"][
+            self.histTuple_flavor
+        ].get(
+            "compute_unc_histograms",
+            self.global_params.get("compute_unc_histograms", False),
+        )
+
         # Safety check that the fullres or the plotvars do not have duplicates
         plotvar_dict = {}
         for var in self.histTuple_plot_vars:

--- a/docs/configuration/user-custom.md
+++ b/docs/configuration/user-custom.md
@@ -33,7 +33,7 @@ Replace `<initial>`/`<user>` with yours (e.g. `k` / `kandroso`). With just this,
 | `phys_model` | string | Which [physics model](processes-and-models.md) to run: `TestModel` (small, for testing/CI) or the analysis's production model (e.g. `BaseModel`). |
 | `analysis_config_area` | string | The analysis config directory, relative to the checkout — normally `config`. |
 | `compute_unc_variations` | bool | Whether to compute systematic (up/down) variations during production. |
-| `compute_unc_histograms` | bool | Whether to also fill histograms for those variations. |
+| `compute_unc_histograms` | bool | Whether to also fill histograms for those variations. Prefer setting this **per histTuple flavor** in `global.yaml` (`histTuple_flavors.<flavor>.compute_unc_histograms`) — uncertainties are usually only needed for the limit-setting shape flavor, so the flavor should dictate it. The value here (or in `global.yaml`) is used as the fallback when the active flavor does not set it. |
 | `store_noncentral` | bool | Whether to keep the non-central (systematic-shift) outputs, not just the central one. |
 | `variables` | list | Restrict which variables are produced/plotted. Omit for the full set. |
 


### PR DESCRIPTION
Fixes #280 — resolve `compute_unc_histograms` from the histTuple flavor.

The histTuple flavor usually dictates whether up/down-variation histograms are needed (uncertainties are only required for the limit-setting shape variable), yet `compute_unc_histograms` lived only in `user_custom.yaml`/`global.yaml`, which is easy to forget or mis-set.

`Setup` now resolves `compute_unc_histograms` from the active flavor config (`histTuple_flavors[<flavor>].compute_unc_histograms`), falling back to the global/user_custom value when the flavor does not set it. All read sites (HistTuple / HistFromNtuple / HistMerger / HistPlot) use `self.setup.compute_unc_histograms` as the fallback under the existing per-invocation `customisation` override.

Back-compatible: existing configs (global-level key) keep working; analyses can now move the key into their `histTuple_flavors` entries so the flavor dictates it.

Testing: Setup loads for Run3_2022/2022EE; `setup.compute_unc_histograms` resolves.