### PR TITLE
Fix: AnaTupleFileTask runs locally instead of submitting to HTCondor (workflow leak via AnaTupleFileListTask)

### DIFF
--- a/AnaProd/tasks.py
+++ b/AnaProd/tasks.py
@@ -497,19 +497,34 @@ class AnaTupleFileListBuilderTask(Task, HTCondorWorkflow, law.LocalWorkflow):
 
 class AnaTupleFileListTask(AnaTupleFileListBuilderTask):
     bundle_flavours = []
+    # This task only copies the Builder's plan into a local_target, so it is forced to run locally
+    # (its output must land on the shared FS, not an ephemeral HTCondor worker). Forcing
+    # workflow="local" would otherwise leak through req() into the upstream Builder and the heavy
+    # AnaTupleFileTask, making production run locally too. This carrier parameter remembers the
+    # originally requested workflow and is forwarded to the Builder, so Builder and AnaTupleFileTask
+    # run on the requested workflow while this task stays local. It is a parameter (not an attribute)
+    # so it survives req_branch and is identical for the workflow and all its branches, keeping
+    # workflow_requires() and requires() consistent; insignificant so it never affects the task id.
+    upstream_workflow = luigi.Parameter(default=law.NO_STR, significant=False)
 
     def __init__(self, *args, **kwargs):
         ana_v = kwargs.get("ana_version") or kwargs.get("anaTuple_version")
         if ana_v:
             kwargs["version"] = ana_v
+        if kwargs.get("upstream_workflow", law.NO_STR) in (law.NO_STR, None):
+            kwargs["upstream_workflow"] = kwargs.get("workflow") or law.NO_STR
         kwargs["workflow"] = "local"
         super(AnaTupleFileListTask, self).__init__(*args, **kwargs)
 
     def workflow_requires(self):
-        return {"AnaTupleFileListBuilderTask": AnaTupleFileListBuilderTask.req(self)}
+        return {
+            "AnaTupleFileListBuilderTask": AnaTupleFileListBuilderTask.req(
+                self, workflow=self.upstream_workflow
+            )
+        }
 
     def requires(self):
-        return AnaTupleFileListBuilderTask.req(self)
+        return AnaTupleFileListBuilderTask.req(self, workflow=self.upstream_workflow)
 
     def output(self):
         dataset_name, process_group = self.branch_data


### PR DESCRIPTION
## Summary

When production is launched via `AnaTupleMergeTask --workflow htcondor` (e.g.
`law run FLAF.AnaProd.tasks.AnaTupleMergeTask --version <v> --period <era> --workflow htcondor`),
the heavy per-file production task **`AnaTupleFileTask` runs locally instead of being submitted to
HTCondor**.

## Root cause

`AnaTupleFileListTask` deliberately forces `workflow="local"` in its `__init__` — it must run
locally because its output is a `local_target` that has to land on the shared filesystem, not an
ephemeral HTCondor worker. However, `law` copies the `workflow` parameter through `req()` (only
`effective_workflow` is in `exclude_params_req`), so the forced `"local"` leaks down the dependency
chain:

```
AnaTupleMergeTask (--workflow htcondor)
  └─ AnaTupleFileListTask        forces local            (correct)
       └─ AnaTupleFileListBuilderTask   inherits local   (wrong)
            └─ AnaTupleFileTask         inherits local   (wrong — production runs locally)
```

Confirmed with an isolated `law` reproduction: with `--workflow htcondor`, `AnaTupleFileTask`
resolves to `effective_workflow == "local"`.

## Fix

`AnaTupleFileListTask` now records the originally-requested workflow on an **insignificant carrier
parameter** (`upstream_workflow`) and forwards it to the Builder, while still forcing *itself*
local. The Builder writes to remote targets, so it (and `AnaTupleFileTask`) run on the requested
workflow. Using a parameter (rather than an instance attribute) is required so the value survives
`req_branch` and is identical for the workflow and all of its branches — keeping `workflow_requires()`
and `requires()` consistent (an attribute made the branch `requires()` path resolve to `local` while
`workflow_requires()` was `htcondor`).

| requested `--workflow` | AnaTupleFileListTask | Builder | AnaTupleFileTask |
|---|---|---|---|
| `htcondor` | local | htcondor | **htcondor** |
| `local` | local | local | local |

## Testing

- Isolated `law` unit reproduction of the exact task pattern (workflow instance **and** branch
  instance, for both `htcondor` and `local`): all consistent and correct.
- HTCondor end-to-end validation on the FLAF analyses (`run_ci_test.sh` htcondor + a targeted
  `AnaTupleMergeTask --workflow htcondor` submission check confirming `AnaTupleFileTask` is
  submitted) — see PR checks / bot run.

## Docs

No docs change: internal task-graph bugfix restoring the expected HTCondor submission behavior; no
task names, arguments, or config fields change.
