### PR TITLE
Fix #214: PreHistTupleProductionTask (run all AnaTuple/AnalysisCache in one command)

### DIFF
--- a/Analysis/tasks.py
+++ b/Analysis/tasks.py
@@ -1668,14 +1668,14 @@ class AnalysisCacheAggregationTask(Task, HTCondorWorkflow, law.LocalWorkflow):
                 shutil.rmtree(job_home)
 
 
-class ProductionTask(HistTupleProducerTask):
+class PreHistTupleProductionTask(HistTupleProducerTask):
     """Force the full AnaTuple + AnalysisCache production for a version without producing
     HistTuples (issue #214).
 
     Reuses HistTupleProducerTask's dependency graph (AnaTupleMerge + AnalysisCache +
     aggregation) but replaces the per-branch histTuple output with a small completion
-    marker, so a single ``law run ProductionTask --version ... --period ...`` runs the
-    entire AnaTuple/AnalysisCache subset (e.g. to freeze and share the caches, as
+    marker, so a single ``law run PreHistTupleProductionTask --version ... --period ...``
+    runs the entire AnaTuple/AnalysisCache subset (e.g. to freeze and share the caches, as
     AnaTupleMergeTask outputs already can be)."""
 
     @HistTupleProducerTask.workflow_condition.output
