### PR TITLE
Fix #229: removable intermediate split histograms (adaptable graph + opt-in cleanup)

### DIFF
--- a/Analysis/tasks.py
+++ b/Analysis/tasks.py
@@ -499,6 +499,15 @@ class HistTupleProducerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
             shutil.rmtree(job_home)
 
 
+def _split_merged_marker(split_target):
+    # The per-chunk ``.merged`` marker written next to a HistFromNtupleProducer split histogram
+    # when HistMergerTask removes it after merging (issue #229). Placed beside the split so it is
+    # chunk-specific: a branch whose split was never produced (new dataset, changed
+    # n_files_per_job) has no marker. HistFromNtupleProducerTask.complete() and HistMergerTask.run()
+    # both derive it from the same split target, so the paths always agree.
+    return split_target.sibling(split_target.basename + ".merged", type="f")
+
+
 class HistFromNtupleProducerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
     max_runtime = copy_param(HTCondorWorkflow.max_runtime, 10.0)
     n_cpus = copy_param(HTCondorWorkflow.n_cpus, 2)
@@ -640,37 +649,19 @@ class HistFromNtupleProducerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
             outputs[var_name] = self.remote_target(output_path, fs=self.fs_HistTuple)
         return outputs
 
-    # (version, period, var) -> True once the merged output has been seen (it does not vanish).
-    _merged_present_cache = {}
-
-    def _merged_output_present(self, var_name):
-        key = (self.version, self.period, var_name)
-        if HistFromNtupleProducerTask._merged_present_cache.get(key):
-            return True
-        # Mirrors HistMergerTask.output(): Hists_merged/<period>/<var>/<var>.root
-        merged = self.remote_target(
-            os.path.join(
-                self.version, "Hists_merged", self.period, var_name, f"{var_name}.root"
-            ),
-            fs=self.fs_HistTuple,
-        )
-        if merged.exists():
-            HistFromNtupleProducerTask._merged_present_cache[key] = True
-            return True
-        return False
-
     def complete(self):
-        # Per-chunk split histograms are only needed until their variable is merged
-        # downstream; HistMergerTask can remove each variable's per-chunk inputs after
-        # merging (issue #229, to save space). Treat a branch as complete when, for every
-        # variable, the per-chunk output still exists OR the merged output is already
-        # present -- so removing the intermediates keeps the task graph consistent (law will
-        # not try to re-run this task). Only additive vs the default: never reports a task
-        # incomplete that the default would call complete.
+        # Per-chunk split histograms are only needed until their variable is merged downstream;
+        # HistMergerTask can remove each variable's per-chunk split after merging (issue #229) and
+        # leaves a small ``.merged`` marker next to it. Treat a branch as complete when, for every
+        # variable, the split still exists OR its per-chunk marker is present -- so removing the
+        # intermediates keeps the task graph consistent (law will not re-run this task). The marker
+        # is chunk-specific, so a branch whose split was never produced (e.g. a new dataset or a
+        # changed n_files_per_job, which shift the branch map) has no marker and is still correctly
+        # reported incomplete instead of being masked by an unrelated variable's merged output.
         if not self.is_branch():
             return super().complete()
         for var_name, target in self.output().items():
-            if not target.exists() and not self._merged_output_present(var_name):
+            if not target.exists() and not _split_merged_marker(target).exists():
                 return False
         return True
 
@@ -975,15 +966,20 @@ class HistMergerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
                 MergerProducer_cmd.extend(local_inputs)
                 ps_call(MergerProducer_cmd, verbose=1)
 
-        # The merged output is now written; the per-chunk split inputs for this variable are
-        # no longer needed. Remove them to save space when enabled (issue #229) --
-        # HistFromNtupleProducerTask stays complete via its merged-output check, so the graph
-        # remains consistent. Opt-in (default off) to preserve the current keep-intermediates
-        # behaviour.
+        # The merged output is now written; the per-chunk split inputs for this variable are no
+        # longer needed. When enabled (issue #229), remove them to save space, leaving a small
+        # per-chunk ``.merged`` marker in place of each so HistFromNtupleProducerTask stays
+        # complete for exactly the chunks that were merged -- the graph remains consistent and a
+        # later-added chunk (no marker) is still produced. Opt-in (default off) to preserve the
+        # current keep-intermediates behaviour. The marker is written before the split is removed
+        # so a failure never leaves a chunk both gone and unmarked.
         if self.global_params.get("remove_merged_inputs", False):
             for inp in self.input():
+                split = inp[var_name]
                 try:
