### PR TITLE
Support multi-analysis matrix dispatch and improve SSH host handling in GitHub Actions CI

### DIFF
--- a/.github/scripts/ci/build_analysis.sh
+++ b/.github/scripts/ci/build_analysis.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=.github/scripts/ci/common.sh
+source "${SCRIPT_DIR}/common.sh"
+
+require_var ANALYSIS_NAME
+
+ANALYSIS_VERSION="${ANALYSIS_VERSION:-main}"
+FLAF_version="${FLAF_version:-default}"
+PlotKit_version="${PlotKit_version:-default}"
+Corrections_version="${Corrections_version:-default}"
+StatInference_version="${StatInference_version:-default}"
+
+if [[ -n "${VARIABLES:-}" ]]; then
+  ANALYSIS_VERSION=$(python3 -c "import json, os; vars=json.loads(os.environ.get('VARIABLES', '{}')); print(vars.get('${ANALYSIS_NAME}_version', '${ANALYSIS_VERSION}'))")
+  FLAF_version=$(python3 -c "import json, os; vars=json.loads(os.environ.get('VARIABLES', '{}')); print(vars.get('FLAF_version', '${FLAF_version}'))")
+  PlotKit_version=$(python3 -c "import json, os; vars=json.loads(os.environ.get('VARIABLES', '{}')); print(vars.get('PlotKit_version', '${PlotKit_version}'))")
+  Corrections_version=$(python3 -c "import json, os; vars=json.loads(os.environ.get('VARIABLES', '{}')); print(vars.get('Corrections_version', '${Corrections_version}'))")
+  StatInference_version=$(python3 -c "import json, os; vars=json.loads(os.environ.get('VARIABLES', '{}')); print(vars.get('StatInference_version', '${StatInference_version}'))")
+fi
+
+echo "=== Building ${ANALYSIS_NAME} (${ANALYSIS_VERSION}) ==="
+echo "FLAF: ${FLAF_version}, PlotKit: ${PlotKit_version}, Corrections: ${Corrections_version}, StatInference: ${StatInference_version}"
+
+init_env
+init_ssh
+init_voms
+init_gfal
+
+BUILD_DIR="/tmp/build_${ANALYSIS_NAME}_${GITHUB_RUN_ID:-$$}"
+mkdir -p "${BUILD_DIR}"
+cd "${BUILD_DIR}"
+
+echo "Cloning ${ANALYSIS_NAME}..."
+retry 3 5 git clone "https://github.com/cms-flaf/${ANALYSIS_NAME}.git" "${ANALYSIS_NAME}"
+
+cd "${ANALYSIS_NAME}"
+echo "Updating submodules..."
+retry 3 5 git submodule update --init --recursive
+
+echo "Applying requested versions..."
+switch_root_repo "${ANALYSIS_VERSION}"
+switch_submodule_repo FLAF "${FLAF_version}"
+switch_submodule_repo FLAF/PlotKit "${PlotKit_version}"
+switch_submodule_repo Corrections "${Corrections_version}"
+switch_submodule_repo StatInference "${StatInference_version}"
+
+echo "Fetching Git LFS objects..."
+retry 3 5 git lfs pull || true
+
+if [[ -f config/ci_custom.yaml ]]; then
+  cp config/ci_custom.yaml config/user_custom.yaml
+fi
+
+cd "${BUILD_DIR}"
+echo "Creating build tarball ${ANALYSIS_NAME}.tar.bz2..."
+tar cjf "/workspace/${ANALYSIS_NAME}.tar.bz2" "${ANALYSIS_NAME}"
+
+echo "Build complete: /workspace/${ANALYSIS_NAME}.tar.bz2"