@@ -1686,7 +1686,7 @@ class ProductionTask(HistTupleProducerTask):
         input = _anaTuple_outputs(self)[prod_br][input_index]
         output_path = os.path.join(
             self.version,
-            "Production",
+            "PreHistTupleProduction",
             self.period,
             dataset_name,
             os.path.basename(input.abspath) + ".done",

--- a/Analysis/tasks.py
+++ b/Analysis/tasks.py
@@ -1678,7 +1678,14 @@ class PreHistTupleProductionTask(HistTupleProducerTask):
     runs the entire AnaTuple/AnalysisCache subset (e.g. to freeze and share the caches, as
     AnaTupleMergeTask outputs already can be)."""
 
-    @HistTupleProducerTask.workflow_condition.output
+    # Own copy of the parent's dynamic workflow condition. Decorating ``.output`` below mutates
+    # the condition instance (sets its ``_output_fn``); reusing HistTupleProducerTask's shared
+    # instance would rebind every HistTupleProducerTask branch to this ``.done`` marker and break
+    # real histTuple production. The copy keeps the inherited create_branch_map/requires; only the
+    # output differs.
+    workflow_condition = HistTupleProducerTask.workflow_condition.copy()
+
+    @workflow_condition.output
     def output(self):
         dataset_name, prod_br, producer_list, aggregate_list, input_index = (
             self.branch_data

--- a/Analysis/tasks.py
+++ b/Analysis/tasks.py
@@ -1680,7 +1680,9 @@ class ProductionTask(HistTupleProducerTask):
 
     @HistTupleProducerTask.workflow_condition.output
     def output(self):
-        dataset_name, prod_br, producer_list, aggregate_list, input_index = self.branch_data
+        dataset_name, prod_br, producer_list, aggregate_list, input_index = (
+            self.branch_data
+        )
         input = _anaTuple_outputs(self)[prod_br][input_index]
         output_path = os.path.join(
             self.version,

--- a/Analysis/tasks.py
+++ b/Analysis/tasks.py
@@ -1666,3 +1666,34 @@ class AnalysisCacheAggregationTask(Task, HTCondorWorkflow, law.LocalWorkflow):
             )
             if remove_job_home:
                 shutil.rmtree(job_home)
+
+
+class ProductionTask(HistTupleProducerTask):
+    """Force the full AnaTuple + AnalysisCache production for a version without producing
+    HistTuples (issue #214).
+
+    Reuses HistTupleProducerTask's dependency graph (AnaTupleMerge + AnalysisCache +
+    aggregation) but replaces the per-branch histTuple output with a small completion
+    marker, so a single ``law run ProductionTask --version ... --period ...`` runs the
+    entire AnaTuple/AnalysisCache subset (e.g. to freeze and share the caches, as
+    AnaTupleMergeTask outputs already can be)."""
+
+    @HistTupleProducerTask.workflow_condition.output
+    def output(self):
+        dataset_name, prod_br, producer_list, aggregate_list, input_index = self.branch_data
+        input = _anaTuple_outputs(self)[prod_br][input_index]
+        output_path = os.path.join(
+            self.version,
+            "Production",
+            self.period,
+            dataset_name,
+            os.path.basename(input.abspath) + ".done",
+        )
+        return self.remote_target(output_path, fs=self.fs_HistTuple)
+
+    def run(self):
+        # requires() has forced the AnaTuple + AnalysisCache upstream to complete; only a
+        # marker is written so the branch counts as done (no histTuple is produced).
+        with self.output().localize("w") as out:
+            with open(out.abspath, "w") as f:
+                f.write("production dependencies complete\n")

--- a/docs/reference/tasks.md
+++ b/docs/reference/tasks.md
@@ -68,13 +68,13 @@ consume.
 
 - **Parameter:** `--producer-to-aggregate`.
 
-### `ProductionTask`
+### `PreHistTupleProductionTask`
 Runs the **entire AnaTuple + AnalysisCache production** for a version in one command, without
 producing histTuples. It shares `HistTupleProducerTask`'s dependency graph but writes only a small
 per-branch completion marker, so a single
 
 ```sh
-law run FLAF.Analysis.tasks.ProductionTask --version <v> --period <era> --workflow local
+law run FLAF.Analysis.tasks.PreHistTupleProductionTask --version <v> --period <era> --workflow local
 ```
 
 forces every `AnaTupleMergeTask` and `AnalysisCacheTask` (plus their aggregation) to run — handy

--- a/docs/reference/tasks.md
+++ b/docs/reference/tasks.md
@@ -68,6 +68,19 @@ consume.
 
 - **Parameter:** `--producer-to-aggregate`.
 
+### `ProductionTask`
+Runs the **entire AnaTuple + AnalysisCache production** for a version in one command, without
+producing histTuples. It shares `HistTupleProducerTask`'s dependency graph but writes only a small
+per-branch completion marker, so a single
+
+```sh
+law run FLAF.Analysis.tasks.ProductionTask --version <v> --period <era> --workflow local
+```
+
+forces every `AnaTupleMergeTask` and `AnalysisCacheTask` (plus their aggregation) to run — handy
+to pre-compute and then freeze/share those caches (as `AnaTupleMergeTask` outputs already can be),
+instead of submitting each `AnalysisCacheTask --producer-to-run` individually.
+
 ### `HistPlotTask`
 Produces the final **plots** via the [PlotKit](https://github.com/cms-flaf/PlotKit) submodule
 (matplotlib + mplhep by default; optional ROOT + cmsstyle). **Branches over variables** (one branch


### PR DESCRIPTION
Fixes #214 — one command to run the full AnaTuple + AnalysisCache production.

Adds `PreHistTupleProductionTask`, a thin subclass of `HistTupleProducerTask` that **reuses its entire dependency graph** (AnaTupleMerge + per-producer AnalysisCache + AnalysisCacheAggregation) but replaces the per-branch histTuple output with a small `.done` marker and a no-op `run()`. A single

```sh
law run FLAF.Analysis.tasks.PreHistTupleProductionTask --version <v> --period <era>
```

therefore forces the whole AnaTuple/AnalysisCache subset to run — so those caches can be frozen and shared (as AnaTupleMerge outputs already can be) — without producing histTuples. The name reflects that the task stops just before the histTuple stage.

Existing tasks and anaTuple content are unchanged; the addition is purely additive.

## Testing

Central integration CI does not cover this task, so a CI-like local run was performed with this task as the target (HH_bbWW, `TestModel`, `--test 1000`, local storage; run under plain `env.sh` with the branch checked out in the analysis submodule so the RDataFrame producers JIT normally):

- From scratch, the task cascades the full upstream — `InputFileTask → AnaTupleFileTask → AnaTupleFileListTask → AnaTupleMergeTask → AnalysisCacheTask` (both cache producers) — with no failed tasks and no cling/JIT errors.
- `AnalysisCacheAggregationTask` is resolved and the per-branch `.done` marker is written under `<version>/PreHistTupleProduction/<era>/<dataset>/…`, after which the task reports **complete** (`--print-status`: `existent (1/1)`).

## Docs

`docs/reference/tasks.md` documents the task (`PreHistTupleProductionTask` section).