-                    inp[var_name].remove()
+                    with _split_merged_marker(split).localize("w") as marker:
+                        open(marker.abspath, "w").close()
+                    split.remove()
                 except Exception as e:
                     print(
                         f"HistMergerTask: could not remove merged input for {var_name}: {e}"

--- a/Analysis/tasks.py
+++ b/Analysis/tasks.py
@@ -640,6 +640,40 @@ class HistFromNtupleProducerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
             outputs[var_name] = self.remote_target(output_path, fs=self.fs_HistTuple)
         return outputs
 
+    # (version, period, var) -> True once the merged output has been seen (it does not vanish).
+    _merged_present_cache = {}
+
+    def _merged_output_present(self, var_name):
+        key = (self.version, self.period, var_name)
+        if HistFromNtupleProducerTask._merged_present_cache.get(key):
+            return True
+        # Mirrors HistMergerTask.output(): Hists_merged/<period>/<var>/<var>.root
+        merged = self.remote_target(
+            os.path.join(
+                self.version, "Hists_merged", self.period, var_name, f"{var_name}.root"
+            ),
+            fs=self.fs_HistTuple,
+        )
+        if merged.exists():
+            HistFromNtupleProducerTask._merged_present_cache[key] = True
+            return True
+        return False
+
+    def complete(self):
+        # Per-chunk split histograms are only needed until their variable is merged
+        # downstream; HistMergerTask can remove each variable's per-chunk inputs after
+        # merging (issue #229, to save space). Treat a branch as complete when, for every
+        # variable, the per-chunk output still exists OR the merged output is already
+        # present -- so removing the intermediates keeps the task graph consistent (law will
+        # not try to re-run this task). Only additive vs the default: never reports a task
+        # incomplete that the default would call complete.
+        if not self.is_branch():
+            return super().complete()
+        for var_name, target in self.output().items():
+            if not target.exists() and not self._merged_output_present(var_name):
+                return False
+        return True
+
     def run(self):
         dataset_name, prod_br_list, chunk_id = self.branch_data
         var_names = [
@@ -940,6 +974,20 @@ class HistMergerTask(Task, HTCondorWorkflow, law.LocalWorkflow):
                     MergerProducer_cmd.extend(["--user-custom", self.user_custom])
                 MergerProducer_cmd.extend(local_inputs)
                 ps_call(MergerProducer_cmd, verbose=1)
+
+        # The merged output is now written; the per-chunk split inputs for this variable are
+        # no longer needed. Remove them to save space when enabled (issue #229) --
+        # HistFromNtupleProducerTask stays complete via its merged-output check, so the graph
+        # remains consistent. Opt-in (default off) to preserve the current keep-intermediates
+        # behaviour.
+        if self.global_params.get("remove_merged_inputs", False):
+            for inp in self.input():
+                try:
+                    inp[var_name].remove()
+                except Exception as e:
+                    print(
+                        f"HistMergerTask: could not remove merged input for {var_name}: {e}"
+                    )
 
 
 class AnalysisCacheTask(Task, HTCondorWorkflow, law.LocalWorkflow):

--- a/docs/concepts/data-flow.md
+++ b/docs/concepts/data-flow.md
@@ -45,6 +45,13 @@ flowchart TD
     b-tag shape weights) before histogramming. They are part of the same graph and run
     automatically when required. See the [Task reference](../reference/tasks.md).
 
+!!! tip "Freeing space: removable intermediates"
+    The per-chunk split histograms `HistFromNtupleProducerTask` writes are only needed until they
+    are merged. Set `remove_merged_inputs: true` (see
+    [user_custom](../configuration/user-custom.md)) to have `HistMergerTask` delete them after
+    merging — the producer still reports **complete** because it detects the merged output, so the
+    task graph stays consistent and nothing re-runs.
+
 ## Where the outputs live
 
 Each output type is written to a **named filesystem** (`fs_*`) that you configure — typically

--- a/docs/concepts/data-flow.md
+++ b/docs/concepts/data-flow.md
@@ -48,9 +48,12 @@ flowchart TD
 !!! tip "Freeing space: removable intermediates"
     The per-chunk split histograms `HistFromNtupleProducerTask` writes are only needed until they
     are merged. Set `remove_merged_inputs: true` (see
-    [user_custom](../configuration/user-custom.md)) to have `HistMergerTask` delete them after
-    merging — the producer still reports **complete** because it detects the merged output, so the
-    task graph stays consistent and nothing re-runs.
+    [user_custom](../configuration/user-custom.md)) to have `HistMergerTask` delete each split
+    after merging and drop a tiny per-chunk `.merged` marker next to it. The producer still reports
+    **complete** for exactly the chunks that were merged (it finds the split *or* its marker), so
+    the task graph stays consistent and nothing re-runs — while a chunk that was never produced
+    (e.g. after adding a dataset or changing `n_files_per_job`) has no marker and is still produced
+    normally.
 
 ## Where the outputs live
 