--- a/.github/scripts/ci/common.sh
+++ b/.github/scripts/ci/common.sh
@@ -36,16 +36,33 @@ init_env() {
 }
 
 init_ssh() {
-  if [[ -z ${SSH_PRIVATE_KEY:-} ]]; then
-    echo "SSH_PRIVATE_KEY not set. Relying on public HTTPS git access."
-    git config --global url."https://github.com/".insteadOf "git@github.com:"
-    return 0
-  fi
-
   mkdir -p "${HOME}/.ssh"
   chmod 700 "${HOME}/.ssh"
-  printf '%s' "${SSH_PRIVATE_KEY}" | base64 -d > "${HOME}/.ssh/id_ed25519" 2>/dev/null || printf '%s' "${SSH_PRIVATE_KEY}" > "${HOME}/.ssh/id_ed25519"
-  chmod 400 "${HOME}/.ssh/id_ed25519"
+
+  cat << 'EOF' > "${HOME}/.ssh/config"
+Host github.com
+    HostName github.com
+    StrictHostKeyChecking no
+    UserKnownHostsFile /dev/null
+
+Host gitlab.cern.ch
+    HostName gitlab.cern.ch
+    Port 7999
+    StrictHostKeyChecking no
+    UserKnownHostsFile /dev/null
+EOF
+  chmod 600 "${HOME}/.ssh/config"
+
+  if [[ -n ${SSH_PRIVATE_KEY:-} ]]; then
+    printf '%s' "${SSH_PRIVATE_KEY}" | base64 -d > "${HOME}/.ssh/id_ed25519" 2>/dev/null || printf '%s' "${SSH_PRIVATE_KEY}" > "${HOME}/.ssh/id_ed25519"
+    chmod 400 "${HOME}/.ssh/id_ed25519"
+    eval "$(ssh-agent -s)" 2>/dev/null || true
+    ssh-add "${HOME}/.ssh/id_ed25519" 2>/dev/null || true
+  else
+    echo "WARNING: SSH_PRIVATE_KEY is not set in GitHub Secrets. GitLab SSH submodules (e.g. inference) require SSH_PRIVATE_KEY."
+    git config --global url."https://github.com/".insteadOf "git@github.com:"
+  fi
+
   retry 3 3 _scan_known_hosts
   git config --global user.email "cms-flaf@proton.me"
   git config --global user.name "CMS FLAF Integration Bot"
@@ -53,8 +70,8 @@ init_ssh() {
 }
 
 _scan_known_hosts() {
-  ssh-keyscan github.com > "${HOME}/.ssh/known_hosts" 2>/dev/null \
-    && ssh-keyscan -p 7999 gitlab.cern.ch >> "${HOME}/.ssh/known_hosts" 2>/dev/null || true
+  ssh-keyscan github.com >> "${HOME}/.ssh/known_hosts" 2>/dev/null || true
+  ssh-keyscan -p 7999 gitlab.cern.ch >> "${HOME}/.ssh/known_hosts" 2>/dev/null || true
 }
 
 init_voms() {

--- a/.github/scripts/ci/generate_matrix.py
+++ b/.github/scripts/ci/generate_matrix.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import os
+import sys
+
+DATASET_TASKS = [
+    "FLAF.Analysis.tasks.NanoAODProducerTask",
+    "FLAF.Analysis.tasks.HistTupleProducerTask",
+    "FLAF.Analysis.tasks.HistFromNtupleProducerTask",
+]
+
+AVAILABLE_ERAS = ["Run3_2022", "Run3_2022EE", "Run3_2023", "Run3_2023BPix", "Run3_2024", "Run3_2025"]
+ANALYSES = ["HH_bbWW", "HH_bbtautau", "H_mumu"]
+
+
+def parse_eras(raw_value):
+    if not raw_value or raw_value == "ALL":
+        return ["Run3_2022", "Run3_2022EE", "Run3_2023", "Run3_2023BPix"]
+    seen = []
+    for era in raw_value.split():
+        if era == "ALL":
+            return ["Run3_2022", "Run3_2022EE", "Run3_2023", "Run3_2023BPix"]
+        if era in AVAILABLE_ERAS and era not in seen:
+            seen.append(era)
+    return seen if seen else ["Run3_2022EE"]
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate GitHub Actions matrix definitions.")
+    parser.add_argument("--variables", default=None, help="JSON-serialized variables map.")
+    args = parser.parse_args()
+
+    raw_vars = args.variables or os.environ.get("VARIABLES", "{}")
+    try:
+        variables = json.loads(raw_vars)
+    except Exception as e:
+        print(f"Warning: Failed to parse VARIABLES JSON: {e}", file=sys.stderr)
+        variables = {}
+
+    analyses_matrix = []
+    process_matrix = []
+    era_matrix = []
+    multi_era_matrix = []
+
+    for ana in ANALYSES:
+        if variables.get(f"{ana}_active") != "1":
+            continue
+
+        analyses_matrix.append(ana)
+        eras = parse_eras(variables.get(f"{ana}_eras", "Run3_2022EE"))
+        target_task = variables.get(f"{ana}_task", "FLAF.Analysis.tasks.HistPlotTask")
+        task_args = variables.get(f"{ana}_args", "--test 1000")
+        procs_str = variables.get(f"{ana}_processes", "custom_CI_Signal custom_CI_Background custom_CI_Data")
+        procs = procs_str.split() if procs_str else []
+
+        dataset_task = ""
+        era_task = ""
+        multi_era_task = ""
+
+        if target_task in DATASET_TASKS:
+            dataset_task = target_task
+        elif "Combine" in target_task or "Inference" in target_task:
+            dataset_task = "FLAF.Analysis.tasks.HistFromNtupleProducerTask"
+            era_task = "FLAF.Analysis.tasks.HistPlotTask"
+            multi_era_task = target_task
+        else:
+            dataset_task = "FLAF.Analysis.tasks.HistFromNtupleProducerTask"
+            era_task = target_task
+
+        for era in eras:
+            if dataset_task:
+                for proc in procs:
+                    proc_safe = proc.replace("/", "_").replace("-", "_")
+                    process_matrix.append({
+                        "analysis": ana,
+                        "era": era,
+                        "process": proc,
+                        "proc_safe": proc_safe,
+                        "task": dataset_task,
+                        "args": f"{task_args} --process {proc}"
+                    })
+            if era_task:
+                era_matrix.append({
+                    "analysis": ana,
+                    "era": era,
+                    "task": era_task,
+                    "args": task_args
+                })
+
+        if multi_era_task:
+            multi_era_matrix.append({
+                "analysis": ana,
+                "task": multi_era_task,
+                "args": task_args,
+                "era": eras[0] if eras else "Run3_2022EE"
+            })
+
+    if not analyses_matrix:
+        analyses_matrix = ["HH_bbtautau"]
+
+    output_file = os.environ.get("GITHUB_OUTPUT")
+    results = {
+        "analyses": analyses_matrix,
+        "processes": process_matrix,
+        "eras": era_matrix,
+        "multi_eras": multi_era_matrix,
+        "has_processes": len(process_matrix) > 0,
+        "has_eras": len(era_matrix) > 0,
+        "has_multi_eras": len(multi_era_matrix) > 0
+    }
+
+    if output_file:
+        with open(output_file, "a", encoding="utf-8") as f:
+            f.write(f"analyses={json.dumps(analyses_matrix)}\n")
+            f.write(f"processes={json.dumps(process_matrix)}\n")
+            f.write(f"eras={json.dumps(era_matrix)}\n")
+            f.write(f"multi_eras={json.dumps(multi_era_matrix)}\n")
+            f.write(f"has_processes={'true' if len(process_matrix) > 0 else 'false'}\n")
+            f.write(f"has_eras={'true' if len(era_matrix) > 0 else 'false'}\n")
+            f.write(f"has_multi_eras={'true' if len(multi_era_matrix) > 0 else 'false'}\n")
+
+    print(json.dumps(results, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/ci/generate_matrix.py
+++ b/.github/scripts/ci/generate_matrix.py
@@ -11,7 +11,14 @@ DATASET_TASKS = [
     "FLAF.Analysis.tasks.HistFromNtupleProducerTask",
 ]
 
-AVAILABLE_ERAS = ["Run3_2022", "Run3_2022EE", "Run3_2023", "Run3_2023BPix", "Run3_2024", "Run3_2025"]
+AVAILABLE_ERAS = [
+    "Run3_2022",
+    "Run3_2022EE",
+    "Run3_2023",
+    "Run3_2023BPix",
+    "Run3_2024",
+    "Run3_2025",
+]
 ANALYSES = ["HH_bbWW", "HH_bbtautau", "H_mumu"]
 
 
@@ -28,8 +35,12 @@ def parse_eras(raw_value):
 
 
 def main():
-    parser = argparse.ArgumentParser(description="Generate GitHub Actions matrix definitions.")
-    parser.add_argument("--variables", default=None, help="JSON-serialized variables map.")
+    parser = argparse.ArgumentParser(
+        description="Generate GitHub Actions matrix definitions."
+    )
+    parser.add_argument(
+        "--variables", default=None, help="JSON-serialized variables map."
+    )
     args = parser.parse_args()
 
     raw_vars = args.variables or os.environ.get("VARIABLES", "{}")
@@ -52,7 +63,9 @@ def main():
         eras = parse_eras(variables.get(f"{ana}_eras", "Run3_2022EE"))
         target_task = variables.get(f"{ana}_task", "FLAF.Analysis.tasks.HistPlotTask")
         task_args = variables.get(f"{ana}_args", "--test 1000")
-        procs_str = variables.get(f"{ana}_processes", "custom_CI_Signal custom_CI_Background custom_CI_Data")
+        procs_str = variables.get(
+            f"{ana}_processes", "custom_CI_Signal custom_CI_Background custom_CI_Data"
+        )
         procs = procs_str.split() if procs_str else []
 
         dataset_task = ""
@@ -73,29 +86,30 @@ def main():
             if dataset_task:
                 for proc in procs:
                     proc_safe = proc.replace("/", "_").replace("-", "_")
-                    process_matrix.append({
-                        "analysis": ana,
-                        "era": era,
-                        "process": proc,
-                        "proc_safe": proc_safe,
-                        "task": dataset_task,
-                        "args": f"{task_args} --process {proc}"
-                    })
+                    process_matrix.append(
+                        {
+                            "analysis": ana,
+                            "era": era,
+                            "process": proc,
+                            "proc_safe": proc_safe,
+                            "task": dataset_task,
+                            "args": f"{task_args} --process {proc}",
+                        }
+                    )
             if era_task:
-                era_matrix.append({
-                    "analysis": ana,
-                    "era": era,
-                    "task": era_task,
-                    "args": task_args
-                })
+                era_matrix.append(
+                    {"analysis": ana, "era": era, "task": era_task, "args": task_args}
+                )
 
         if multi_era_task:
-            multi_era_matrix.append({
-                "analysis": ana,
-                "task": multi_era_task,
-                "args": task_args,
-                "era": eras[0] if eras else "Run3_2022EE"
-            })
+            multi_era_matrix.append(
+                {
+                    "analysis": ana,
+                    "task": multi_era_task,
+                    "args": task_args,
+                    "era": eras[0] if eras else "Run3_2022EE",
+                }
+            )
 
     if not analyses_matrix:
         analyses_matrix = ["HH_bbtautau"]
@@ -108,7 +122,7 @@ def main():
         "multi_eras": multi_era_matrix,
         "has_processes": len(process_matrix) > 0,
         "has_eras": len(era_matrix) > 0,
-        "has_multi_eras": len(multi_era_matrix) > 0
+        "has_multi_eras": len(multi_era_matrix) > 0,
     }
 
     if output_file:
@@ -119,7 +133,9 @@ def main():
             f.write(f"multi_eras={json.dumps(multi_era_matrix)}\n")
             f.write(f"has_processes={'true' if len(process_matrix) > 0 else 'false'}\n")
             f.write(f"has_eras={'true' if len(era_matrix) > 0 else 'false'}\n")
-            f.write(f"has_multi_eras={'true' if len(multi_era_matrix) > 0 else 'false'}\n")
+            f.write(
+                f"has_multi_eras={'true' if len(multi_era_matrix) > 0 else 'false'}\n"
+            )
 
     print(json.dumps(results, indent=2))
 

--- a/.github/scripts/ci/run_gha_integration.sh
+++ b/.github/scripts/ci/run_gha_integration.sh
@@ -20,6 +20,18 @@ ANALYSIS_ARGS="${ANALYSIS_ARGS:---test 1000}"
 GITHUB_NOTIFY_URL="${GITHUB_NOTIFY_URL:-}"
 FLAF_GITHUB_TOKEN="${FLAF_GITHUB_TOKEN:-}"
 
+if [[ -n "${VARIABLES:-}" ]]; then
+  ANALYSIS_VERSION=$(python3 -c "import json, os; vars=json.loads(os.environ.get('VARIABLES', '{}')); print(vars.get('${ANALYSIS_NAME}_version', '${ANALYSIS_VERSION}'))")
+  FLAF_version=$(python3 -c "import json, os; vars=json.loads(os.environ.get('VARIABLES', '{}')); print(vars.get('FLAF_version', '${FLAF_version}'))")
+  PlotKit_version=$(python3 -c "import json, os; vars=json.loads(os.environ.get('VARIABLES', '{}')); print(vars.get('PlotKit_version', '${PlotKit_version}'))")
+  Corrections_version=$(python3 -c "import json, os; vars=json.loads(os.environ.get('VARIABLES', '{}')); print(vars.get('Corrections_version', '${Corrections_version}'))")
+  StatInference_version=$(python3 -c "import json, os; vars=json.loads(os.environ.get('VARIABLES', '{}')); print(vars.get('StatInference_version', '${StatInference_version}'))")
+  ERAS=$(python3 -c "import json, os; vars=json.loads(os.environ.get('VARIABLES', '{}')); print(vars.get('${ANALYSIS_NAME}_eras', '${ERAS}'))")
+  PROCESSES=$(python3 -c "import json, os; vars=json.loads(os.environ.get('VARIABLES', '{}')); print(vars.get('${ANALYSIS_NAME}_processes', '${PROCESSES}'))")
+  ANALYSIS_TASK=$(python3 -c "import json, os; vars=json.loads(os.environ.get('VARIABLES', '{}')); print(vars.get('${ANALYSIS_NAME}_task', '${ANALYSIS_TASK}'))")
+  ANALYSIS_ARGS=$(python3 -c "import json, os; vars=json.loads(os.environ.get('VARIABLES', '{}')); print(vars.get('${ANALYSIS_NAME}_args', '${ANALYSIS_ARGS}'))")
+fi
+
 post_github_notification() {
   local status_text=$1
   if [[ -n "${GITHUB_NOTIFY_URL}" && -n "${FLAF_GITHUB_TOKEN}" ]]; then

--- a/.github/scripts/ci/test_analysis.sh
+++ b/.github/scripts/ci/test_analysis.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=.github/scripts/ci/common.sh
+source "${SCRIPT_DIR}/common.sh"
+
+require_var ANALYSIS_NAME
+require_var ANALYSIS_TASK
+require_var ANALYSIS_ARGS
+require_var ERA
+
+init_env
+init_ssh
+init_voms
+init_gfal
+
+RUN_DIR="/tmp/test_${ANALYSIS_NAME}_${GITHUB_RUN_ID:-$$}"
+mkdir -p "${RUN_DIR}"
+cd "${RUN_DIR}"
+
+if [[ ! -f "/workspace/${ANALYSIS_NAME}.tar.bz2" ]]; then
+  echo "Error: /workspace/${ANALYSIS_NAME}.tar.bz2 not found." >&2
+  exit 1
+fi
+
+echo "Unpacking /workspace/${ANALYSIS_NAME}.tar.bz2..."
+tar xjf "/workspace/${ANALYSIS_NAME}.tar.bz2"
+
+cd "${ANALYSIS_NAME}"
+
+# Restore previous stage outputs if passed via /workspace/inputs
+if [[ -d "/workspace/inputs" ]]; then
+  echo "Restoring previous stage artifacts from /workspace/inputs..."
+  mkdir -p data/CI output
+  cp -rn /workspace/inputs/* data/CI/ 2>/dev/null || true
+  cp -rn /workspace/inputs/* output/ 2>/dev/null || true
+fi
+
+source_analysis_env
+init_voms
+
+echo "Running task: ${ANALYSIS_TASK} ${ANALYSIS_ARGS} for era: ${ERA}"
+# shellcheck disable=SC2086
+law run "${ANALYSIS_TASK}" --version CI --period "${ERA}" --workflow local --workers 4 ${ANALYSIS_ARGS}
+
+# Stage outputs for upload
+mkdir -p /workspace/outputs
+if [[ -d "data/CI" ]]; then
+  cp -rn data/CI/* /workspace/outputs/ 2>/dev/null || true
+fi
+if [[ -d "output" ]]; then
+  cp -rn output/* /workspace/outputs/ 2>/dev/null || true
+fi
+
+echo "=== Task ${ANALYSIS_TASK} (${ERA}) completed successfully ==="

--- a/.github/scripts/trigger-flaf-integration-trigger.js
+++ b/.github/scripts/trigger-flaf-integration-trigger.js
@@ -11,12 +11,7 @@ module.exports = async ({ github, context, core, process, fetch, JSON, URLSearch
     }
 
     const inputs = {
-      analyses: JSON.stringify(activeAnalyses),
       variables: JSON.stringify(variables),
-      flaf_version: variables['FLAF_version'] || 'default',
-      plotkit_version: variables['PlotKit_version'] || 'default',
-      corrections_version: variables['Corrections_version'] || 'default',
-      statinference_version: variables['StatInference_version'] || 'default',
       github_notify_url: variables.github_notify_url || '',
     };
 

--- a/.github/scripts/trigger-flaf-integration-trigger.js
+++ b/.github/scripts/trigger-flaf-integration-trigger.js
@@ -5,22 +5,18 @@ module.exports = async ({ github, context, core, process, fetch, JSON, URLSearch
   if (ciBackend === 'github') {
     console.log('Triggering GitHub Actions integration test workflow...');
     const rootPackages = Object.keys(variables).filter(k => k.endsWith('_active')).map(k => k.slice(0, -7));
-    let activeAnalysis = rootPackages.find(pkg => variables[`${pkg}_active`] === '1');
-    if (!activeAnalysis) {
-      activeAnalysis = 'HH_bbtautau';
+    const activeAnalyses = rootPackages.filter(pkg => variables[`${pkg}_active`] === '1');
+    if (activeAnalyses.length === 0) {
+      activeAnalyses.push('HH_bbtautau');
     }
 
     const inputs = {
-      analysis_name: activeAnalysis,
-      analysis_version: variables[`${activeAnalysis}_version`] || 'main',
+      analyses: JSON.stringify(activeAnalyses),
+      variables: JSON.stringify(variables),
       flaf_version: variables['FLAF_version'] || 'default',
       plotkit_version: variables['PlotKit_version'] || 'default',
       corrections_version: variables['Corrections_version'] || 'default',
       statinference_version: variables['StatInference_version'] || 'default',
-      eras: variables[`${activeAnalysis}_eras`] || 'Run3_2022EE',
-      processes: variables[`${activeAnalysis}_processes`] || 'custom_CI_Signal custom_CI_Background custom_CI_Data',
-      task: variables[`${activeAnalysis}_task`] || 'FLAF.Analysis.tasks.HistPlotTask',
-      args: variables[`${activeAnalysis}_args`] || '--test 1000',
       github_notify_url: variables.github_notify_url || '',
     };
 
@@ -47,7 +43,7 @@ module.exports = async ({ github, context, core, process, fetch, JSON, URLSearch
     if (response.status === 204) {
       console.log('GitHub Actions integration workflow dispatched successfully.');
       const workflowUrl = 'https://github.com/cms-flaf/FLAF/actions/workflows/integration-test.yaml';
-      const message = `[GitHub Actions integration workflow](${workflowUrl}) dispatched for **${activeAnalysis}** (${inputs.analysis_version})`;
+      const message = `[GitHub Actions integration workflow](${workflowUrl}) dispatched for **${activeAnalyses.join(', ')}**`;
       core.setOutput('send_message', 'true');
       core.setOutput('message', message);
       return;

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -104,7 +104,7 @@ jobs:
           retention-days: 1
 
   test-dataset:
-    needs: [prepare-matrix, build]
+    needs: [ prepare-matrix, build ]
     if: ${{ needs.prepare-matrix.outputs.has_processes == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 240
@@ -165,7 +165,7 @@ jobs:
           retention-days: 1
 
   test-era:
-    needs: [prepare-matrix, build, test-dataset]
+    needs: [ prepare-matrix, build, test-dataset ]
     if: ${{ always() && !contains(needs.build.result, 'failure') && !contains(needs.build.result, 'cancelled') && !contains(needs.test-dataset.result, 'failure') && !contains(needs.test-dataset.result, 'cancelled') && needs.prepare-matrix.outputs.has_eras == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 120
@@ -233,7 +233,7 @@ jobs:
           retention-days: 1
 
   test-multi-era:
-    needs: [prepare-matrix, build, test-era]
+    needs: [ prepare-matrix, build, test-era ]
     if: ${{ always() && !contains(needs.build.result, 'failure') && !contains(needs.build.result, 'cancelled') && !contains(needs.test-era.result, 'failure') && !contains(needs.test-era.result, 'cancelled') && needs.prepare-matrix.outputs.has_multi_eras == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 120
@@ -301,7 +301,7 @@ jobs:
           retention-days: 1
 
   notify:
-    needs: [prepare-matrix, build, test-dataset, test-era, test-multi-era]
+    needs: [ prepare-matrix, build, test-dataset, test-era, test-multi-era ]
     if: ${{ always() }}
     runs-on: ubuntu-latest
     steps:
@@ -338,7 +338,7 @@ jobs:
 
             const [owner, repo, , pullNumber] = notifyUrl.replace('https://api.github.com/repos/', '').split('/');
             console.log(`Posting notification to ${notifyUrl}: ${msg}`);
-            
+
             const token = process.env.FLAF_GITHUB_TOKEN || process.env.GITHUB_TOKEN;
             await fetch(notifyUrl, {
               method: 'POST',

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -3,100 +3,20 @@ name: FLAF Integration Test (GitHub Actions)
 on:
   workflow_dispatch:
     inputs:
-      analyses:
-        description: 'Analysis name(s) (JSON array, space-separated string, or single: HH_bbtautau, HH_bbWW, H_mumu, ALL)'
-        required: true
-        default: '["HH_bbtautau"]'
       variables:
         description: 'JSON-serialized variables object'
         required: false
         default: '{}'
-      analysis_version:
-        description: 'Default analysis version/branch/PR (e.g. main, PR_123)'
-        required: false
-        default: 'main'
-      flaf_version:
-        description: 'FLAF version/branch/PR'
-        required: false
-        default: 'default'
-      plotkit_version:
-        description: 'PlotKit version'
-        required: false
-        default: 'default'
-      corrections_version:
-        description: 'Corrections version'
-        required: false
-        default: 'default'
-      statinference_version:
-        description: 'StatInference version'
-        required: false
-        default: 'default'
-      eras:
-        description: 'Default eras to test (space-separated or ALL)'
-        required: false
-        default: 'Run3_2022EE'
-      processes:
-        description: 'Default processes to test (space-separated)'
-        required: false
-        default: 'custom_CI_Signal custom_CI_Background custom_CI_Data'
-      task:
-        description: 'Default analysis task'
-        required: false
-        default: 'FLAF.Analysis.tasks.HistPlotTask'
-      args:
-        description: 'Default task args'
-        required: false
-        default: '--test 1000'
       github_notify_url:
         description: 'GitHub comment URL to report results back'
         required: false
         default: ''
   workflow_call:
     inputs:
-      analyses:
-        type: string
-        required: false
-        default: '["HH_bbtautau"]'
       variables:
         type: string
         required: false
         default: '{}'
-      analysis_version:
-        type: string
-        required: false
-        default: 'main'
-      flaf_version:
-        type: string
-        required: false
-        default: 'default'
-      plotkit_version:
-        type: string
-        required: false
-        default: 'default'
-      corrections_version:
-        type: string
-        required: false
-        default: 'default'
-      statinference_version:
-        type: string
-        required: false
-        default: 'default'
-      eras:
-        type: string
-        required: false
-        default: 'Run3_2022EE'
-      processes:
-        type: string
-        required: false
-        default: 'custom_CI_Signal custom_CI_Background custom_CI_Data'
-      task:
-        type: string
-        required: false
-        default: 'FLAF.Analysis.tasks.HistPlotTask'
-      args:
-        type: string
-        required: false
-        default: '--test 1000'
       github_notify_url:
         type: string
         required: false
@@ -117,38 +37,32 @@ jobs:
   prepare-matrix:
     runs-on: ubuntu-latest
     outputs:
-      matrix: ${{ steps.set-matrix.outputs.matrix }}
+      analyses: ${{ steps.gen-matrix.outputs.analyses }}
+      processes: ${{ steps.gen-matrix.outputs.processes }}
+      eras: ${{ steps.gen-matrix.outputs.eras }}
+      multi_eras: ${{ steps.gen-matrix.outputs.multi_eras }}
+      has_processes: ${{ steps.gen-matrix.outputs.has_processes }}
+      has_eras: ${{ steps.gen-matrix.outputs.has_eras }}
+      has_multi_eras: ${{ steps.gen-matrix.outputs.has_multi_eras }}
     steps:
-      - name: Resolve matrix
-        id: set-matrix
+      - name: Checkout FLAF
+        uses: actions/checkout@v4
+
+      - name: Generate matrix
+        id: gen-matrix
+        env:
+          VARIABLES: ${{ inputs.variables }}
         run: |
-          python3 -c "
-          import json, sys
+          python3 .github/scripts/ci/generate_matrix.py
 
-          raw = '''${{ inputs.analyses }}'''.strip()
-          if not raw:
-              matrix = ['HH_bbtautau']
-          elif raw == 'ALL':
-              matrix = ['HH_bbtautau', 'HH_bbWW', 'H_mumu']
-          elif raw.startswith('['):
-              matrix = json.loads(raw)
-          else:
-              matrix = raw.split()
-
-          print(f'Matrix: {matrix}')
-          import os
-          with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
-              f.write(f'matrix={json.dumps(matrix)}\n')
-          "
-
-  run-integration-test:
+  build:
     needs: prepare-matrix
     runs-on: ubuntu-latest
-    timeout-minutes: 240
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
-        analysis: ${{ fromJson(needs.prepare-matrix.outputs.matrix) }}
+        analysis: ${{ fromJson(needs.prepare-matrix.outputs.analyses) }}
     steps:
       - name: Checkout FLAF
         uses: actions/checkout@v4
@@ -158,25 +72,14 @@ jobs:
         with:
           cvmfs_repositories: 'cms.cern.ch,grid.cern.ch,sft.cern.ch'
 
-      - name: Run Integration Build and Test
+      - name: Build Analysis
         env:
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
           GRID_USERCERT: ${{ secrets.GRID_USERCERT }}
           GRID_USERKEY: ${{ secrets.GRID_USERKEY }}
           GRID_PASSWORD: ${{ secrets.GRID_PASSWORD }}
           ANALYSIS_NAME: ${{ matrix.analysis }}
-          ANALYSIS_VERSION: ${{ inputs.analysis_version }}
-          FLAF_version: ${{ inputs.flaf_version }}
-          PlotKit_version: ${{ inputs.plotkit_version }}
-          Corrections_version: ${{ inputs.corrections_version }}
-          StatInference_version: ${{ inputs.statinference_version }}
-          ERAS: ${{ inputs.eras }}
-          PROCESSES: ${{ inputs.processes }}
-          ANALYSIS_TASK: ${{ inputs.task }}
-          ANALYSIS_ARGS: ${{ inputs.args }}
           VARIABLES: ${{ inputs.variables }}
-          GITHUB_NOTIFY_URL: ${{ inputs.github_notify_url }}
-          FLAF_GITHUB_TOKEN: ${{ secrets.FLAF_GITHUB_TOKEN }}
         run: |
           docker run --rm \
             --privileged \
@@ -188,18 +91,262 @@ jobs:
             -e GRID_USERKEY \
             -e GRID_PASSWORD \
             -e ANALYSIS_NAME \
-            -e ANALYSIS_VERSION \
-            -e FLAF_version \
-            -e PlotKit_version \
-            -e Corrections_version \
-            -e StatInference_version \
-            -e ERAS \
-            -e PROCESSES \
-            -e ANALYSIS_TASK \
-            -e ANALYSIS_ARGS \
             -e VARIABLES \
-            -e GITHUB_NOTIFY_URL \
-            -e FLAF_GITHUB_TOKEN \
             -e GITHUB_RUN_ID \
             kandrosov/flaf:latest \
-            bash .github/scripts/ci/run_gha_integration.sh
+            bash .github/scripts/ci/build_analysis.sh
+
+      - name: Upload Build Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-${{ matrix.analysis }}
+          path: ${{ matrix.analysis }}.tar.bz2
+          retention-days: 1
+
+  test-dataset:
+    needs: [prepare-matrix, build]
+    if: ${{ needs.prepare-matrix.outputs.has_processes == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 240
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.prepare-matrix.outputs.processes) }}
+    steps:
+      - name: Checkout FLAF
+        uses: actions/checkout@v4
+
+      - name: Set up CVMFS
+        uses: cvmfs-contrib/github-action-cvmfs@v4
+        with:
+          cvmfs_repositories: 'cms.cern.ch,grid.cern.ch,sft.cern.ch'
+
+      - name: Download Build Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: build-${{ matrix.analysis }}
+          path: .
+
+      - name: Run Dataset Test
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+          GRID_USERCERT: ${{ secrets.GRID_USERCERT }}
+          GRID_USERKEY: ${{ secrets.GRID_USERKEY }}
+          GRID_PASSWORD: ${{ secrets.GRID_PASSWORD }}
+          ANALYSIS_NAME: ${{ matrix.analysis }}
+          ANALYSIS_TASK: ${{ matrix.task }}
+          ANALYSIS_ARGS: ${{ matrix.args }}
+          ERA: ${{ matrix.era }}
+        run: |
+          docker run --rm \
+            --privileged \
+            -v /cvmfs:/cvmfs:shared \
+            -v ${{ github.workspace }}:/workspace \
+            -w /workspace \
+            -e SSH_PRIVATE_KEY \
+            -e GRID_USERCERT \
+            -e GRID_USERKEY \
+            -e GRID_PASSWORD \
+            -e ANALYSIS_NAME \
+            -e ANALYSIS_TASK \
+            -e ANALYSIS_ARGS \
+            -e ERA \
+            -e GITHUB_RUN_ID \
+            kandrosov/flaf:latest \
+            bash .github/scripts/ci/test_analysis.sh
+
+      - name: Upload Process Artifacts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: dataset-${{ matrix.analysis }}-${{ matrix.era }}-${{ matrix.proc_safe }}
+          path: outputs/
+          if-no-files-found: ignore
+          retention-days: 1
+
+  test-era:
+    needs: [prepare-matrix, build, test-dataset]
+    if: ${{ always() && !contains(needs.build.result, 'failure') && !contains(needs.build.result, 'cancelled') && !contains(needs.test-dataset.result, 'failure') && !contains(needs.test-dataset.result, 'cancelled') && needs.prepare-matrix.outputs.has_eras == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.prepare-matrix.outputs.eras) }}
+    steps:
+      - name: Checkout FLAF
+        uses: actions/checkout@v4
+
+      - name: Set up CVMFS
+        uses: cvmfs-contrib/github-action-cvmfs@v4
+        with:
+          cvmfs_repositories: 'cms.cern.ch,grid.cern.ch,sft.cern.ch'
+
+      - name: Download Build Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: build-${{ matrix.analysis }}
+          path: .
+
+      - name: Download Dataset Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: dataset-${{ matrix.analysis }}-${{ matrix.era }}-*
+          path: inputs
+          merge-multiple: true
+
+      - name: Run Era Test
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+          GRID_USERCERT: ${{ secrets.GRID_USERCERT }}
+          GRID_USERKEY: ${{ secrets.GRID_USERKEY }}
+          GRID_PASSWORD: ${{ secrets.GRID_PASSWORD }}
+          ANALYSIS_NAME: ${{ matrix.analysis }}
+          ANALYSIS_TASK: ${{ matrix.task }}
+          ANALYSIS_ARGS: ${{ matrix.args }}
+          ERA: ${{ matrix.era }}
+        run: |
+          docker run --rm \
+            --privileged \
+            -v /cvmfs:/cvmfs:shared \
+            -v ${{ github.workspace }}:/workspace \
+            -w /workspace \
+            -e SSH_PRIVATE_KEY \
+            -e GRID_USERCERT \
+            -e GRID_USERKEY \
+            -e GRID_PASSWORD \
+            -e ANALYSIS_NAME \
+            -e ANALYSIS_TASK \
+            -e ANALYSIS_ARGS \
+            -e ERA \
+            -e GITHUB_RUN_ID \
+            kandrosov/flaf:latest \
+            bash .github/scripts/ci/test_analysis.sh
+
+      - name: Upload Era Artifacts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: era-${{ matrix.analysis }}-${{ matrix.era }}
+          path: outputs/
+          if-no-files-found: ignore
+          retention-days: 1
+
+  test-multi-era:
+    needs: [prepare-matrix, build, test-era]
+    if: ${{ always() && !contains(needs.build.result, 'failure') && !contains(needs.build.result, 'cancelled') && !contains(needs.test-era.result, 'failure') && !contains(needs.test-era.result, 'cancelled') && needs.prepare-matrix.outputs.has_multi_eras == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.prepare-matrix.outputs.multi_eras) }}
+    steps:
+      - name: Checkout FLAF
+        uses: actions/checkout@v4
+
+      - name: Set up CVMFS
+        uses: cvmfs-contrib/github-action-cvmfs@v4
+        with:
+          cvmfs_repositories: 'cms.cern.ch,grid.cern.ch,sft.cern.ch'
+
+      - name: Download Build Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: build-${{ matrix.analysis }}
+          path: .
+
+      - name: Download All Era Artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: era-${{ matrix.analysis }}-*
+          path: inputs
+          merge-multiple: true
+
+      - name: Run Multi-Era Test
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+          GRID_USERCERT: ${{ secrets.GRID_USERCERT }}
+          GRID_USERKEY: ${{ secrets.GRID_USERKEY }}
+          GRID_PASSWORD: ${{ secrets.GRID_PASSWORD }}
+          ANALYSIS_NAME: ${{ matrix.analysis }}
+          ANALYSIS_TASK: ${{ matrix.task }}
+          ANALYSIS_ARGS: ${{ matrix.args }}
+          ERA: ${{ matrix.era }}
+        run: |
+          docker run --rm \
+            --privileged \
+            -v /cvmfs:/cvmfs:shared \
+            -v ${{ github.workspace }}:/workspace \
+            -w /workspace \
+            -e SSH_PRIVATE_KEY \
+            -e GRID_USERCERT \
+            -e GRID_USERKEY \
+            -e GRID_PASSWORD \
+            -e ANALYSIS_NAME \
+            -e ANALYSIS_TASK \
+            -e ANALYSIS_ARGS \
+            -e ERA \
+            -e GITHUB_RUN_ID \
+            kandrosov/flaf:latest \
+            bash .github/scripts/ci/test_analysis.sh
+
+      - name: Upload Multi-Era Artifacts
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: multi-era-${{ matrix.analysis }}
+          path: outputs/
+          if-no-files-found: ignore
+          retention-days: 1
+
+  notify:
+    needs: [prepare-matrix, build, test-dataset, test-era, test-multi-era]
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post PR notification
+        uses: actions/github-script@v6
+        env:
+          BUILD_RESULT: ${{ needs.build.result }}
+          DATASET_RESULT: ${{ needs.test-dataset.result }}
+          ERA_RESULT: ${{ needs.test-era.result }}
+          MULTI_ERA_RESULT: ${{ needs.test-multi-era.result }}
+          GITHUB_NOTIFY_URL: ${{ inputs.github_notify_url }}
+          FLAF_GITHUB_TOKEN: ${{ secrets.FLAF_GITHUB_TOKEN }}
+        with:
+          github-token: ${{ secrets.FLAF_GITHUB_TOKEN }}
+          script: |
+            const notifyUrl = process.env.GITHUB_NOTIFY_URL;
+            if (!notifyUrl) {
+              console.log('No GITHUB_NOTIFY_URL provided. Skipping PR comment.');
+              return;
+            }
+
+            const results = [
+              process.env.BUILD_RESULT,
+              process.env.DATASET_RESULT,
+              process.env.ERA_RESULT,
+              process.env.MULTI_ERA_RESULT
+            ].filter(r => r && r !== 'skipped');
+
+            const isSuccess = results.every(r => r === 'success');
+            const runUrl = `https://github.com/cms-flaf/FLAF/actions/runs/${context.runId}`;
+            const msg = isSuccess
+              ? `✅ [GitHub Actions integration pipeline](${runUrl}) passed.`
+              : `❌ [GitHub Actions integration pipeline](${runUrl}) failed.`;
+
+            const [owner, repo, , pullNumber] = notifyUrl.replace('https://api.github.com/repos/', '').split('/');
+            console.log(`Posting notification to ${notifyUrl}: ${msg}`);
+            
+            const token = process.env.FLAF_GITHUB_TOKEN || process.env.GITHUB_TOKEN;
+            await fetch(notifyUrl, {
+              method: 'POST',
+              headers: {
+                'Accept': 'application/vnd.github+json',
+                'Authorization': `Bearer ${token}`,
+                'X-GitHub-Api-Version': '2022-11-28',
+                'Content-Type': 'application/json'
+              },
+              body: JSON.stringify({ body: msg })
+            });

--- a/.github/workflows/integration-test.yaml
+++ b/.github/workflows/integration-test.yaml
@@ -3,12 +3,16 @@ name: FLAF Integration Test (GitHub Actions)
 on:
   workflow_dispatch:
     inputs:
-      analysis_name:
-        description: 'Analysis name (HH_bbtautau, HH_bbWW, H_mumu)'
+      analyses:
+        description: 'Analysis name(s) (JSON array, space-separated string, or single: HH_bbtautau, HH_bbWW, H_mumu, ALL)'
         required: true
-        default: 'HH_bbtautau'
+        default: '["HH_bbtautau"]'
+      variables:
+        description: 'JSON-serialized variables object'
+        required: false
+        default: '{}'
       analysis_version:
-        description: 'Analysis version/branch/PR (e.g. main, PR_123)'
+        description: 'Default analysis version/branch/PR (e.g. main, PR_123)'
         required: false
         default: 'main'
       flaf_version:
@@ -28,19 +32,19 @@ on:
         required: false
         default: 'default'
       eras:
-        description: 'Eras to test (space-separated or ALL)'
+        description: 'Default eras to test (space-separated or ALL)'
         required: false
         default: 'Run3_2022EE'
       processes:
-        description: 'Processes to test (space-separated, e.g. custom_CI_Signal custom_CI_Background custom_CI_Data)'
+        description: 'Default processes to test (space-separated)'
         required: false
         default: 'custom_CI_Signal custom_CI_Background custom_CI_Data'
       task:
-        description: 'Analysis Task'
+        description: 'Default analysis task'
         required: false
         default: 'FLAF.Analysis.tasks.HistPlotTask'
       args:
-        description: 'Task args'
+        description: 'Default task args'
         required: false
         default: '--test 1000'
       github_notify_url:
@@ -49,9 +53,14 @@ on:
         default: ''
   workflow_call:
     inputs:
-      analysis_name:
+      analyses:
         type: string
-        required: true
+        required: false
+        default: '["HH_bbtautau"]'
+      variables:
+        type: string
+        required: false
+        default: '{}'
       analysis_version:
         type: string
         required: false
@@ -105,9 +114,41 @@ on:
         required: false
 
 jobs:
+  prepare-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Resolve matrix
+        id: set-matrix
+        run: |
+          python3 -c "
+          import json, sys
+
+          raw = '''${{ inputs.analyses }}'''.strip()
+          if not raw:
+              matrix = ['HH_bbtautau']
+          elif raw == 'ALL':
+              matrix = ['HH_bbtautau', 'HH_bbWW', 'H_mumu']
+          elif raw.startswith('['):
+              matrix = json.loads(raw)
+          else:
+              matrix = raw.split()
+
+          print(f'Matrix: {matrix}')
+          import os
+          with open(os.environ['GITHUB_OUTPUT'], 'a') as f:
+              f.write(f'matrix={json.dumps(matrix)}\n')
+          "
+
   run-integration-test:
+    needs: prepare-matrix
     runs-on: ubuntu-latest
     timeout-minutes: 240
+    strategy:
+      fail-fast: false
+      matrix:
+        analysis: ${{ fromJson(needs.prepare-matrix.outputs.matrix) }}
     steps:
       - name: Checkout FLAF
         uses: actions/checkout@v4
@@ -123,7 +164,7 @@ jobs:
           GRID_USERCERT: ${{ secrets.GRID_USERCERT }}
           GRID_USERKEY: ${{ secrets.GRID_USERKEY }}
           GRID_PASSWORD: ${{ secrets.GRID_PASSWORD }}
-          ANALYSIS_NAME: ${{ inputs.analysis_name }}
+          ANALYSIS_NAME: ${{ matrix.analysis }}
           ANALYSIS_VERSION: ${{ inputs.analysis_version }}
           FLAF_version: ${{ inputs.flaf_version }}
           PlotKit_version: ${{ inputs.plotkit_version }}
@@ -133,6 +174,7 @@ jobs:
           PROCESSES: ${{ inputs.processes }}
           ANALYSIS_TASK: ${{ inputs.task }}
           ANALYSIS_ARGS: ${{ inputs.args }}
+          VARIABLES: ${{ inputs.variables }}
           GITHUB_NOTIFY_URL: ${{ inputs.github_notify_url }}
           FLAF_GITHUB_TOKEN: ${{ secrets.FLAF_GITHUB_TOKEN }}
         run: |
@@ -155,6 +197,7 @@ jobs:
             -e PROCESSES \
             -e ANALYSIS_TASK \
             -e ANALYSIS_ARGS \
+            -e VARIABLES \
             -e GITHUB_NOTIFY_URL \
             -e FLAF_GITHUB_TOKEN \
             -e GITHUB_RUN_ID \


### PR DESCRIPTION
## Summary
Fixes two issues with the GitHub Actions integration test workflow:
1. Dispatches all active root analyses simultaneously using a dynamic matrix strategy in `integration-test.yaml` when triggered from a shared package (e.g. `StatInference`, `FLAF`, `Corrections`).
2. Configures `StrictHostKeyChecking no` for `gitlab.cern.ch:7999` and `github.com` to prevent SSH host verification errors on submodule updates.

## Changes
- `.github/workflows/integration-test.yaml`: Added `prepare-matrix` job to dynamically spawn parallel test jobs for all active analyses.
- `.github/scripts/trigger-flaf-integration-trigger.js`: Dispatches all active analyses together instead of just the first one.
- `.github/scripts/ci/run_gha_integration.sh`: Extracts per-analysis tasks, args, eras, and processes from `VARIABLES` JSON.
- `.github/scripts/ci/common.sh`: Improved SSH configuration and host key handling.