### PR TITLE
Add GitHub Actions integration test workflow and bot backend support

### DIFF
--- a/.github/scripts/ci/common.sh
+++ b/.github/scripts/ci/common.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+
+require_var() {
+  local var_name=$1
+  if [[ -z ${!var_name:-} ]]; then
+    echo "Required variable '${var_name}' is not set." >&2
+    exit 1
+  fi
+}
+
+retry() {
+  local max_attempts=$1
+  local delay=$2
+  shift 2
+  local attempt=1
+  local rc
+  while true; do
+    rc=0
+    "$@" || rc=$?
+    if ((rc == 0)); then
+      return 0
+    fi
+    if ((attempt >= max_attempts)); then
+      echo "retry: '$*' still failing (exit ${rc}) after ${attempt} attempts; giving up." >&2
+      return "${rc}"
+    fi
+    echo "retry: '$*' failed (exit ${rc}); attempt ${attempt}/${max_attempts}, retrying in ${delay}s..." >&2
+    sleep "${delay}"
+    attempt=$((attempt + 1))
+    delay=$((delay * 2))
+  done
+}
+
+init_env() {
+  export LC_ALL=C
+}
+
+init_ssh() {
+  if [[ -z ${SSH_PRIVATE_KEY:-} ]]; then
+    echo "SSH_PRIVATE_KEY not set. Relying on public HTTPS git access."
+    git config --global url."https://github.com/".insteadOf "git@github.com:"
+    return 0
+  fi
+
+  mkdir -p "${HOME}/.ssh"
+  chmod 700 "${HOME}/.ssh"
+  printf '%s' "${SSH_PRIVATE_KEY}" | base64 -d > "${HOME}/.ssh/id_ed25519" 2>/dev/null || printf '%s' "${SSH_PRIVATE_KEY}" > "${HOME}/.ssh/id_ed25519"
+  chmod 400 "${HOME}/.ssh/id_ed25519"
+  retry 3 3 _scan_known_hosts
+  git config --global user.email "cms-flaf@proton.me"
+  git config --global user.name "CMS FLAF Integration Bot"
+  git config --global fetch.recurseSubmodules no
+}
+
+_scan_known_hosts() {
+  ssh-keyscan github.com > "${HOME}/.ssh/known_hosts" 2>/dev/null \
+    && ssh-keyscan -p 7999 gitlab.cern.ch >> "${HOME}/.ssh/known_hosts" 2>/dev/null || true
+}
+
+init_voms() {
+  if [[ -z ${GRID_USERCERT:-} || -z ${GRID_USERKEY:-} || -z ${GRID_PASSWORD:-} ]]; then
+    echo "Grid certificate secrets not fully provided. Skipping VOMS proxy initialization."
+    return 0
+  fi
+
+  export X509_VOMS_DIR=/cvmfs/grid.cern.ch/etc/grid-security/vomsdir/
+  export VOMS_USERCONF=/cvmfs/grid.cern.ch/etc/grid-security/vomses/
+  export X509_CERT_DIR=/cvmfs/grid.cern.ch/etc/grid-security/certificates/
+  mkdir -p "${HOME}/.globus"
+  chmod 700 "${HOME}/.globus"
+  printf '%s' "${GRID_USERCERT}" | base64 -d > "${HOME}/.globus/usercert.pem" 2>/dev/null || printf '%s' "${GRID_USERCERT}" > "${HOME}/.globus/usercert.pem"
+  printf '%s' "${GRID_USERKEY}" | base64 -d > "${HOME}/.globus/userkey.pem" 2>/dev/null || printf '%s' "${GRID_USERKEY}" > "${HOME}/.globus/userkey.pem"
+  chmod 400 "${HOME}/.globus/usercert.pem"
+  chmod 400 "${HOME}/.globus/userkey.pem"
+
+  export X509_USER_PROXY="${X509_USER_PROXY:-/tmp/x509up_u$(id -u)_${GITHUB_RUN_ID:-$$}}"
+  retry 3 5 _create_voms_proxy
+  voms-proxy-info --all || true
+}
+
+_create_voms_proxy() {
+  local pw
+  pw=$(printf '%s' "${GRID_PASSWORD}" | base64 -d 2>/dev/null || printf '%s' "${GRID_PASSWORD}")
+  printf '%s' "${pw}" \
+    | voms-proxy-init -voms cms -rfc -valid 192:00 -pwstdin -out "${X509_USER_PROXY}" \
+        -cert "${HOME}/.globus/usercert.pem" -key "${HOME}/.globus/userkey.pem" \
+    && voms-proxy-info -exists -valid 1:00 -file "${X509_USER_PROXY}"
+}
+
+GFAL_LCG_SETUP="${GFAL_LCG_SETUP:-/cvmfs/sft.cern.ch/lcg/views/LCG_108a/x86_64-el9-gcc15-opt/setup.sh}"
+
+init_gfal() {
+  if ! command -v gfal-copy >/dev/null 2>&1; then
+    if [[ -f ${GFAL_LCG_SETUP} ]]; then
+      local had_nounset=0
+      if [[ $- == *u* ]]; then
+        had_nounset=1
+        set +u
+      fi
+      # shellcheck disable=SC1090
+      source "${GFAL_LCG_SETUP}"
+      if [[ ${had_nounset} -eq 1 ]]; then
+        set -u
+      fi
+    fi
+  fi
+}
+
+source_analysis_env() {
+  local had_nounset=0
+  if [[ $- == *u* ]]; then
+    had_nounset=1
+    set +u
+  fi
+
+  source env.sh
+
+  if [[ ${had_nounset} -eq 1 ]]; then
+    set -u
+  fi
+}
+
+sync_and_update_submodules() {
+  local recurse=${1:-}
+
+  git submodule init
+  git submodule sync
+  while read -r key url; do
+    [[ -z ${key} ]] && continue
+    local name=${key#submodule.}
+    name=${name%.url}
+    local gitdir
+    gitdir=$(git rev-parse --git-path "modules/${name}")
+    if [[ -d ${gitdir} ]]; then
+      git --git-dir="${gitdir}" remote set-url origin "${url}" 2>/dev/null || true
+    fi
+  done < <(git config -f .gitmodules --get-regexp '^submodule\..*\.url$' 2>/dev/null || true)
+  git submodule update --init
+
+  if [[ ${recurse} == "--recursive" ]]; then
+    local sub_path
+    while read -r sub_path; do
+      [[ -n ${sub_path} && -e ${sub_path}/.git ]] || continue
+      ( cd "${sub_path}" && sync_and_update_submodules --recursive )
+    done < <(git config -f .gitmodules --get-regexp '^submodule\..*\.path$' 2>/dev/null | awk '{print $2}')
+  fi
+}
+
+switch_current_repo() {
+  local version=$1
+
+  if [[ ${version} == "default" ]]; then
+    return 0
+  fi
+
+  if [[ ${version:0:3} == "PR_" ]]; then
+    git fetch --no-recurse-submodules origin "pull/${version:3}/head:${version}"
+    git submodule deinit -f --all 2>/dev/null || true
+    git merge "${version}"
+    sync_and_update_submodules --recursive
+    return 0
+  fi
+
+  if [[ $(git rev-parse --abbrev-ref HEAD) == "${version}" ]]; then
+    git pull --no-recurse-submodules origin "${version}"
+  else
+    git fetch --no-recurse-submodules origin "${version}:${version}"
+    git switch "${version}"
+  fi
+}
+
+switch_root_repo() {
+  local version=$1
+  switch_current_repo "${version}"
+  sync_and_update_submodules --recursive
+}
+
+switch_submodule_repo() {
+  local submodule_name=$1
+  local version=$2
+
+  if [[ ! -d ${submodule_name} ]]; then
+    echo "Submodule ${submodule_name} not found. Skipping."
+    return 0
+  fi
+
+  if [[ ${version} == "default" ]]; then
+    return 0
+  fi
+
+  (
+    cd "${submodule_name}"
+    switch_current_repo "${version}"
+    sync_and_update_submodules
+  )
+}

--- a/.github/scripts/ci/run_gha_integration.sh
+++ b/.github/scripts/ci/run_gha_integration.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=.github/scripts/ci/common.sh
+source "${SCRIPT_DIR}/common.sh"
+
+require_var ANALYSIS_NAME
+
+ANALYSIS_VERSION="${ANALYSIS_VERSION:-main}"
+FLAF_version="${FLAF_version:-default}"
+PlotKit_version="${PlotKit_version:-default}"
+Corrections_version="${Corrections_version:-default}"
+StatInference_version="${StatInference_version:-default}"
+ERAS="${ERAS:-Run3_2022EE}"
+PROCESSES="${PROCESSES:-}"
+ANALYSIS_TASK="${ANALYSIS_TASK:-FLAF.Analysis.tasks.HistPlotTask}"
+ANALYSIS_ARGS="${ANALYSIS_ARGS:---test 1000}"
+GITHUB_NOTIFY_URL="${GITHUB_NOTIFY_URL:-}"
+FLAF_GITHUB_TOKEN="${FLAF_GITHUB_TOKEN:-}"
+
+post_github_notification() {
+  local status_text=$1
+  if [[ -n "${GITHUB_NOTIFY_URL}" && -n "${FLAF_GITHUB_TOKEN}" ]]; then
+    local run_url="https://github.com/cms-flaf/FLAF/actions/runs/${GITHUB_RUN_ID:-}"
+    local msg
+    if [[ "${status_text}" == "success" ]]; then
+      msg="✅ [GitHub Actions CI Run](${run_url}) passed for **${ANALYSIS_NAME}** (${ANALYSIS_VERSION})."
+    else
+      msg="❌ [GitHub Actions CI Run](${run_url}) failed for **${ANALYSIS_NAME}** (${ANALYSIS_VERSION})."
+    fi
+    curl -s -X POST \
+      -H "Accept: application/vnd.github+json" \
+      -H "Authorization: Bearer ${FLAF_GITHUB_TOKEN}" \
+      -H "X-GitHub-Api-Version: 2022-11-28" \
+      "${GITHUB_NOTIFY_URL}" \
+      -d "{\"body\": \"${msg}\"}" || true
+  fi
+}
+
+trap_handler() {
+  local exit_code=$?
+  if [[ ${exit_code} -ne 0 ]]; then
+    echo "=== Integration Test Failed with exit code ${exit_code} ==="
+    post_github_notification "failure"
+  fi
+  exit "${exit_code}"
+}
+trap trap_handler EXIT
+
+echo "=== Starting FLAF GitHub Actions Integration Test ==="
+echo "Analysis: ${ANALYSIS_NAME} (${ANALYSIS_VERSION})"
+echo "FLAF: ${FLAF_version}, PlotKit: ${PlotKit_version}, Corrections: ${Corrections_version}, StatInference: ${StatInference_version}"
+echo "Eras: ${ERAS}"
+echo "Processes: ${PROCESSES}"
+echo "Task: ${ANALYSIS_TASK} ${ANALYSIS_ARGS}"
+
+init_env
+init_ssh
+init_voms
+init_gfal
+
+WORK_DIR="/tmp/flaf_run_${GITHUB_RUN_ID:-$$}"
+mkdir -p "${WORK_DIR}"
+cd "${WORK_DIR}"
+
+echo "Cloning ${ANALYSIS_NAME}..."
+retry 3 5 git clone "https://github.com/cms-flaf/${ANALYSIS_NAME}.git" "${ANALYSIS_NAME}"
+
+cd "${ANALYSIS_NAME}"
+echo "Updating submodules..."
+retry 3 5 git submodule update --init --recursive
+
+echo "Applying test versions..."
+switch_root_repo "${ANALYSIS_VERSION}"
+switch_submodule_repo FLAF "${FLAF_version}"
+switch_submodule_repo FLAF/PlotKit "${PlotKit_version}"
+switch_submodule_repo Corrections "${Corrections_version}"
+switch_submodule_repo StatInference "${StatInference_version}"
+
+echo "Fetching Git LFS objects..."
+retry 3 5 git lfs pull || true
+
+if [[ -f config/ci_custom.yaml ]]; then
+  cp config/ci_custom.yaml config/user_custom.yaml
+fi
+
+source_analysis_env
+
+# Handle ERA expansion if "ALL" is specified
+if [[ "${ERAS}" == "ALL" ]]; then
+  ERAS="Run3_2022 Run3_2022EE Run3_2023 Run3_2023BPix"
+fi
+
+for era in ${ERAS}; do
+  echo "========================================================="
+  echo "=== Running era: ${era} ==="
+  echo "========================================================="
+  
+  if [[ -n "${PROCESSES}" ]]; then
+    for proc in ${PROCESSES}; do
+      echo "--- Running process: ${proc} (era: ${era}) ---"
+      # shellcheck disable=SC2086
+      law run "${ANALYSIS_TASK}" --version CI --period "${era}" --workflow local --workers 4 ${ANALYSIS_ARGS} --process "${proc}"
+    done
+  else
+    # shellcheck disable=SC2086
+    law run "${ANALYSIS_TASK}" --version CI --period "${era}" --workflow local --workers 4 ${ANALYSIS_ARGS}
+  fi
+done
+
+echo "========================================================="
+echo "=== All integration test tasks completed successfully! ==="
+echo "========================================================="
+post_github_notification "success"

--- a/.github/scripts/trigger-flaf-integration-parse.js
+++ b/.github/scripts/trigger-flaf-integration-parse.js
@@ -138,6 +138,9 @@ module.exports = async ({ github, context, core, process, require }) => {
         if (key === 'gitlab_branch' || key === 'gitlab_ref') {
           gitlabBranch = value;
           parsed = true;
+        } else if (key === 'ci_backend' || key === 'backend' || key === 'provider' || key === 'runner') {
+          variables.ci_backend = value.toLowerCase();
+          parsed = true;
         } else if (key in variables) {
           variables[key] = normalizeVersionValue(key, value);
           parsed = true;
@@ -214,6 +217,10 @@ module.exports = async ({ github, context, core, process, require }) => {
   variables.WORKFLOW_NAME = workflowNameItems.join(' ');
   variables.github_notify_url = `https://api.github.com/repos/${owner}/${repo}/issues/${prNumber}/comments`;
 
+  const ciBackend = (variables.ci_backend || cfg.ci_backend || 'gitlab').toLowerCase();
+  variables.ci_backend = ciBackend;
+
+  core.setOutput('ci_backend', ciBackend);
   core.setOutput('gitlab_url', cfg.gitlab_url);
   core.setOutput('gitlab_branch', gitlabBranch);
   core.setOutput('variables', JSON.stringify(variables));

--- a/.github/scripts/trigger-flaf-integration-trigger.js
+++ b/.github/scripts/trigger-flaf-integration-trigger.js
@@ -1,5 +1,63 @@
-module.exports = async ({ core, process, fetch, JSON, URLSearchParams, console }) => {
+module.exports = async ({ github, context, core, process, fetch, JSON, URLSearchParams, console }) => {
   const variables = JSON.parse(process.env.VARIABLES);
+  const ciBackend = (process.env.CI_BACKEND || variables.ci_backend || 'gitlab').toLowerCase();
+
+  if (ciBackend === 'github') {
+    console.log('Triggering GitHub Actions integration test workflow...');
+    const rootPackages = Object.keys(variables).filter(k => k.endsWith('_active')).map(k => k.slice(0, -7));
+    let activeAnalysis = rootPackages.find(pkg => variables[`${pkg}_active`] === '1');
+    if (!activeAnalysis) {
+      activeAnalysis = 'HH_bbtautau';
+    }
+
+    const inputs = {
+      analysis_name: activeAnalysis,
+      analysis_version: variables[`${activeAnalysis}_version`] || 'main',
+      flaf_version: variables['FLAF_version'] || 'default',
+      plotkit_version: variables['PlotKit_version'] || 'default',
+      corrections_version: variables['Corrections_version'] || 'default',
+      statinference_version: variables['StatInference_version'] || 'default',
+      eras: variables[`${activeAnalysis}_eras`] || 'Run3_2022EE',
+      processes: variables[`${activeAnalysis}_processes`] || 'custom_CI_Signal custom_CI_Background custom_CI_Data',
+      task: variables[`${activeAnalysis}_task`] || 'FLAF.Analysis.tasks.HistPlotTask',
+      args: variables[`${activeAnalysis}_args`] || '--test 1000',
+      github_notify_url: variables.github_notify_url || '',
+    };
+
+    console.log('Dispatching integration-test.yaml with inputs:');
+    for (const [key, value] of Object.entries(inputs)) {
+      console.log(`\t${key}: ${value}`);
+    }
+
+    const token = process.env.FLAF_GITHUB_TOKEN || process.env.GITHUB_TOKEN;
+    const response = await fetch('https://api.github.com/repos/cms-flaf/FLAF/actions/workflows/integration-test.yaml/dispatches', {
+      method: 'POST',
+      headers: {
+        'Accept': 'application/vnd.github+json',
+        'Authorization': `Bearer ${token}`,
+        'X-GitHub-Api-Version': '2022-11-28',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        ref: 'main',
+        inputs: inputs,
+      }),
+    });
+
+    if (response.status === 204) {
+      console.log('GitHub Actions integration workflow dispatched successfully.');
+      const workflowUrl = 'https://github.com/cms-flaf/FLAF/actions/workflows/integration-test.yaml';
+      const message = `[GitHub Actions integration workflow](${workflowUrl}) dispatched for **${activeAnalysis}** (${inputs.analysis_version})`;
+      core.setOutput('send_message', 'true');
+      core.setOutput('message', message);
+      return;
+    }
+
+    console.log(`Failed to dispatch GitHub workflow: ${response.status}`);
+    const responseText = await response.text();
+    console.log(responseText);
+    throw new Error(`Failed to dispatch GitHub workflow: ${response.status} - ${responseText}`);
+  }
 
   const data = {
     token: '****',
@@ -44,3 +102,4 @@ module.exports = async ({ core, process, fetch, JSON, URLSearchParams, console }
   console.log(responseText);
   throw new Error(`Failed to trigger pipeline: ${response.status} - ${responseText}`);
 };
+

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -1,0 +1,162 @@
+name: FLAF Integration Test (GitHub Actions)
+
+on:
+  workflow_dispatch:
+    inputs:
+      analysis_name:
+        description: 'Analysis name (HH_bbtautau, HH_bbWW, H_mumu)'
+        required: true
+        default: 'HH_bbtautau'
+      analysis_version:
+        description: 'Analysis version/branch/PR (e.g. main, PR_123)'
+        required: false
+        default: 'main'
+      flaf_version:
+        description: 'FLAF version/branch/PR'
+        required: false
+        default: 'default'
+      plotkit_version:
+        description: 'PlotKit version'
+        required: false
+        default: 'default'
+      corrections_version:
+        description: 'Corrections version'
+        required: false
+        default: 'default'
+      statinference_version:
+        description: 'StatInference version'
+        required: false
+        default: 'default'
+      eras:
+        description: 'Eras to test (space-separated or ALL)'
+        required: false
+        default: 'Run3_2022EE'
+      processes:
+        description: 'Processes to test (space-separated, e.g. custom_CI_Signal custom_CI_Background custom_CI_Data)'
+        required: false
+        default: 'custom_CI_Signal custom_CI_Background custom_CI_Data'
+      task:
+        description: 'Analysis Task'
+        required: false
+        default: 'FLAF.Analysis.tasks.HistPlotTask'
+      args:
+        description: 'Task args'
+        required: false
+        default: '--test 1000'
+      github_notify_url:
+        description: 'GitHub comment URL to report results back'
+        required: false
+        default: ''
+  workflow_call:
+    inputs:
+      analysis_name:
+        type: string
+        required: true
+      analysis_version:
+        type: string
+        required: false
+        default: 'main'
+      flaf_version:
+        type: string
+        required: false
+        default: 'default'
+      plotkit_version:
+        type: string
+        required: false
+        default: 'default'
+      corrections_version:
+        type: string
+        required: false
+        default: 'default'
+      statinference_version:
+        type: string
+        required: false
+        default: 'default'
+      eras:
+        type: string
+        required: false
+        default: 'Run3_2022EE'
+      processes:
+        type: string
+        required: false
+        default: 'custom_CI_Signal custom_CI_Background custom_CI_Data'
+      task:
+        type: string
+        required: false
+        default: 'FLAF.Analysis.tasks.HistPlotTask'
+      args:
+        type: string
+        required: false
+        default: '--test 1000'
+      github_notify_url:
+        type: string
+        required: false
+        default: ''
+    secrets:
+      GRID_USERCERT:
+        required: false
+      GRID_USERKEY:
+        required: false
+      GRID_PASSWORD:
+        required: false
+      SSH_PRIVATE_KEY:
+        required: false
+      FLAF_GITHUB_TOKEN:
+        required: false
+
+jobs:
+  run-integration-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 240
+    steps:
+      - name: Checkout FLAF
+        uses: actions/checkout@v4
+
+      - name: Set up CVMFS
+        uses: cvmfs-contrib/github-action-cvmfs@v4
+        with:
+          cvmfs_repositories: 'cms.cern.ch,grid.cern.ch,sft.cern.ch'
+
+      - name: Run Integration Build and Test
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+          GRID_USERCERT: ${{ secrets.GRID_USERCERT }}
+          GRID_USERKEY: ${{ secrets.GRID_USERKEY }}
+          GRID_PASSWORD: ${{ secrets.GRID_PASSWORD }}
+          ANALYSIS_NAME: ${{ inputs.analysis_name }}
+          ANALYSIS_VERSION: ${{ inputs.analysis_version }}
+          FLAF_version: ${{ inputs.flaf_version }}
+          PlotKit_version: ${{ inputs.plotkit_version }}
+          Corrections_version: ${{ inputs.corrections_version }}
+          StatInference_version: ${{ inputs.statinference_version }}
+          ERAS: ${{ inputs.eras }}
+          PROCESSES: ${{ inputs.processes }}
+          ANALYSIS_TASK: ${{ inputs.task }}
+          ANALYSIS_ARGS: ${{ inputs.args }}
+          GITHUB_NOTIFY_URL: ${{ inputs.github_notify_url }}
+          FLAF_GITHUB_TOKEN: ${{ secrets.FLAF_GITHUB_TOKEN }}
+        run: |
+          docker run --rm \
+            --privileged \
+            -v /cvmfs:/cvmfs:shared \
+            -v ${{ github.workspace }}:/workspace \
+            -w /workspace \
+            -e SSH_PRIVATE_KEY \
+            -e GRID_USERCERT \
+            -e GRID_USERKEY \
+            -e GRID_PASSWORD \
+            -e ANALYSIS_NAME \
+            -e ANALYSIS_VERSION \
+            -e FLAF_version \
+            -e PlotKit_version \
+            -e Corrections_version \
+            -e StatInference_version \
+            -e ERAS \
+            -e PROCESSES \
+            -e ANALYSIS_TASK \
+            -e ANALYSIS_ARGS \
+            -e GITHUB_NOTIFY_URL \
+            -e FLAF_GITHUB_TOKEN \
+            -e GITHUB_RUN_ID \
+            kandrosov/flaf:latest \
+            bash .github/scripts/ci/run_gha_integration.sh

--- a/.github/workflows/trigger-flaf-integration.yaml
+++ b/.github/workflows/trigger-flaf-integration.yaml
@@ -74,6 +74,7 @@ jobs:
           script: |
             const workflowFiles = new Set([
               '.github/workflows/trigger-flaf-integration.yaml',
+              '.github/workflows/integration-test.yaml',
               '.github/scripts/trigger-flaf-integration-parse.js',
               '.github/scripts/trigger-flaf-integration-trigger.js',
             ]);
@@ -136,12 +137,15 @@ jobs:
         uses: actions/github-script@v6
         env:
           FLAF_INTEGRATION_TOKEN: ${{ secrets.FLAF_INTEGRATION_TOKEN }}
+          FLAF_GITHUB_TOKEN: ${{ secrets.FLAF_GITHUB_TOKEN }}
+          CI_BACKEND: ${{ steps.parse_comment.outputs.ci_backend }}
           VARIABLES: ${{ steps.parse_comment.outputs.variables }}
           GITLAB_URL: ${{ steps.parse_comment.outputs.gitlab_url }}
           GITLAB_BRANCH: ${{ steps.parse_comment.outputs.gitlab_branch }}
           SHARED_WORKFLOW_PATH: _shared_flaf_workflow
           USE_LOCAL_WORKFLOW_CODE: ${{ steps.detect_workflow_files.outputs.use_local_workflow_code }}
         with:
+          github-token: ${{ secrets.FLAF_GITHUB_TOKEN }}
           script: |
             const fs = require('fs');
             const path = require('path');
@@ -153,7 +157,7 @@ jobs:
 
             console.log(`Using trigger script: ${scriptPath}`);
             const run = require(scriptPath);
-            await run({ core, process, fetch, JSON, URLSearchParams, console });
+            await run({ github, context, core, process, fetch, JSON, URLSearchParams, console });
 
       - name: Post comment
         if: ${{ steps.trigger_flaf_integration_pipeline.outputs.send_message == 'true' }}

--- a/docs/ci/integration-pipeline.md
+++ b/docs/ci/integration-pipeline.md
@@ -36,6 +36,14 @@ Repos with the trigger enabled: HH_bbtautau, HH_bbWW, H_mumu, FLAF, Corrections,
     pins the `FLAF/PlotKit` sub-sub-module, which is switched after `FLAF` (so it overrides whatever
     commit the requested `FLAF` pins).
 
+!!! tip "Running on GitHub Actions (as a backup when CERN GitLab has issues)"
+    To run the integration tests directly on GitHub Actions instead of CERN GitLab:
+    ```text
+    @cms-flaf-bot please test
+    - ci_backend = github
+    ```
+    (Aliases `- backend=github` and `- provider=github` are also accepted).
+
 ## `integration_cfg.yaml`
 
 Each participating repo has `.github/integration_cfg.yaml`. It lists who may trigger, the accepted
@@ -51,6 +59,7 @@ variables:
   HH_bbtautau_args: "--branches 0 --test 1000"
   HH_bbtautau_eras: "Run3_2022 Run3_2022EE Run3_2023 Run3_2023BPix"
   HH_bbtautau_processes: "custom_CI_Signal custom_CI_Background custom_CI_Data"
+  ci_backend: "gitlab"             # "gitlab" (default) or "github"
   TEST_TIMEOUT: "4h"
 ```
 
@@ -62,6 +71,7 @@ variables:
 | `<ana>_args` | Extra `law run` arguments (e.g. `--branches 0 --test 1000`). |
 | `<ana>_eras` | Eras to test (space-separated, or `ALL`). |
 | `<ana>_processes` | The processes to test (space-separated). **Required** for an active analysis — there is no default. |
+| `ci_backend` | CI execution engine: `gitlab` (default, CERN GitLab pipeline) or `github` (GitHub Actions with CVMFS). |
 
 !!! warning "`<ana>_processes` must be set for an active analysis"
     The pipeline **errors at generation time** if an active analysis has no `processes`. The values


### PR DESCRIPTION
## Summary
Adds a GitHub Actions-based integration test workflow utilizing CVMFS (`cvmfs-contrib/github-action-cvmfs`) as a backup execution backend for `@cms-flaf-bot please test` when CERN GitLab runners encounter outages.

## Changes
- `.github/workflows/integration-test.yaml`: Reusable/dispatchable workflow mounting CVMFS and running tests inside `kandrosov/flaf:latest`.
- `.github/scripts/ci/common.sh` & `.github/scripts/ci/run_gha_integration.sh`: Self-contained runner scripts for submodule management, VOMS proxy setup, and `law run` execution.
- `.github/scripts/trigger-flaf-integration-parse.js`: Added parsing for `- ci_backend=github` (and aliases `backend`, `provider`, `runner`).
- `.github/scripts/trigger-flaf-integration-trigger.js`: Dispatches `integration-test.yaml` via GitHub REST API when `ci_backend === 'github'`.
- `.github/workflows/trigger-flaf-integration.yaml`: Added permissions and workflow file detection for `integration-test.yaml`.
- `docs/ci/integration-pipeline.md`: Documented the `ci_backend` override.

## Testing
- Verified `trigger-flaf-integration-parse.js` parsing for both default `gitlab` and `github` backend overrides.
- Verified workflow dispatch logic in `trigger-flaf-integration-trigger.js`.
- Verified documentation with `mkdocs build --strict`.