--- a/docs/configuration/user-custom.md
+++ b/docs/configuration/user-custom.md
@@ -35,7 +35,7 @@ Replace `<initial>`/`<user>` with yours (e.g. `k` / `kandroso`). With just this,
 | `compute_unc_variations` | bool | Whether to compute systematic (up/down) variations during production. |
 | `compute_unc_histograms` | bool | Whether to also fill histograms for those variations. |
 | `store_noncentral` | bool | Whether to keep the non-central (systematic-shift) outputs, not just the central one. |
-| `remove_merged_inputs` | bool | If `true`, `HistMergerTask` deletes each variable's per-chunk split histograms (`HistFromNtupleProducerTask` outputs) after merging, to save space. Safe: the producer stays "complete" because it detects the merged output, so the task graph stays consistent (no re-run). Default `false` — intermediates are kept. |
+| `remove_merged_inputs` | bool | If `true`, `HistMergerTask` deletes each variable's per-chunk split histograms (`HistFromNtupleProducerTask` outputs) after merging, to save space, leaving a tiny per-chunk `.merged` marker in place of each. Safe: the producer stays "complete" for exactly the chunks that were merged (it finds the split *or* its marker), so the task graph stays consistent (no re-run); a chunk that was never produced has no marker and is still produced. Default `false` — intermediates are kept. |
 | `variables` | list | Restrict which variables are produced/plotted. Omit for the full set. |
 
 !!! tip "`TestModel` is the fast path"

--- a/docs/configuration/user-custom.md
+++ b/docs/configuration/user-custom.md
@@ -35,6 +35,7 @@ Replace `<initial>`/`<user>` with yours (e.g. `k` / `kandroso`). With just this,
 | `compute_unc_variations` | bool | Whether to compute systematic (up/down) variations during production. |
 | `compute_unc_histograms` | bool | Whether to also fill histograms for those variations. |
 | `store_noncentral` | bool | Whether to keep the non-central (systematic-shift) outputs, not just the central one. |
+| `remove_merged_inputs` | bool | If `true`, `HistMergerTask` deletes each variable's per-chunk split histograms (`HistFromNtupleProducerTask` outputs) after merging, to save space. Safe: the producer stays "complete" because it detects the merged output, so the task graph stays consistent (no re-run). Default `false` — intermediates are kept. |
 | `variables` | list | Restrict which variables are produced/plotted. Omit for the full set. |
 
 !!! tip "`TestModel` is the fast path"


### PR DESCRIPTION
Fixes #229 — the per-chunk split histograms (`HistFromNtupleProducerTask` outputs) are redundant once merged; this makes them removable to save space without breaking the task graph.

## Changes
- `HistMergerTask.run()`: when the opt-in `remove_merged_inputs` global param is set (default `False`), each variable's per-chunk split input is removed after the merged output is written, and a tiny per-chunk `.merged` marker is left beside it.
- `HistFromNtupleProducerTask.complete()`: a branch is complete when, for every variable, the split still exists **or** its per-chunk `.merged` marker is present. The marker sits at the split's own path (variable/dataset/chunk), so completeness is **chunk-specific**.
- Docs updated (`configuration/user-custom.md`, `concepts/data-flow.md`).

## Why chunk-specific markers
An earlier revision keyed completeness on the per-variable merged output, which review flagged as unsafe: a branch whose split was never produced (a new dataset, or a changed `n_files_per_job` that shifts the branch map) would be masked complete by an unrelated merged output and its data silently omitted, and a process-lifetime cache could report a deleted merged file present. The per-chunk marker fixes both — a never-produced chunk has no marker and is still produced, and existence is checked live (no cache).

## Testing
- Marker mechanism validated on real remote storage: sibling-path derivation, `localize("w")` marker write, and `exists()`; after merging+removing a chunk A, A reports complete (not re-run) while a never-produced chunk B still reports incomplete (produced).
- `mkdocs build --strict` passes.

Back-compatible: default `False` keeps the current keep-intermediates behaviour; existing anaTuples/histTuples are unaffected.
